### PR TITLE
Improve settings and documents to run RuboCop locally

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - "test/**/*"
     - "acceptance/**/*"
     - "lib/activerecord-spanner-adapter.rb"
+    - "vendor/**/*"
 
 Documentation:
   Enabled: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,11 @@ on seattle-style:
 You can check your code against these rules by running Rubocop like so:
 
 ```sh
-$ cd activerecord-spanner-adapter
-$ bundle exec rake rubocop
+$ cd ruby-spanner-activerecord
+$ bundle exec rubocop
 ```
+
+The rubocop settings depend on [googleapis/ruby-style](https://github.com/googleapis/ruby-style/), in addition to [.rubocop.yml](https://github.com/googleapis/ruby-spanner-activerecord/blob/master/.rubocop.yml).
 
 ## Code of Conduct
 


### PR DESCRIPTION
This PR enables developer to run RuboCop when they install dependent gems by `bundle install --path=vendor/bundle`

* Like `.gitignore`, ignore files under the `vendor` which is populated with Ruby files.
* Fix commands on `CONTRIBUTING.md`
* Add information on `googleapis/ruby-style`
* Change `rake rubocop` to `rubocop` according to https://github.com/googleapis/ruby-style#usage
  * If we prefer `rake rubocop` style, I will edit `Rakefile` to include RuboCop tasks.