### PR TITLE
Add basic test on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,26 +1,12 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
-name: test
-
 on:
   push:
     branches:
       - master
   pull_request:
-    branches:
-      - master
-  workflow_dispatch:
-
+name: ci
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
     strategy:
       max-parallel: 4
       fail-fast: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
-      fail-fast: true
       matrix:
         ruby: [2.5, 2.6, 2.7]
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 4
+      fail-fast: true
+      matrix:
+        ruby: [2.5, 2.6, 2.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
+    # (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake test


### PR DESCRIPTION
This covers basic test by running `bundle exec rake test`.

c.f. #47

* As a first step, acceptance test is out of the scope of this Pull Request.
* To avoid conflict with #49, I did not include badge on README.md.

These can be implemented afterwards.

You can see how this works at 
https://github.com/aeroastro/ruby-spanner-activerecord/pull/1