### PR TITLE
Add basic emulator support with updated `google-cloud-spanner`

### DIFF
--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.2"
+  spec.add_dependency "google-cloud-spanner", "~> 2.4"
   spec.add_runtime_dependency "activerecord", "~> 6.0.3.4"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -28,6 +28,7 @@ module ActiveRecordSpannerAdapter
         @spanners[database_path(config)] ||= Google::Cloud::Spanner.new(
           project_id: config[:project],
           credentials: config[:credentials],
+          emulator_host: config[:emulator_host],
           scope: config[:scope],
           timeout: config[:timeout],
           lib_name: "spanner-activerecord-adapter",


### PR DESCRIPTION
@jiren 

This is not fully-functional support for Spanner Emulator, but the first step.

I have updated the `google-cloud-spanner` to 2.4 to include https://github.com/googleapis/google-cloud-ruby/pull/8416,
and pass the `emulator_host` to `Google::Cloud::Spanner.new`.

This makes the following code working.

```ruby
ActiveRecord::Base.establish_connection(
  adapter: :spanner,
  project: 'test-project',
  instance: 'test-instance',
  database: 'test-database',
  emulator_host: 'localhost:9010'
)

ActiveRecord::Base.tap(&:connection).connected?
# => true
```

The reasons why I omit the test codes are:

* This part is not something to be fully tested.
* Actually, I did not find existing test on checking the arguments passed to `Google::Cloud::Spanner`
* In the future, I would like to run acceptance test with Spanner Emulator on CI, which is appropriate for testing the functionality

Although I confirmed that Spanner Emulator has an issue on `ALTER TABLE`, this introduced support will helps us a lot.

https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/16

c.f. #48 