### PR TITLE
test: add mock server and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ build-iPhoneSimulator/
 #
 # vendor/Pods/
 
+# Ignore RubyMine project files
+.idea
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
         def begin_db_transaction
           log "BEGIN" do
-            @connection.begin_trasaction
+            @connection.begin_transaction
           end
         end
 

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         end
 
         def visit_ColumnDefinition o
-          o.sql_type = type_to_sql o.type, o.options
+          o.sql_type = type_to_sql o.type, _opts: o.options
           column_sql = +"#{quote_column_name o.name} #{o.sql_type}"
           add_column_options! column_sql, column_options(o)
           column_sql

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -47,7 +47,7 @@ module ActiveRecord
             if pk.is_a? Array
               td.primary_keys pk
             else
-              td.primary_key pk, options.fetch(:id, :primary_key), {}
+              td.primary_key pk, options.fetch(:id, :primary_key)
             end
           end
 
@@ -404,7 +404,7 @@ module ActiveRecord
         end
 
         def create_table_definition *args
-          TableDefinition.new self, *args
+          TableDefinition.new self, args[0], options: args[1]
         end
 
         def able_to_ddl_batch? table_name

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -187,7 +187,7 @@ module ActiveRecordSpannerAdapter
         id: current_transaction.transaction_id
     end
 
-    def snapshot sql, options = {}
+    def snapshot sql, _options = {}
       raise "Nested snapshots are not allowed" if current_transaction
 
       session.snapshot do |snp|

--- a/test/activerecord_spanner_adapter/connection_mock_server_test.rb
+++ b/test/activerecord_spanner_adapter/connection_mock_server_test.rb
@@ -1,0 +1,101 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../mock_server/spanner_mock_server"
+require_relative "../test_helper"
+
+class SpannerMockServerConnectionTest
+  describe "Connection with Spanner Mock Server" do
+
+    before do
+      @server = GRPC::RpcServer.new
+      @port = @server.add_http2_port('localhost:0', :this_port_is_insecure)
+      @mock = SpannerMockServer.new
+      @server.handle(@mock)
+      # Run the server in a separate thread
+      @server_thread = Thread.new do
+        @server.run
+      end
+    end
+
+    after do
+      @server.stop
+      @server_thread.exit
+    end
+
+    # @private
+    def create_connection
+      ActiveRecordSpannerAdapter::Connection.new({
+        project: "test-project",
+        instance: "test-instance",
+        database: "test-database",
+        emulator_host: "localhost:#{@port}"
+      })
+    end
+
+    it "can execute SELECT 1" do
+      connection = create_connection
+      result = connection.execute_query "SELECT 1"
+      row_count = 0
+      result.rows.each do |row|
+        _(row[:Col1]).must_equal 1
+        row_count += 1
+      end
+      _(row_count).must_equal 1
+      connection.disconnect!
+
+      _(@mock.requests.length).must_equal 3
+      _(@mock.requests[0]).must_be_kind_of V1::CreateSessionRequest
+      _(@mock.requests[1]).must_be_kind_of V1::ExecuteSqlRequest
+      _(@mock.requests[2]).must_be_kind_of V1::DeleteSessionRequest
+    end
+
+    it "can execute random query" do
+      sql = "SELECT * FROM RandomTable"
+      @mock.put_statement_result(sql, StatementResult.create_random_result(100))
+
+      connection = create_connection
+      result = connection.execute_query(sql)
+      row_count = 0
+      result.rows.each do |row|
+        _(row.fields[:ColBool]).must_equal :BOOL
+        _(row.fields[:ColInt64]).must_equal :INT64
+        _(row.fields[:ColFloat64]).must_equal :FLOAT64
+        _(row.fields[:ColNumeric]).must_equal :NUMERIC
+        _(row.fields[:ColString]).must_equal :STRING
+        _(row.fields[:ColBytes]).must_equal :BYTES
+        _(row.fields[:ColDate]).must_equal :DATE
+        _(row.fields[:ColTimestamp]).must_equal :TIMESTAMP
+
+        _(row.fields[0]).must_equal :BOOL
+        _(row.fields[1]).must_equal :INT64
+        _(row.fields[2]).must_equal :FLOAT64
+        _(row.fields[3]).must_equal :NUMERIC
+        _(row.fields[4]).must_equal :STRING
+        _(row.fields[5]).must_equal :BYTES
+        _(row.fields[6]).must_equal :DATE
+        _(row.fields[7]).must_equal :TIMESTAMP
+        row_count += 1
+      end
+      connection.disconnect!
+
+      _(@mock.requests.length).must_equal 3
+      _(@mock.requests[0]).must_be_kind_of V1::CreateSessionRequest
+      _(@mock.requests[1]).must_be_kind_of V1::ExecuteSqlRequest
+      _(@mock.requests[2]).must_be_kind_of V1::DeleteSessionRequest
+    end
+
+    it "can execute transaction" do
+      sql = "UPDATE TestTable SET SomeValue=1 WHERE Id IN (1,2,3)"
+      @mock.put_statement_result(sql, StatementResult.new(3))
+
+      connection = create_connection
+      connection.begin_transaction
+      update_count = connection.current_transaction.execute_update sql
+      _(update_count).must_equal 3
+    end
+  end
+end

--- a/test/activerecord_spanner_adapter/connection_test.rb
+++ b/test/activerecord_spanner_adapter/connection_test.rb
@@ -45,6 +45,7 @@ class SpannerConnectionTest < TestHelper::MockActiveRecordTest
   end
 
   def test_connection_is_active
+    connection.connect!
     assert_equal connection.active?, true
   end
 

--- a/test/activerecord_spanner_adapter/information_schema_test.rb
+++ b/test/activerecord_spanner_adapter/information_schema_test.rb
@@ -90,8 +90,8 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal result.length, 1
 
     assert_sql_equal(
-      last_executed_sql,
-      "SELECT * FROM information_schema.tables WHERE table_schema=''"
+      "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''",
+      last_executed_sql
     )
 
     result.each do |table|
