### PR TITLE
Remove caching at ActiveRecordSpannerAdapter::Connection#.spanners

### DIFF
--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -16,25 +16,22 @@ module ActiveRecordSpannerAdapter
     def initialize config
       @instance_id = config[:instance]
       @database_id = config[:database]
-      @spanner = self.class.spanners config
+      @spanner = self.class.new_spanner config
       @ddl_statements = []
     end
 
-    def self.spanners config
+    def self.new_spanner config
       config = config.symbolize_keys
-      @spanners ||= {}
-      @mutex ||= Mutex.new
-      @mutex.synchronize do
-        @spanners[database_path(config)] ||= Google::Cloud.spanner(
-          config[:project],
-          config[:credentials],
-          scope: config[:scope],
-          timeout: config[:timeout],
-          client_config: config[:client_config]&.symbolize_keys,
-          lib_name: "spanner-activerecord-adapter",
-          lib_version: ActiveRecordSpannerAdapter::VERSION
-        )
-      end
+
+      Google::Cloud.spanner(
+        config[:project],
+        config[:credentials],
+        scope: config[:scope],
+        timeout: config[:timeout],
+        client_config: config[:client_config]&.symbolize_keys,
+        lib_name: "spanner-activerecord-adapter",
+        lib_version: ActiveRecordSpannerAdapter::VERSION
+      )
     end
 
     def self.information_schema config


### PR DESCRIPTION
Existing other `ActiveRecord::ConnectionAdapters` returns a newly established connection
when `ActiveRecord::ConnectionHandling#{adapter_name}_connection` is called.

For example,
Mysql2Adapter:
https://github.com/rails/rails/blob/cf4fa5caf39f1271d3f8c4c9774e874430ea0f68/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L23
https://github.com/rails/rails/blob/cf4fa5caf39f1271d3f8c4c9774e874430ea0f68/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L40

PostgreSQLAdapter:
https://github.com/rails/rails/blob/cf4fa5caf39f1271d3f8c4c9774e874430ea0f68/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L37
https://github.com/rails/rails/blob/cf4fa5caf39f1271d3f8c4c9774e874430ea0f68/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L78

SQLite3Adapter:
https://github.com/rails/rails/blob/cf4fa5caf39f1271d3f8c4c9774e874430ea0f68/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L35-L38

This is because the caching is handled at `ActiveRecord::ConnectionAdapters::ConnectionPool`.
We will follow this style and remove the current instance variable cache.

Also, this change allows developers to use a dedicated connection for each thread, not for each process.