### PR TITLE
feat: google-cloud-spanner version upgraded to 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in activerecord-spanner.gemspec
 gemspec
 
-gem "activerecord", "~> 6.0"
+gem "activerecord", "~> 6.0.3.4"
 gem "rake", "~> 12.3"
 gem "minitest", "~> 5.11.3"
 gem "pry", "~> 0.12.2"

--- a/Rakefile
+++ b/Rakefile
@@ -43,10 +43,10 @@ task :acceptance, :project, :keyfile, :instance do |t, args|
 
   # clear any env var already set
   require "google/cloud/spanner/credentials"
-  (Google::Cloud::Spanner::Credentials::PATH_ENV_VARS +
-   Google::Cloud::Spanner::Credentials::JSON_ENV_VARS).each do |path|
+  Google::Cloud::Spanner::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
+
   # always overwrite when running tests
   ENV["SPANNER_PROJECT"] = project
   ENV["SPANNER_KEYFILE_JSON"] = keyfile

--- a/acceptance/cases/migration/column_attributes_test.rb
+++ b/acceptance/cases/migration/column_attributes_test.rb
@@ -107,10 +107,9 @@ module ActiveRecord
         assert_instance_of TrueClass, bob.male?
       end
 
-      def test_out_of_range_limit_should_raise
-        assert_raise(ArgumentError) {
-          add_column :test_models, :integer_too_big, :integer, limit: 10
-        }
+      def test_add_column_and_ignore_limit
+        add_column :test_models, :integer_ignore_limit, :integer, limit: 10
+        assert_column TestModel, :integer_ignore_limit
       end
     end
   end

--- a/acceptance/cases/migration/columns_test.rb
+++ b/acceptance/cases/migration/columns_test.rb
@@ -14,11 +14,11 @@ module ActiveRecord
       include SpannerAdapter::Migration::TestHelper
 
       def test_rename_column
-        error = assert_raise ActiveRecordSpannerAdapter::NotSupportedError do
-          rename_column "test_models", :hat_name, :cap_name
-        end
+        add_column "test_models", :hat_name, :string
+        assert_column TestModel, :hat_name
 
-        assert_equal "rename column not supported.", error.message
+        rename_column "test_models", :hat_name, :cap_name
+        assert_column TestModel, :cap_name
       end
 
       def test_change_column_default_value

--- a/acceptance/cases/migration/command_recorder_test.rb
+++ b/acceptance/cases/migration/command_recorder_test.rb
@@ -296,7 +296,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
-        assert_equal [:remove_foreign_key, [:dogs, :people]], enable
+        assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
       end
 
       def test_invert_remove_foreign_key
@@ -306,7 +306,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
-        assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
+        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column
@@ -316,7 +316,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column_and_name
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
-        assert_equal [:remove_foreign_key, [:dogs, name: "fk"]], enable
+        assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column_and_name

--- a/acceptance/cases/migration/rename_column_test.rb
+++ b/acceptance/cases/migration/rename_column_test.rb
@@ -35,6 +35,9 @@ module ActiveRecord
           t.string :comment
           t.references :rename_column_post, index: true, foreign_key: true
         end
+
+        RenameColumnPost.reset_column_information
+        RenameColumnComment.reset_column_information
       end
 
       def teardown

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.2"
-  spec.add_runtime_dependency "activerecord", ">= 5.2.4.2"
+  spec.add_runtime_dependency "activerecord", "~> 6.0.3.4"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "google-cloud-spanner", "~> 1.16.0"
+  spec.add_dependency "google-cloud-spanner", "~> 2.2"
   spec.add_runtime_dependency "activerecord", ">= 5.2.4.2"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/lib/active_record/connection_adapters/spanner/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_definitions.rb
@@ -87,10 +87,15 @@ module ActiveRecord
           @null_filtered = null_filtered
           @interleve_in = interleve_in
           @storing = Array(storing)
-          @orders = (orders || {}).symbolize_keys
-
           columns = columns.split(/\W/) if columns.is_a? String
           @columns = Array(columns).map(&:to_s)
+          @orders = orders || {}
+
+          unless @orders.is_a? Hash
+            @orders = columns.each_with_object({}) { |c, r| r[c] = orders }
+          end
+
+          @orders = @orders.symbolize_keys
         end
 
         def columns_with_order

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -25,12 +25,11 @@ module ActiveRecordSpannerAdapter
       @spanners ||= {}
       @mutex ||= Mutex.new
       @mutex.synchronize do
-        @spanners[database_path(config)] ||= Google::Cloud.spanner(
-          config[:project],
-          config[:credentials],
+        @spanners[database_path(config)] ||= Google::Cloud::Spanner.new(
+          project_id: config[:project],
+          credentials: config[:credentials],
           scope: config[:scope],
           timeout: config[:timeout],
-          client_config: config[:client_config]&.symbolize_keys,
           lib_name: "spanner-activerecord-adapter",
           lib_version: ActiveRecordSpannerAdapter::VERSION
         )

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+
 module Google
   module Cloud
     module Spanner
@@ -12,7 +13,9 @@ module Google
           ensure_service!
 
           grpc = @service.create_session(
-            database_path(instance_id, database_id),
+            Admin::Database::V1::DatabaseAdmin::Paths.database_path(
+              project: project, instance: instance_id, database: database_id
+            ),
             labels: labels
           )
           Session.from_grpc grpc, @service

--- a/test/activerecord_spanner_adapter/connection_test.rb
+++ b/test/activerecord_spanner_adapter/connection_test.rb
@@ -8,12 +8,14 @@ require "test_helper"
 
 class SpannerConnectionTest < TestHelper::MockActiveRecordTest
   def test_create_connection
-    connection = ActiveRecordSpannerAdapter::Connection.new({
-      project: project_id,
-      instance: instance_id,
-      database: database_id,
-      credentials: credentials
-    })
+    Google::Cloud::Spanner.stub :new, Object.new do
+      connection = ActiveRecordSpannerAdapter::Connection.new({
+        project: project_id,
+        instance: instance_id,
+        database: database_id,
+        credentials: credentials
+      })
+    end
 
     assert_equal connection.instance_id, instance_id
     assert_equal connection.database_id, database_id


### PR DESCRIPTION
Fixes issue:  https://github.com/googleapis/ruby-spanner-activerecord/issues/52

- Upgraded `google-cloud-spanner` gem version upgraded from 1.6 to 2.2
- Fix unit and acceptance tests


Note: Upgrade will help us to add emulator support.