### PR TITLE
test: remove non-existant checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,9 +5,6 @@ branchProtectionRules:
 - pattern: master
   isAdminEnforced: true
   requiredStatusCheckContexts:
-    - 'OSx'
-    - 'Ubuntu'
-    - 'Windows'
     - 'cla/google'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true


### PR DESCRIPTION
These non-existent checks are currently preventing us from merging PRs. Instead, we plan to setup GitHub Actions (#47).