@@ -107,11 +107,11 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.tables view: :columns
 
     assert_sql_equal(
-      last_executed_sqls,
       [
-        "SELECT * FROM information_schema.tables WHERE table_schema=''",
-        "SELECT * FROM information_schema.columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC"
-      ]
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''",
+        "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -120,12 +120,12 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.tables view: :indexes
 
     assert_sql_equal(
-      last_executed_sqls,
       [
-        "SELECT * FROM information_schema.tables WHERE table_schema=''",
-        "SELECT * FROM information_schema.index_columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.indexes WHERE table_name='accounts' AND spanner_is_managed=false"
-      ]
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''",
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='accounts' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -134,13 +134,13 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.tables view: :full
 
     assert_sql_equal(
-      last_executed_sqls,
       [
-        "SELECT * FROM information_schema.tables WHERE table_schema=''",
-        "SELECT * FROM information_schema.columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.index_columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.indexes WHERE table_name='accounts' AND spanner_is_managed=false"
-      ]
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''",
+        "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='accounts' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -150,8 +150,8 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_instance_of ActiveRecordSpannerAdapter::Table, table
 
     assert_sql_equal(
-      last_executed_sql,
-      "SELECT * FROM information_schema.tables WHERE table_schema='' AND table_name='accounts'"
+      "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='accounts'",
+      last_executed_sql
     )
   end
 
@@ -160,9 +160,11 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.table "accounts", view: :columns
 
     assert_sql_equal(
-      last_executed_sqls,
-      "SELECT * FROM information_schema.tables WHERE table_schema='' AND table_name='accounts'",
-      "SELECT * FROM information_schema.columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC"
+      [
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='accounts'",
+        "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -171,12 +173,12 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.table "accounts", view: :indexes
 
     assert_sql_equal(
-      last_executed_sqls,
       [
-        "SELECT * FROM information_schema.tables WHERE table_schema='' AND table_name='accounts'",
-        "SELECT * FROM information_schema.index_columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.indexes WHERE table_name='accounts' AND spanner_is_managed=false"
-      ]
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='accounts'",
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='accounts' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -185,13 +187,13 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     info_schema.table "accounts", view: :full
 
     assert_sql_equal(
-      last_executed_sqls,
       [
-        "SELECT * FROM information_schema.tables WHERE table_schema='' AND table_name='accounts'",
-        "SELECT * FROM information_schema.columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.index_columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC",
-        "SELECT * FROM information_schema.indexes WHERE table_name='accounts' AND spanner_is_managed=false"
-      ]
+        "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='accounts'",
+        "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='accounts' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
   end
 
@@ -201,8 +203,8 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal result.length, 2
 
     assert_sql_equal(
-      last_executed_sql,
-      "SELECT * FROM information_schema.columns WHERE table_name='accounts' ORDER BY ORDINAL_POSITION ASC"
+      "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' ORDER BY ORDINAL_POSITION ASC",
+      last_executed_sql
     )
 
     result.each do |column|
@@ -230,8 +232,8 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_instance_of ActiveRecordSpannerAdapter::Table::Column, column
 
     assert_sql_equal(
-      last_executed_sql,
-      "SELECT * FROM information_schema.columns WHERE table_name='accounts' AND column_name='account_id' ORDER BY ORDINAL_POSITION ASC"
+      "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='accounts' AND COLUMN_NAME='account_id' ORDER BY ORDINAL_POSITION ASC",
+      last_executed_sql
     )
   end
 
@@ -242,9 +244,11 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal result.length, 1
 
     assert_sql_equal(
-      last_executed_sqls,
-      "SELECT * FROM information_schema.index_columns WHERE table_name='orders' ORDER BY ORDINAL_POSITION ASC",
-      "SELECT * FROM information_schema.indexes WHERE table_name='orders' AND spanner_is_managed=false"
+      [
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='orders' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='orders' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
 
     result.each do |index|
@@ -273,9 +277,11 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_instance_of ActiveRecordSpannerAdapter::Index, index
 
     assert_sql_equal(
-      last_executed_sqls,
-      "SELECT * FROM information_schema.index_columns WHERE table_name='orders' AND index_name='index_orders_on_user_id' ORDER BY ORDINAL_POSITION ASC",
-      "SELECT * FROM information_schema.indexes WHERE table_name='orders' AND index_name='index_orders_on_user_id' AND spanner_is_managed=false"
+      [
+        "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='orders' AND INDEX_NAME='index_orders_on_user_id' ORDER BY ORDINAL_POSITION ASC",
+        "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='orders' AND INDEX_NAME='index_orders_on_user_id' AND SPANNER_IS_MANAGED=FALSE"
+      ],
+      last_executed_sqls
     )
 
     assert_equal index.table, "orders"
@@ -298,8 +304,8 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal result.length, 1
 
     assert_sql_equal(
-      last_executed_sqls,
-      "SELECT * FROM information_schema.index_columns WHERE table_name='orders' AND index_name='index_orders_on_user_id' ORDER BY ORDINAL_POSITION ASC"
+      "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='orders' AND INDEX_NAME='index_orders_on_user_id' ORDER BY ORDINAL_POSITION ASC",
+      last_executed_sqls
     )
 
     column = result.first

--- a/test/activerecord_spanner_mock_server/models/album.rb
+++ b/test/activerecord_spanner_mock_server/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/test/activerecord_spanner_mock_server/models/singer.rb
+++ b/test/activerecord_spanner_mock_server/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -22,6 +22,7 @@ class SpannerActiveRecordMockServerTest < Minitest::Test
     @server_thread = Thread.new do
       @server.run
     end
+    @server.wait_till_running
     # Register INFORMATION_SCHEMA queries on the mock server.
     register_select_tables_result
     register_singers_columns_result

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -17,7 +17,7 @@ class SpannerActiveRecordMockServerTest < Minitest::Test
     @server = GRPC::RpcServer.new
     @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
     @mock = SpannerMockServer.new
-    @server.handle(@mock)
+    @server.handle @mock
     # Run the server in a separate thread
     @server_thread = Thread.new do
       @server.run

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -1,0 +1,280 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../mock_server/spanner_mock_server"
+require_relative "../test_helper"
+require_relative "models/singer"
+require_relative "models/album"
+
+require "securerandom"
+
+class SpannerActiveRecordMockServerTest < Minitest::Test
+  def setup
+    super
+    @server = GRPC::RpcServer.new
+    @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+    @mock = SpannerMockServer.new
+    @server.handle(@mock)
+    # Run the server in a separate thread
+    @server_thread = Thread.new do
+      @server.run
+    end
+    # Register INFORMATION_SCHEMA queries on the mock server.
+    register_select_tables_result
+    register_singers_columns_result
+    register_singers_primary_key_result
+    register_singer_index_columns_result
+    # Connect ActiveRecord to the mock server
+    ActiveRecord::Base.establish_connection(
+      adapter: "spanner",
+      emulator_host: "localhost:#{@port}",
+      project: "test-project",
+      instance: "test-instance",
+      database: "testdb"
+    )
+    ActiveRecord::Base.logger = nil
+  end
+
+  def teardown
+    super
+    ActiveRecord::Base.connection_pool.disconnect!
+    @server.stop
+    @server_thread.exit
+  end
+
+  def test_selects_all_singers_without_transaction
+    sql = "SELECT `singers`.* FROM `singers`"
+    @mock.put_statement_result sql, create_random_singers_result(4)
+    Singer.all.each do |singer|
+      assert singer.id != nil
+      assert singer.first_name != nil
+      assert singer.last_name != nil
+    end
+    # None of the requests should use a (read-only) transaction.
+    select_requests = @mock.requests.select { |req| req.is_a? V1::ExecuteSqlRequest }
+    select_requests.each do |request|
+      assert_nil request.transaction
+    end
+    # Executing a simple query should not initiate any transactions.
+    begin_transaction_requests = @mock.requests.select { |req| req.is_a? V1::BeginTransactionRequest }
+    assert_empty begin_transaction_requests
+  end
+
+  def test_selects_one_singer_without_transaction
+    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = 1 LIMIT 1"
+    @mock.put_statement_result sql, create_random_singers_result(1)
+    singer = Singer.find_by id: 1
+
+    refute_nil singer
+    refute_nil singer.first_name
+    refute_nil singer.last_name
+    # None of the requests should use a (read-only) transaction.
+    select_requests = @mock.requests.select { |req| req.is_a? V1::ExecuteSqlRequest }
+    select_requests.each do |request|
+      assert_nil request.transaction
+    end
+    # Executing a simple query should not initiate any transactions.
+    begin_transaction_requests = @mock.requests.select { |req| req.is_a? V1::BeginTransactionRequest }
+    assert_empty begin_transaction_requests
+  end
+
+  def test_update_one_singer_should_use_transaction
+    # Preferably, this use case should use mutations instead of DML, as single updates
+    # using DML are a lot slower than using mutations. Mutations can however not be
+    # read back during a transaction (no read-your-writes), but that is not needed in
+    # this case as the application is not managing the transaction itself.
+    select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = 1 LIMIT 1"
+    @mock.put_statement_result select_sql, create_random_singers_result(1)
+
+    singer = Singer.find_by id: 1
+
+    update_sql = "UPDATE `singers` SET `first_name` = 'Dave' WHERE `singers`.`id` = #{singer.id}"
+    @mock.put_statement_result update_sql, StatementResult.new(1)
+
+    singer.first_name = 'Dave'
+    singer.save!
+
+    begin_transaction_requests = @mock.requests.select { |req| req.is_a? V1::BeginTransactionRequest }
+    assert_equal 1, begin_transaction_requests.length
+  end
+
+  def test_update_two_singers_should_use_transaction
+    select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` BETWEEN 1 AND 2"
+    @mock.put_statement_result select_sql, create_random_singers_result(2)
+
+    ActiveRecord::Base.transaction do
+      singers = Singer.where id: 1..2
+      @mock.put_statement_result "UPDATE `singers` SET `first_name` = 'Name1' WHERE `singers`.`id` = #{singers[0].id}", StatementResult.new(1)
+      @mock.put_statement_result "UPDATE `singers` SET `first_name` = 'Name2' WHERE `singers`.`id` = #{singers[1].id}", StatementResult.new(1)
+
+      singers[0].update! first_name: "Name1"
+      singers[1].update! first_name: "Name2"
+    end
+
+    begin_transaction_requests = @mock.requests.select { |req| req.is_a? V1::BeginTransactionRequest }
+    assert_equal 1, begin_transaction_requests.length
+    # All of the requests should use a transaction.
+    select_requests = @mock.requests.select { |req| req.is_a?(V1::ExecuteSqlRequest) && (req.sql.starts_with?("SELECT `singers`.*") || req.sql.starts_with?("UPDATE")) }
+    select_requests.each do |request|
+      refute_nil request.transaction
+    end
+  end
+
+  def create_random_singers_result(row_count)
+    first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy]
+    last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson]
+    col_id = V1::StructType::Field.new name: "id", type: V1::Type.new(code: V1::TypeCode::INT64)
+    col_first_name = V1::StructType::Field.new name: "first_name", type: V1::Type.new(code: V1::TypeCode::STRING)
+    col_last_name = V1::StructType::Field.new name: "last_name", type: V1::Type.new(code: V1::TypeCode::STRING)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push col_id, col_first_name, col_last_name
+    result_set = V1::ResultSet.new metadata: metadata
+
+    (1..row_count).each { |_|
+      row = Protobuf::ListValue.new
+      row.values.push(
+        Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
+        Protobuf::Value.new(string_value: first_names.sample),
+        Protobuf::Value.new(string_value: last_names.sample)
+      )
+      result_set.rows.push row
+    }
+
+    StatementResult.new result_set
+  end
+
+  def register_select_tables_result
+    sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''"
+
+    table_catalog = V1::StructType::Field.new name: "TABLE_CATALOG", type: V1::Type.new(code: V1::TypeCode::STRING)
+    table_schema = V1::StructType::Field.new name: "TABLE_SCHEMA", type: V1::Type.new(code: V1::TypeCode::STRING)
+    table_name = V1::StructType::Field.new name: "TABLE_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    parent_table_name = V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    on_delete_action = V1::StructType::Field.new name: "ON_DELETE_ACTION", type: V1::Type.new(code: V1::TypeCode::STRING)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push table_catalog, table_schema, table_name, parent_table_name, on_delete_action
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: ""),
+      Protobuf::Value.new(string_value: ""),
+      Protobuf::Value.new(string_value: "singers"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: ""),
+      Protobuf::Value.new(string_value: ""),
+      Protobuf::Value.new(string_value: "albums"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_singers_columns_result
+    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='singers' ORDER BY ORDINAL_POSITION ASC"
+
+    column_name = V1::StructType::Field.new name: "COLUMN_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    spanner_type = V1::StructType::Field.new name: "SPANNER_TYPE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    is_nullable = V1::StructType::Field.new name: "IS_NULLABLE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    column_default = V1::StructType::Field.new name: "COLUMN_DEFAULT", type: V1::Type.new(code: V1::TypeCode::BYTES)
+    ordinal_position = V1::StructType::Field.new name: "ORDINAL_POSITION", type: V1::Type.new(code: V1::TypeCode::INT64)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "id"),
+      Protobuf::Value.new(string_value: "INT64"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "1")
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "first_name"),
+      Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "2")
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "last_name"),
+      Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "3")
+    )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_singers_primary_key_result
+    sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND INDEX_TYPE='PRIMARY_KEY' AND SPANNER_IS_MANAGED=FALSE"
+
+    index_name = V1::StructType::Field.new name: "INDEX_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    index_type = V1::StructType::Field.new name: "INDEX_TYPE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    is_unique = V1::StructType::Field.new name: "IS_UNIQUE", type: V1::Type.new(code: V1::TypeCode::BOOL)
+    is_null_filtered = V1::StructType::Field.new name: "IS_NULL_FILTERED", type: V1::Type.new(code: V1::TypeCode::BOOL)
+    parent_table_name = V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    index_state = V1::StructType::Field.new name: "INDEX_STATE", type: V1::Type.new(code: V1::TypeCode::STRING)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push index_name, index_type, is_unique, is_null_filtered, parent_table_name, index_state
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "PRIMARY_KEY"), # INDEX_NAME
+      Protobuf::Value.new(string_value: "PRIMARY_KEY"), # INDEX_TYPE
+      Protobuf::Value.new(bool_value: true),
+      Protobuf::Value.new(bool_value: false),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+    )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_singer_index_columns_result
+    sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' ORDER BY ORDINAL_POSITION ASC"
+
+    index_name = V1::StructType::Field.new name: "INDEX_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    column_name = V1::StructType::Field.new name: "COLUMN_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    column_ordering = V1::StructType::Field.new name: "COLUMN_ORDERING", type: V1::Type.new(code: V1::TypeCode::STRING)
+    ordinal_position = V1::StructType::Field.new name: "ORDINAL_POSITION", type: V1::Type.new(code: V1::TypeCode::INT64)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push index_name, column_name, column_ordering, ordinal_position
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+      Protobuf::Value.new(string_value: "id"),
+      Protobuf::Value.new(string_value: "ASC"),
+      Protobuf::Value.new(string_value: "1"),
+    )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+end

--- a/test/migrations_with_mock_server/db/migrate/01_create_singer_and_album_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/01_create_singer_and_album_tables.rb
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateSingerAndAlbumTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :singers do |t|
+      t.string :first_name
+      t.string :last_name
+    end
+
+    create_table :albums do |t|
+      t.string :title
+      t.integer :singer_id
+    end
+  end
+end

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -24,6 +24,7 @@ class SpannerMigrationsMockServerTest < Minitest::Test
     @server_thread = Thread.new do
       @server.run
     end
+    @server.wait_till_running
     # Register INFORMATION_SCHEMA queries on the mock server.
     register_schema_migrations_table_result
     register_schema_migrations_columns_result

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -1,0 +1,223 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../mock_server/spanner_mock_server"
+require_relative "../mock_server/database_admin_mock_server"
+require_relative "../test_helper"
+
+require "securerandom"
+
+# Tests executing a simple migration on a mock Spanner server.
+class SpannerMigrationsMockServerTest < Minitest::Test
+  def setup
+    super
+    @server = GRPC::RpcServer.new
+    @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+    @mock = SpannerMockServer.new
+    @database_admin_mock = DatabaseAdminMockServer.new
+    @server.handle @mock
+    @server.handle @database_admin_mock
+    # Run the server in a separate thread
+    @server_thread = Thread.new do
+      @server.run
+    end
+    # Register INFORMATION_SCHEMA queries on the mock server.
+    register_schema_migrations_table_result
+    register_schema_migrations_columns_result
+    register_ar_internal_metadata_table_result
+    register_ar_internal_metadata_columns_result
+    register_ar_internal_metadata_results
+    register_ar_internal_metadata_insert_result
+
+    ActiveRecord::Base.establish_connection(
+      adapter: "spanner",
+      emulator_host: "localhost:#{@port}",
+      project: "test-project",
+      instance: "test-instance",
+      database: "testdb"
+    )
+    ActiveRecord::Base.logger = nil
+    ActiveRecord::Migration.verbose = false
+  end
+
+  def teardown
+    super
+    ActiveRecord::Base.connection_pool.disconnect!
+    @server.stop
+    @server_thread.exit
+  end
+
+  def test_execute_migrations
+    context = ActiveRecord::MigrationContext.new(
+      "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
+      ActiveRecord::SchemaMigration
+    )
+
+    # Register migration result for the current version (nil) to the new version (1).
+    register_version_result nil, "1"
+
+    context.migrate
+
+    # The migration should create the migration tables and the singers and albums tables in one request.
+    ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Admin::UpdateDatabaseDdlRequest) }
+    assert_equal 3, ddl_requests.length
+    assert_equal 1, ddl_requests[0].statements.length
+    assert ddl_requests[0].statements[0].starts_with? "CREATE TABLE `schema_migrations`"
+    assert_equal 1, ddl_requests[1].statements.length
+    assert ddl_requests[1].statements[0].starts_with? "CREATE TABLE `ar_internal_metadata`"
+    # The actual migration should be executed as one batch.
+    assert_equal 2, ddl_requests[2].statements.length
+    assert ddl_requests[2].statements[0].starts_with? "CREATE TABLE `singers`"
+    assert ddl_requests[2].statements[1].starts_with? "CREATE TABLE `albums`"
+  end
+
+  def register_schema_migrations_table_result
+    sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='schema_migrations'"
+    register_empty_select_tables_result sql
+  end
+
+  def register_schema_migrations_columns_result
+    # CREATE TABLE `schema_migrations` (`version` STRING(MAX) NOT NULL) PRIMARY KEY (`version`)
+    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='schema_migrations' ORDER BY ORDINAL_POSITION ASC"
+
+    column_name = V1::StructType::Field.new name: "COLUMN_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    spanner_type = V1::StructType::Field.new name: "SPANNER_TYPE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    is_nullable = V1::StructType::Field.new name: "IS_NULLABLE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    column_default = V1::StructType::Field.new name: "COLUMN_DEFAULT", type: V1::Type.new(code: V1::TypeCode::BYTES)
+    ordinal_position = V1::StructType::Field.new name: "ORDINAL_POSITION", type: V1::Type.new(code: V1::TypeCode::INT64)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "version"),
+      Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "1")
+    )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_ar_internal_metadata_table_result
+    sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='ar_internal_metadata'"
+    register_empty_select_tables_result sql
+  end
+
+  def register_ar_internal_metadata_columns_result
+    # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
+    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='ar_internal_metadata' ORDER BY ORDINAL_POSITION ASC"
+
+    column_name = V1::StructType::Field.new name: "COLUMN_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    spanner_type = V1::StructType::Field.new name: "SPANNER_TYPE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    is_nullable = V1::StructType::Field.new name: "IS_NULLABLE", type: V1::Type.new(code: V1::TypeCode::STRING)
+    column_default = V1::StructType::Field.new name: "COLUMN_DEFAULT", type: V1::Type.new(code: V1::TypeCode::BYTES)
+    ordinal_position = V1::StructType::Field.new name: "ORDINAL_POSITION", type: V1::Type.new(code: V1::TypeCode::INT64)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+    result_set = V1::ResultSet.new metadata: metadata
+
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "key"),
+      Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "1")
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "value"),
+      Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Protobuf::Value.new(string_value: "YES"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "2")
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "created_at"),
+      Protobuf::Value.new(string_value: "TIMESTAMP"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "3")
+    )
+    result_set.rows.push row
+    row = Protobuf::ListValue.new
+    row.values.push(
+      Protobuf::Value.new(string_value: "updated_at"),
+      Protobuf::Value.new(string_value: "TIMESTAMP"),
+      Protobuf::Value.new(string_value: "NO"),
+      Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Protobuf::Value.new(string_value: "4")
+    )
+    result_set.rows.push row
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_ar_internal_metadata_results
+    # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
+    sql = "SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = 'environment' LIMIT 1"
+
+    key = V1::StructType::Field.new name: "key", type: V1::Type.new(code: V1::TypeCode::STRING)
+    value = V1::StructType::Field.new name: "value", type: V1::Type.new(code: V1::TypeCode::STRING)
+    created_at = V1::StructType::Field.new name: "created_at", type: V1::Type.new(code: V1::TypeCode::TIMESTAMP)
+    updated_at = V1::StructType::Field.new name: "updated_at", type: V1::Type.new(code: V1::TypeCode::TIMESTAMP)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push key, value, created_at, updated_at
+    result_set = V1::ResultSet.new metadata: metadata
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_ar_internal_metadata_insert_result
+    sql = "INSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES ('environment', 'default_env', '%"
+    @mock.put_statement_result sql, StatementResult.new(1)
+  end
+
+  def register_empty_select_tables_result(sql)
+    table_catalog = V1::StructType::Field.new name: "TABLE_CATALOG", type: V1::Type.new(code: V1::TypeCode::STRING)
+    table_schema = V1::StructType::Field.new name: "TABLE_SCHEMA", type: V1::Type.new(code: V1::TypeCode::STRING)
+    table_name = V1::StructType::Field.new name: "TABLE_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    parent_table_name = V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: V1::Type.new(code: V1::TypeCode::STRING)
+    on_delete_action = V1::StructType::Field.new name: "ON_DELETE_ACTION", type: V1::Type.new(code: V1::TypeCode::STRING)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push table_catalog, table_schema, table_name, parent_table_name, on_delete_action
+    result_set = V1::ResultSet.new metadata: metadata
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def register_version_result(from_version, to_version)
+    sql = "SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC"
+
+    version_column = V1::StructType::Field.new name: "version", type: V1::Type.new(code: V1::TypeCode::STRING)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push version_column
+    result_set = V1::ResultSet.new metadata: metadata
+
+    if from_version
+      row = Protobuf::ListValue.new
+      row.values.push Protobuf::Value.new(string_value: from_version)
+      result_set.rows.push row
+    end
+
+    @mock.put_statement_result sql, StatementResult.new(result_set)
+
+    update_sql = "INSERT INTO `schema_migrations` (`version`) VALUES ('#{to_version}')"
+    @mock.put_statement_result update_sql, StatementResult.new(1)
+  end
+end

--- a/test/migrations_with_mock_server/models/album.rb
+++ b/test/migrations_with_mock_server/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/test/migrations_with_mock_server/models/singer.rb
+++ b/test/migrations_with_mock_server/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end

--- a/test/mock_server/database_admin_mock_server.rb
+++ b/test/mock_server/database_admin_mock_server.rb
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "statement_result"
+require "grpc"
+require "gapic/grpc/service_stub"
+require "securerandom"
+
+require "google/spanner/admin/database/v1/spanner_database_admin_pb"
+require "google/spanner/admin/database/v1/spanner_database_admin_services_pb"
+require "google/cloud/spanner/admin/database/v1/database_admin"
+require "google/longrunning/operations_pb"
+
+Admin = Google::Cloud::Spanner::Admin::Database::V1
+
+# Mock implementation of Spanner Database Admin
+class DatabaseAdminMockServer < Admin::DatabaseAdmin::Service
+  attr_reader :requests
+
+  def initialize
+    super
+    @requests = []
+  end
+
+  def get_database request, _unused_call
+    @requests << request
+    Admin::Database.new name: request.name
+  end
+
+  def update_database_ddl request, _unused_call
+    @requests << request
+    Google::Longrunning::Operation.new(
+      done: true,
+      name: "#{request.database}/operations/#{SecureRandom.uuid}",
+    )
+  end
+
+end

--- a/test/mock_server/spanner_mock_server.rb
+++ b/test/mock_server/spanner_mock_server.rb
@@ -1,0 +1,196 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "statement_result"
+require "google/spanner/v1/spanner_pb"
+require "google/spanner/v1/spanner_services_pb"
+require "google/cloud/spanner/v1/spanner"
+
+require "grpc"
+require "gapic/grpc/service_stub"
+require "securerandom"
+
+V1 = Google::Cloud::Spanner::V1
+Protobuf = Google::Protobuf
+
+# Mock implementation of Spanner
+class SpannerMockServer < V1::Spanner::Service
+  attr_reader :requests
+
+  def initialize
+    super
+    @statement_results = {}
+    @sessions = {}
+    @transactions = {}
+    @requests = []
+    put_statement_result "SELECT 1", StatementResult.create_select1_result
+  end
+
+  def put_statement_result sql, result
+    @statement_results[sql] = result
+  end
+
+  def create_session request, _unused_call
+    @requests << request
+    do_create_session request.database
+  end
+
+  def batch_create_sessions request, _unused_call
+    @requests << request
+    num_created = 0
+    response = V1::BatchCreateSessionsResponse.new
+    while num_created < request.session_count
+      response.session << do_create_session(request.database)
+      num_created += 1
+    end
+    response
+  end
+
+  def get_session request, _unused_call
+    @requests << request
+    @sessions[request.name]
+  end
+
+  def list_sessions request, _unused_call
+    @requests << request
+    response = V1::ListSessionsResponse.new
+    @sessions.each_value do |s|
+      response.sessions << s
+    end
+    response
+  end
+
+  def delete_session request, _unused_call
+    @requests << request
+    @sessions.delete request.name
+  end
+
+  def execute_sql request, _unused_call
+    do_execute_sql request, false
+  end
+
+  def execute_streaming_sql request, _unused_call
+    do_execute_sql request, true
+  end
+
+  # @private
+  def do_execute_sql request, streaming
+    @requests << request
+    validate_session request.session
+    result = get_statement_result request.sql
+    if result.result_type == StatementResult::EXCEPTION
+      raise result.result
+    end
+    if streaming
+      result.each
+    else
+      result.result
+    end
+  end
+
+  def execute_batch_dml request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  def read request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  def streaming_read request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  def begin_transaction request, _unused_call
+    @requests << request
+    validate_session request.session
+    do_create_transaction request.session
+  end
+
+  def commit request, _unused_call
+    @requests << request
+    validate_session request.session
+    validate_transaction request.session, request.transaction_id
+    V1::CommitResponse.new commit_timestamp: Protobuf::Timestamp.new(seconds: Time.now.to_i)
+  end
+
+  def rollback request, _unused_call
+    @requests << request
+    validate_session request.session
+    name = "#{request.session}/transactions/#{request.transaction_id}"
+    @transactions.delete name
+    Protobuf::Empty.new
+  end
+
+  def partition_query request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  def partition_read request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  def get_database request, _unused_call
+    @requests << request
+    raise GRPC::BadStatus.new GRPC::Core::StatusCodes::UNIMPLEMENTED, "Not yet implemented"
+  end
+
+  private
+
+  def get_statement_result sql
+    unless @statement_results.has_key? sql
+      @statement_results.each do |key,value|
+        if key.ends_with?("%") && sql.starts_with?(key.chop)
+          return value
+        end
+      end
+      raise GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::INVALID_ARGUMENT,
+        "There's no result registered for #{sql}"
+      )
+    end
+    @statement_results[sql]
+  end
+
+  def validate_session session
+    unless @sessions.has_key? session
+      raise GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::NOT_FOUND,
+        "Session not found: Session with id #{session} not found"
+      )
+    end
+  end
+
+  def do_create_session database
+    name = "#{database}/sessions/#{SecureRandom.uuid}"
+    session = V1::Session.new name: name
+    @sessions[name] = session
+    session
+  end
+
+  def validate_transaction session, transaction
+    name = "#{session}/transactions/#{transaction}"
+    unless @transactions.has_key? name
+      raise GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::NOT_FOUND,
+        "Transaction not found: Transaction with id #{transaction} not found"
+      )
+    end
+  end
+
+  def do_create_transaction session
+    id = SecureRandom.uuid
+    name = "#{session}/transactions/#{id}"
+    transaction = V1::Transaction.new id: id
+    @transactions[name] = transaction
+    transaction
+  end
+
+end

--- a/test/mock_server/spanner_mock_server_test.rb
+++ b/test/mock_server/spanner_mock_server_test.rb
@@ -1,0 +1,139 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "./spanner_mock_server"
+require_relative "../test_helper"
+
+require "grpc"
+require "gapic/grpc/service_stub"
+require "securerandom"
+
+require "google/spanner/v1/spanner_pb"
+require "google/spanner/v1/spanner_services_pb"
+require "google/cloud/spanner/v1/spanner"
+
+describe "Spanner Mock Server" do
+
+  before do
+    @server = GRPC::RpcServer.new
+    @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+    @mock = SpannerMockServer.new
+    @server.handle @mock
+    # Run the server in a separate thread
+    @server_thread = Thread.new do
+      @server.run
+    end
+    @client = V1::Spanner::Client.new do |config|
+      config.credentials = :this_channel_is_insecure
+      config.endpoint = "localhost:#{@port}"
+    end
+  end
+
+  after do
+    @server.stop
+    @server_thread.exit
+  end
+
+  it "creates single session" do
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    _(session.name).must_match "projects/p/instances/i/databases/d/sessions/"
+  end
+
+  it "creates batch of sessions" do
+    response = @client.batch_create_sessions V1::BatchCreateSessionsRequest.new(
+      database: "projects/p/instances/i/databases/d",
+      session_count: 2
+    )
+    _(response.session.length).must_equal 2
+    response.session.each do |session|
+      _(session.name).must_match "projects/p/instances/i/databases/d/sessions/"
+    end
+  end
+
+  it "gets session" do
+    created = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    session = @client.get_session V1::GetSessionRequest.new name: created.name
+    _(session.name).must_match created.name
+  end
+
+  it "lists sessions" do
+    created = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    paged_response = @client.list_sessions V1::ListSessionsRequest.new database: "projects/p/instances/i/databases/d"
+    _((paged_response.response.sessions.select {|session| session.name == created.name}).length).must_equal 1
+  end
+
+  it "deletes session" do
+    created = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    @client.delete_session V1::DeleteSessionRequest.new name: created.name
+    paged_response = @client.list_sessions V1::ListSessionsRequest.new database: "projects/p/instances/i/databases/d"
+    _((paged_response.response.sessions.select {|session| session.name == created.name}).length).must_equal 0
+  end
+
+  it "can execute SELECT 1" do
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    resultSet = @client.execute_sql V1::ExecuteSqlRequest.new session: session.name, sql: "SELECT 1"
+    _(resultSet.rows.length).must_equal 1 # Number of rows
+    _(resultSet.rows[0].values.length).must_equal 1 # Number of columns
+    _(resultSet.rows[0].values[0].string_value).must_equal "1" # Value
+  end
+
+  it "raises an error" do
+    sql = "SELECT * FROM NonExistingTable"
+    @mock.put_statement_result(
+      sql,
+      StatementResult.new(
+        GRPC::BadStatus.new(GRPC::Core::StatusCodes::NOT_FOUND,
+                            "Table NonExistingTable not found")
+      )
+    )
+
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    assert_raises Google::Cloud::NotFoundError do
+      @client.execute_sql V1::ExecuteSqlRequest.new session: session.name, sql: sql
+    end
+  end
+
+  it "returns an update count" do
+    sql = "UPDATE TestTable SET Value=1 WHERE TRUE"
+    @mock.put_statement_result sql, StatementResult.new(100)
+
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    update_count = @client.execute_sql V1::ExecuteSqlRequest.new session: session.name, sql: sql
+    _(update_count.stats.row_count_exact).must_equal 100
+  end
+
+  it "returns a streaming result for SELECT 1" do
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    stream = @client.execute_streaming_sql V1::ExecuteSqlRequest.new session: session.name, sql: "SELECT 1"
+    stream.each do |partial|
+      _(partial.values.length).must_equal 1 # Number values in partial result set
+      _(partial.values[0].string_value).must_equal "1" # Value
+    end
+  end
+
+  it "can create a random result set" do
+    result = StatementResult.create_random_result 100
+    _(result.result.metadata.row_type.fields.length).must_equal 8
+    _(result.result.rows.length).must_equal 100
+    result.each do |partial|
+      _(partial.values.length).must_equal 8 # Number values in partial result set
+    end
+  end
+
+  it "returns a random streaming result" do
+    sql = "SELECT * FROM RandomTable"
+    @mock.put_statement_result sql, StatementResult.create_random_result(100)
+
+    session = @client.create_session V1::CreateSessionRequest.new database: "projects/p/instances/i/databases/d"
+    stream = @client.execute_streaming_sql V1::ExecuteSqlRequest.new session: session.name, sql: sql
+    row_count = 0
+    stream.each do |partial|
+      _(partial.values.length).must_equal 8 # Number values in partial result set
+      row_count += 1
+    end
+    _(row_count).must_equal 100
+  end
+end

--- a/test/mock_server/spanner_mock_server_test.rb
+++ b/test/mock_server/spanner_mock_server_test.rb
@@ -26,6 +26,7 @@ describe "Spanner Mock Server" do
     @server_thread = Thread.new do
       @server.run
     end
+    @server.wait_till_running
     @client = V1::Spanner::Client.new do |config|
       config.credentials = :this_channel_is_insecure
       config.endpoint = "localhost:#{@port}"

--- a/test/mock_server/statement_result.rb
+++ b/test/mock_server/statement_result.rb
@@ -1,0 +1,135 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "base64"
+require "securerandom"
+
+class StatementResult
+  QUERY = 1
+  UPDATE_COUNT = 2
+  EXCEPTION = 3
+
+  def self.create_select1_result
+    col1 = V1::StructType::Field.new name: "Col1", type: V1::Type.new(code: V1::TypeCode::INT64)
+    metadata = V1::ResultSetMetadata.new
+    metadata.row_type = V1::StructType.new
+    metadata.row_type.fields << col1
+    resultSet = V1::ResultSet.new
+    resultSet.metadata = metadata
+    row = Protobuf::ListValue.new
+    row.values << Protobuf::Value.new(string_value: "1")
+    resultSet.rows << row
+
+    StatementResult.new(resultSet)
+  end
+
+  def self.create_random_result row_count
+    col_bool = V1::StructType::Field.new name: "ColBool", type: V1::Type.new(code: V1::TypeCode::BOOL)
+    col_int64 = V1::StructType::Field.new name: "ColInt64", type: V1::Type.new(code: V1::TypeCode::INT64)
+    col_float64 = V1::StructType::Field.new name: "ColFloat64", type: V1::Type.new(code: V1::TypeCode::FLOAT64)
+    col_numeric = V1::StructType::Field.new name: "ColNumeric", type: V1::Type.new(code: V1::TypeCode::NUMERIC)
+    col_string = V1::StructType::Field.new name: "ColString", type: V1::Type.new(code: V1::TypeCode::STRING)
+    col_bytes = V1::StructType::Field.new name: "ColBytes", type: V1::Type.new(code: V1::TypeCode::BYTES)
+    col_date = V1::StructType::Field.new name: "ColDate", type: V1::Type.new(code: V1::TypeCode::DATE)
+    col_timestamp = V1::StructType::Field.new name: "ColTimestamp", type: V1::Type.new(code: V1::TypeCode::TIMESTAMP)
+
+    metadata = V1::ResultSetMetadata.new row_type: V1::StructType.new
+    metadata.row_type.fields.push(col_bool, col_int64, col_float64, col_numeric, col_string, col_bytes, col_date,
+                                  col_timestamp)
+    result_set = V1::ResultSet.new metadata: metadata
+
+    (1..row_count).each { |i|
+      row = Protobuf::ListValue.new
+      row.values.push(
+        random_value_or_null(Protobuf::Value.new(bool_value: [true, false].sample), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s), 10),
+        random_value_or_null(Protobuf::Value.new(number_value: SecureRandom.random_number), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: SecureRandom.random_number(999999.99).round(2).to_s), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: SecureRandom.alphanumeric(SecureRandom.random_number(10..200))), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: Base64.encode64(SecureRandom.alphanumeric(SecureRandom.random_number(10..200)))), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: sprintf("%04d-%02d-%02d",
+                                                  SecureRandom.random_number(1900..2021),
+                                                  SecureRandom.random_number(1..12),
+                                                  SecureRandom.random_number(1..28))
+        ), 10),
+        random_value_or_null(Protobuf::Value.new(string_value: sprintf("%04d-%02d-%02dT%02d:%02d:%02d.%dZ",
+                                                  SecureRandom.random_number(1900..2021),
+                                                  SecureRandom.random_number(1..12),
+                                                  SecureRandom.random_number(1..28),
+                                                  SecureRandom.random_number(0..23),
+                                                  SecureRandom.random_number(0..59),
+                                                  SecureRandom.random_number(0..59),
+                                                  SecureRandom.random_number(1..999999999))
+        ),10)
+      )
+      result_set.rows.push row
+    }
+
+    StatementResult.new result_set
+  end
+
+  def self.random_value_or_null value, null_fraction_divisor
+    SecureRandom.random_number(1..null_fraction_divisor) == 1 ?
+      Protobuf::Value.new(null_value: "NULL_VALUE")
+      : value
+  end
+
+  attr_reader :result_type
+  attr_reader :result
+
+  def initialize result
+    if result.is_a?(V1::ResultSet)
+      @result_type = QUERY
+      @result = result
+    elsif result.is_a?(Integer)
+      @result_type = UPDATE_COUNT
+      @result = create_update_count_result result
+    elsif result.is_a?(Exception)
+      @result_type = EXCEPTION
+      @result = result
+    else
+      raise ArgumentError, "result must be either a ResultSet, an Integer (update count) or an exception"
+    end
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+    if @result.rows.length == 0
+      partial = V1::PartialResultSet.new
+      partial.metadata = result.metadata
+      partial.stats = result.stats
+      yield partial
+    else
+      @result.rows.each do |row|
+        index = 0
+        partial = V1::PartialResultSet.new
+        if index == 0
+          partial.metadata = result.metadata
+        end
+        index += 1
+        if index == result.rows.length
+          partial.stats = result.stats
+        end
+        partial.values = row.values
+        yield partial
+      end
+    end
+  end
+
+  private
+
+  def create_update_count_result update_count
+    resultSet = V1::ResultSet.new
+    metadata = V1::ResultSetMetadata.new
+    metadata.row_type = V1::StructType.new
+    resultSet.metadata = metadata
+    resultSet.stats = V1::ResultSetStats.new
+    resultSet.stats.row_count_exact = update_count
+
+    resultSet
+  end
+
+end


### PR DESCRIPTION
Adds a mock server and several end-to-end tests using the mock server.
Also fixes:
- Invalid function calls in migrations
- Unnecessary use of snapshots for INFORMATION_SCHEMA queries
- Unnecessary SELECT 1 query each time a connection is checked out of the pool
- A typo in `begin_transaction`