### PR TITLE
Fix draft version of URLs on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Index with fields length [add_index](https://apidock.com/rails/v5.2.3/ActiveReco
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/activerecord-spanner-adapter. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/googleapis/ruby-spanner-activerecord. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -59,6 +59,6 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Activerecord::Spanner project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/activerecord-spanner-adapter/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Activerecord::Spanner project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/googleapis/ruby-spanner-activerecord/blob/master/CODE_OF_CONDUCT.md).
 
 # 🚨THIS CODE IS STILL UNDER DEVELOPMENT🚨


### PR DESCRIPTION
Previously URLs on README.md was not correct.
It contains `USERNAME` and wrong repository name.

Now, they are fixed to point at this repository.
https://github.com/googleapis/ruby-spanner-activerecord