### PR TITLE
Enable and improve `bin/console` for easier gem development

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "activerecord/spanner"
+require "activerecord-spanner-adapter"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,10 @@
 require "bundler/setup"
 require "activerecord-spanner-adapter"
 
+require "active_record"
+
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
 
 require "pry"
 require "pry-byebug" # For easy debugging

--- a/bin/console
+++ b/bin/console
@@ -10,5 +10,6 @@ require "activerecord-spanner-adapter"
 # require "pry"
 # Pry.start
 
-require "irb"
-IRB.start(__FILE__)
+require "pry"
+require "pry-byebug" # For easy debugging
+Pry.start


### PR DESCRIPTION
## Issue

Previously, `bin/console` does not work because of wrong gem path. ( `activerecord/spanner` )

```
$ ./bin/console
Traceback (most recent call last):
	1: from ./bin/console:4:in `<main>'
./bin/console:4:in `require': cannot load such file -- activerecord/spanner (LoadError)
```

## Solution

This patch fixes the above issue and improves gem development as follows.

* Fix gem path from `activerecord/spanner` to `activerecord-spanner-adapter`
* Use `pry` and `pry-byebug` instead of `irb`. (This helps development especially when we use old Ruby versions)
* Require `active_record`. (This is indispensable for gem development)