### PR TITLE
feat: interleaved tables

### DIFF
--- a/acceptance/cases/associations/has_many_associations_test.rb
+++ b/acceptance/cases/associations/has_many_associations_test.rb
@@ -98,7 +98,7 @@ module ActiveRecord
         end
       end
 
-      def test_fetch_associated_recoed_with_order
+      def test_fetch_associated_record_with_order
         accounts = customer.accounts.order(credit_limit: :desc)
         assert_equal [200, 100], accounts.pluck(:credit_limit)
 

--- a/acceptance/cases/associations/has_one_associations_test.rb
+++ b/acceptance/cases/associations/has_one_associations_test.rb
@@ -17,57 +17,39 @@ module ActiveRecord
     class HasOneTest < SpannerAdapter::TestCase
       include SpannerAdapter::Associations::TestHelper
 
-      attr_accessor :singer, :album1, :album2, :track1_1, :track1_2, :track2_1, :track2_2
+      attr_accessor :firm, :account
 
       def setup
         super
 
-        @singer = Singer.create first_name: "FirstName1", last_name: "LastName1"
+        @account = Account.create name: "Account - #{rand 1000}", credit_limit: 100
+        @firm = Firm.create name: "Firm-#{rand 1000}", account: account
 
-        @album2 = Album.create title: "Title2", singer: singer
-        @album1 = Album.create title: "Title1", singer: singer
-
-        @track2_1 = Track.create title: "Title2_1", album: album2, duration: 3.6
-        @track2_2 = Track.create title: "Title2_2", album: album2, duration: 3.3
-        @track1_1 = Track.create title: "Title1_1", album: album1, duration: 4.5
-        @track1_2 = Track.create title: "Title1_2", album: album1
-
-        @singer.reload
-        @album1.reload
-        @album2.reload
-        @track1_1.reload
-        @track2_1.reload
-        @track1_2.reload
-        @track2_2.reload
+        @account.reload
+        @firm.reload
       end
 
       def teardown
-        Album.destroy_all
-        Singer.destroy_all
+        Firm.destroy_all
+        Account.destroy_all
+        Department.destroy_all
       end
 
       def test_has_one
-        assert_equal singer, album1.singer
-        assert_equal singer, album2.singer
-
-        assert_equal album1, track1_1.album
-        assert_equal album1, track1_2.album
-        assert_equal album2, track2_1.album
-        assert_equal album2, track2_2.album
+        assert_equal account, firm.account
+        assert_equal account.credit_limit, firm.account.credit_limit
       end
 
       def test_has_one_does_not_use_order_by
-        sql_log = capture_sql { album1.singer }
+        sql_log = capture_sql { firm.account }
         assert sql_log.all? { |sql| !/order by/i.match?(sql) }, "ORDER BY was used in the query: #{sql_log}"
       end
 
-      def test_find_using_primary_key
-        assert_equal Singer.find_by(singerid: singer.id), album1.singer
+      def test_finding_using_primary_key
+        assert_equal Account.find_by(firm_id: firm.id), firm.account
       end
 
       def test_successful_build_association
-
-
         account = firm.build_account(credit_limit: 1000)
         assert account.save
 

--- a/acceptance/cases/associations/has_one_associations_test.rb
+++ b/acceptance/cases/associations/has_one_associations_test.rb
@@ -17,39 +17,57 @@ module ActiveRecord
     class HasOneTest < SpannerAdapter::TestCase
       include SpannerAdapter::Associations::TestHelper
 
-      attr_accessor :firm, :account
+      attr_accessor :singer, :album1, :album2, :track1_1, :track1_2, :track2_1, :track2_2
 
       def setup
         super
 
-        @account = Account.create name: "Account - #{rand 1000}", credit_limit: 100
-        @firm = Firm.create name: "Firm-#{rand 1000}", account: account
+        @singer = Singer.create first_name: "FirstName1", last_name: "LastName1"
 
-        @account.reload
-        @firm.reload
+        @album2 = Album.create title: "Title2", singer: singer
+        @album1 = Album.create title: "Title1", singer: singer
+
+        @track2_1 = Track.create title: "Title2_1", album: album2, duration: 3.6
+        @track2_2 = Track.create title: "Title2_2", album: album2, duration: 3.3
+        @track1_1 = Track.create title: "Title1_1", album: album1, duration: 4.5
+        @track1_2 = Track.create title: "Title1_2", album: album1
+
+        @singer.reload
+        @album1.reload
+        @album2.reload
+        @track1_1.reload
+        @track2_1.reload
+        @track1_2.reload
+        @track2_2.reload
       end
 
       def teardown
-        Firm.destroy_all
-        Account.destroy_all
-        Department.destroy_all
+        Album.destroy_all
+        Singer.destroy_all
       end
 
       def test_has_one
-        assert_equal account, firm.account
-        assert_equal account.credit_limit, firm.account.credit_limit
+        assert_equal singer, album1.singer
+        assert_equal singer, album2.singer
+
+        assert_equal album1, track1_1.album
+        assert_equal album1, track1_2.album
+        assert_equal album2, track2_1.album
+        assert_equal album2, track2_2.album
       end
 
       def test_has_one_does_not_use_order_by
-        sql_log = capture_sql { firm.account }
+        sql_log = capture_sql { album1.singer }
         assert sql_log.all? { |sql| !/order by/i.match?(sql) }, "ORDER BY was used in the query: #{sql_log}"
       end
 
-      def test_finding_using_primary_key
-        assert_equal Account.find_by(firm_id: firm.id), firm.account
+      def test_find_using_primary_key
+        assert_equal Singer.find_by(singerid: singer.id), album1.singer
       end
 
       def test_successful_build_association
+
+
         account = firm.build_account(credit_limit: 1000)
         assert account.save
 

--- a/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
+++ b/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
@@ -16,15 +16,20 @@ module ActiveRecord
     class HasManyUsingInterleavedTest < SpannerAdapter::TestCase
       include SpannerAdapter::Associations::TestHelper
 
-      attr_accessor :singer
+      attr_accessor :singer, :album1, :album2
 
       def setup
         super
 
         @singer = Singer.create first_name: "FirstName1", last_name: "LastName1"
 
-        Album.create title: "Title2", singer: singer
-        Album.create title: "Title1", singer: singer
+        @album2 = Album.create title: "Title2", singer: singer
+        @album1 = Album.create title: "Title1", singer: singer
+
+        @track2_1 = Track.create title: "Title2_1", album: album2, duration: 3.6
+        @track2_2 = Track.create title: "Title2_2", album: album2, duration: 3.3
+        @track1_1 = Track.create title: "Title1_1", album: album1, duration: 4.5
+        @track1_2 = Track.create title: "Title1_2", album: album1
       end
 
       def teardown
@@ -35,6 +40,153 @@ module ActiveRecord
       def test_has_many
         assert_equal 2, singer.albums.count
         assert_equal singer.albums.pluck(:title).sort, %w[Title1 Title2]
+
+        assert_equal 4, singer.tracks.count
+        assert_equal singer.tracks.pluck(:title).sort, %w[Title1_1 Title1_2 Title2_1 Title2_2]
+
+        assert_equal 2, album1.tracks.count
+        assert_equal album1.tracks.pluck(:title).sort, %w[Title1_1 Title1_2]
+        assert_equal 2, album2.tracks.count
+        assert_equal album2.tracks.pluck(:title).sort, %w[Title2_1 Title2_2]
+      end
+
+      def test_finding_using_associated_fields
+        assert_equal Album.where(singerid: singer.id).to_a, singer.albums.to_a
+        assert_equal Track.where(singerid: singer.id).to_a, singer.tracks.to_a
+      end
+
+      def test_successful_build_association
+        album = singer.albums.build title: "New Title"
+        assert album.save
+
+        singer.reload
+        assert_equal album, singer.albums.find(album.id)
+      end
+
+      def test_successful_build_nested_association
+        track = album1.tracks.build title: "New Title", duration: 4.45
+        assert track.save
+
+        album1.reload
+        assert_equal track, album1.tracks.find(track.id)
+      end
+
+      def test_create_and_destroy_associated_records
+        singer2 = Singer.new first_name: "First", last_name: "Last"
+        singer2.albums.build title: "New Title 1"
+        singer2.albums.build title: "New Title 2"
+        singer2.save!
+
+        singer2.reload
+
+        assert_equal 2, singer2.albums.count
+        assert_equal 4, Album.count
+
+        singer2.albums.destroy_all
+        singer2.reload
+
+        assert_equal 0, singer2.albums.count
+        assert_equal 2, Album.count
+      end
+
+      def test_create_and_destroy_nested_associated_records
+        album3 = Album.new singer: singer, title: "Title 3"
+        album3.tracks.build title: "Title3_1", duration: 2.5, singer: singer
+        album3.tracks.build title: "Title3_2", singer: singer
+        album3.save!
+
+        album3.reload
+
+        assert_equal 2, album3.tracks.count
+        assert_equal 6, singer.tracks.count
+        assert_equal 6, Track.count
+
+        album3.tracks.destroy_all
+        album3.reload
+
+        assert_equal 0, album3.tracks.count
+        assert_equal 4, Track.count
+      end
+
+      def test_create_and_delete_associated_records
+        singer2 = Singer.new first_name: "First", last_name: "Last"
+        singer2.albums.build title: "Album - 11"
+        singer2.albums.build title: "Album - 12"
+        singer2.save!
+
+        singer2.reload
+
+        assert_equal 2, singer2.albums.count
+        assert_equal 4, Album.count
+
+        assert_equal 2, singer2.albums.delete_all
+        singer2.reload
+
+        assert_equal 0, singer2.albums.count
+        assert_equal 2, Album.count
+      end
+
+      def test_create_and_delete_nested_associated_records
+        album3 = Album.new title: "Album 3", singer: singer
+        album3.tracks.build title: "Track - 31", singer: singer
+        album3.tracks.build title: "Track - 32", singer: singer
+        album3.save!
+
+        album3.reload
+
+        assert_equal 2, album3.tracks.count
+        assert_equal 6, Track.count
+
+        assert_equal 2, album3.tracks.delete_all
+        album3.reload
+
+        assert_equal 0, album3.tracks.count
+        assert_equal 4, Track.count
+      end
+
+      def test_update_associated_records
+        count = singer.albums.update_all title: "Title - Update"
+        assert_equal singer.albums.count, count
+
+        singer.reload
+        singer.albums.each do |album|
+          assert_equal "Title - Update", album.title
+        end
+      end
+
+      def test_update_nested_associated_records
+        count = album1.tracks.update_all title: "Title - Update", duration: 6.626
+        assert_equal album1.tracks.count, count
+
+        album1.reload
+        album1.tracks.each do |track|
+          assert_equal "Title - Update", track.title
+          assert_equal 6.626, track.duration
+        end
+      end
+
+      def test_fetch_associated_record_with_order
+        albums = singer.albums.order title: :desc
+        assert_equal %w[Title2 Title1], albums.pluck(:title)
+
+        albums = singer.albums.order title: :asc
+        assert_equal %w[Title1 Title2], albums.pluck(:title)
+      end
+
+      def test_fetch_nested_associated_record_with_order
+        tracks = album1.tracks.order duration: :desc
+        assert_equal [4.5, nil], tracks.pluck(:duration)
+
+        tracks = album1.tracks.order duration: :asc
+        assert_equal [nil, 4.5], tracks.pluck(:duration)
+      end
+
+      def test_set_counter_cache
+        singer.tracks.create! title: "New Title 1", album: album1
+        singer.tracks.create! title: "New Title 2", album: album2
+
+        singer.reload
+        assert_equal 6, singer.tracks_count
       end
     end
   end

--- a/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
+++ b/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
@@ -187,6 +187,24 @@ module ActiveRecord
 
         singer.reload
         assert_equal 6, singer.tracks_count
+      end
+
+      def test_cascade_destroy
+        assert_equal 4, singer.tracks.count
+
+        assert album1.destroy
+
+        singer.reload
+        assert_equal 2, singer.tracks.count
+      end
+
+      def test_cascade_delete
+        assert_equal 4, singer.tracks.count
+
+        assert album1.delete
+
+        singer.reload
+        assert_equal 2, singer.tracks.count
       end
     end
   end

--- a/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
+++ b/acceptance/cases/interleaved_associations/has_many_associations_using_interleaved_test.rb
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/singer"
+require "models/album"
+require "models/track"
+
+module ActiveRecord
+  module Associations
+    class HasManyUsingInterleavedTest < SpannerAdapter::TestCase
+      include SpannerAdapter::Associations::TestHelper
+
+      attr_accessor :singer
+
+      def setup
+        super
+
+        @singer = Singer.create first_name: "FirstName1", last_name: "LastName1"
+
+        Album.create title: "Title2", singer: singer
+        Album.create title: "Title1", singer: singer
+      end
+
+      def teardown
+        Album.destroy_all
+        Singer.destroy_all
+      end
+
+      def test_has_many
+        assert_equal 2, singer.albums.count
+        assert_equal singer.albums.pluck(:title).sort, %w[Title1 Title2]
+      end
+    end
+  end
+end

--- a/acceptance/models/album.rb
+++ b/acceptance/models/album.rb
@@ -8,5 +8,5 @@ class Album < ActiveRecord::Base
   # The relationship with singer is not really a foreign key, but an INTERLEAVE IN relationship. We still need to
   # use the `foreign_key` attribute to indicate which column to use for the relationship.
   belongs_to :singer, foreign_key: "singerid"
-  has_many :tracks
+  has_many :tracks, foreign_key: "albumid", dependent: :delete_all
 end

--- a/acceptance/models/album.rb
+++ b/acceptance/models/album.rb
@@ -1,0 +1,12 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  # The relationship with singer is not really a foreign key, but an INTERLEAVE IN relationship. We still need to
+  # use the `foreign_key` attribute to indicate which column to use for the relationship.
+  belongs_to :singer, foreign_key: "singerid"
+  has_many :tracks
+end

--- a/acceptance/models/singer.rb
+++ b/acceptance/models/singer.rb
@@ -5,6 +5,6 @@
 # https://opensource.org/licenses/MIT.
 
 class Singer < ActiveRecord::Base
-  has_many :albums, foreign_key: "singerid"
-  has_many :tracks, through: :albums
+  has_many :albums, foreign_key: "singerid", dependent: :delete_all
+  has_many :tracks, foreign_key: "singerid"
 end

--- a/acceptance/models/singer.rb
+++ b/acceptance/models/singer.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
-  has_many :tracks
+class Singer < ActiveRecord::Base
+  has_many :albums, foreign_key: "singerid"
+  has_many :tracks, through: :albums
 end

--- a/acceptance/models/track.rb
+++ b/acceptance/models/track.rb
@@ -4,7 +4,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
-  has_many :tracks
+class Track < ActiveRecord::Base
+  belongs_to :album
 end

--- a/acceptance/models/track.rb
+++ b/acceptance/models/track.rb
@@ -5,5 +5,16 @@
 # https://opensource.org/licenses/MIT.
 
 class Track < ActiveRecord::Base
-  belongs_to :album
+  belongs_to :album, foreign_key: "albumid"
+  belongs_to :singer, foreign_key: "singerid", counter_cache: true
+
+  def initialize attributes = nil
+    super
+    self.singer ||= self.album&.singer
+  end
+
+  def album=value
+    super
+    self.singer = value&.singer
+  end
 end

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -99,11 +99,14 @@ ActiveRecord::Schema.define do
     create_table :albums, id: false do |t|
       t.interleave_in :singers
       t.primary_key :albumid
+      # `singerid` is part of the primary key in the table definition, but it is not visible to ActiveRecord as part of
+      # the primary key, to prevent ActiveRecord from considering this to be an entity with a composite primary key.
       t.parent_key :singerid
       t.string :title
     end
 
     create_table :tracks, id: false do |t|
+      # `:cascade` causes all tracks that belong to an album to automatically be deleted when an album is deleted.
       t.interleave_in :albums, :cascade
       t.primary_key :trackid
       t.parent_key :singerid

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define do
       t.primary_key :singerid
       t.column :first_name, :string, limit: 200
       t.string :last_name
+      t.integer :tracks_count
     end
 
     create_table :albums, id: false do |t|

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -7,84 +7,108 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-  create_table :firms do |t|
-    t.string  :name
-    t.integer :rating
-    t.string :description
-    t.references :account
-  end
+  connection.ddl_batch do
+    create_table :firms do |t|
+      t.string  :name
+      t.integer :rating
+      t.string :description
+      t.references :account
+    end
 
-  create_table :customers do |t|
-    t.string  :name
-  end
+    create_table :customers do |t|
+      t.string  :name
+    end
 
-  create_table :accounts do |t|
-    t.references :customer, index: false
-    t.references :firm, index: false
-    t.string  :name
-    t.integer :credit_limit
-    t.integer :transactions_count
-  end
+    create_table :accounts do |t|
+      t.references :customer, index: false
+      t.references :firm, index: false
+      t.string  :name
+      t.integer :credit_limit
+      t.integer :transactions_count
+    end
 
-  create_table :transactions do |t|
-    t.float :amount
-    t.references :account, index: false
-  end
+    create_table :transactions do |t|
+      t.float :amount
+      t.references :account, index: false
+    end
 
-  create_table :departments do |t|
-    t.string :name
-    t.references :resource, polymorphic: true
-  end
+    create_table :departments do |t|
+      t.string :name
+      t.references :resource, polymorphic: true
+    end
 
-  create_table :member_types do |t|
-    t.string :name
-  end
+    create_table :member_types do |t|
+      t.string :name
+    end
 
-  create_table :members do |t|
-    t.string :name
-    t.references :member_type, index: false
-    t.references :admittable, polymorphic: true, index: false
-  end
+    create_table :members do |t|
+      t.string :name
+      t.references :member_type, index: false
+      t.references :admittable, polymorphic: true, index: false
+    end
 
-  create_table :memberships do |t|
-    t.datetime :joined_on
-    t.references :club, index: false
-    t.references :member, index: false
-    t.boolean :favourite
-  end
+    create_table :memberships do |t|
+      t.datetime :joined_on
+      t.references :club, index: false
+      t.references :member, index: false
+      t.boolean :favourite
+    end
 
-  create_table :clubs do |t|
-    t.string :name
-  end
+    create_table :clubs do |t|
+      t.string :name
+    end
 
-  create_table :authors do |t|
-    t.string :name, null: false
-    t.date :registered_date
-    t.references :organization, index: false
-  end
+    create_table :authors do |t|
+      t.string :name, null: false
+      t.date :registered_date
+      t.references :organization, index: false
+    end
 
-  create_table :posts do |t|
-    t.string :title
-    t.string :content
-    t.references :author
-    t.integer :comments_count
-    t.date :post_date
-    t.time :published_time
-  end
+    create_table :posts do |t|
+      t.string :title
+      t.string :content
+      t.references :author
+      t.integer :comments_count
+      t.date :post_date
+      t.time :published_time
+    end
 
-  create_table :comments do |t|
-    t.string :comment
-    t.references :post, index: false, foreign_key: true
-  end
+    create_table :comments do |t|
+      t.string :comment
+      t.references :post, index: false, foreign_key: true
+    end
 
-  create_table :addresses do |t|
-    t.string :line1
-    t.string :postal_code
-    t.string :city
-    t.references :author, index: false
-  end
+    create_table :addresses do |t|
+      t.string :line1
+      t.string :postal_code
+      t.string :city
+      t.references :author, index: false
+    end
 
-  create_table :organizations do |t|
-    t.string :name
+    create_table :organizations do |t|
+      t.string :name
+    end
+
+    create_table :singers, id: false do |t|
+      t.primary_key :singerid
+      t.column :first_name, :string, limit: 200
+      t.string :last_name
+    end
+
+    create_table :albums, id: false do |t|
+      t.interleave_in :singers
+      t.primary_key :albumid
+      t.parent_key :singerid
+      t.string :title
+    end
+
+    create_table :tracks, id: false do |t|
+      t.interleave_in :albums, :cascade
+      t.primary_key :trackid
+      t.parent_key :singerid
+      t.parent_key :albumid
+      t.string :title
+      t.numeric :duration
+    end
   end
 end

--- a/examples/snippets/interleaved-tables/README.md
+++ b/examples/snippets/interleaved-tables/README.md
@@ -8,7 +8,7 @@ on interleaved tables if you are not familiar with this concept.
 ## Creating Interleaved Tables in ActiveRecord
 You can create interleaved tables using migrations in ActiveRecord by using the following Spanner ActiveRecord specific
 methods that are defined on `TableDefinition`:
-* `interleave_in`: Specifies the which parent table a child table should be interleaved in and optionally whether
+* `interleave_in`: Specifies which parent table a child table should be interleaved in and optionally whether
   deletes of a parent record should automatically cascade delete all child records. 
 * `parent_key`: Creates a column that is a reference to (a part of) the primary key of the parent table. Each child
   table must include all the primary key columns of the parent table as a `parent_key`.
@@ -85,8 +85,8 @@ include the custom column name in the `belongs_to` and `has_many` definitions.
 
 Instances of these models can be used in the same way as any other association in ActiveRecord, but with a couple of
 inherent limitations:
-* It is not possible to change the parent record of a child record. Changing the singer of an album in the above example
-  is for example not possible, as Cloud Spanner does not allow such an update.
+* It is not possible to change the parent record of a child record. For instance, changing the singer of an album in the
+  above example is impossible, as Cloud Spanner does not allow such an update.
 * It is not possible to de-reference a parent record by setting it to null.
 * It is only possible to delete a parent record with existing child records, if the child records are also deleted. This
   can be done by enabling ON DELETE CASCADE in Cloud Spanner, or by deleting the child records using ActiveRecord.

--- a/examples/snippets/interleaved-tables/README.md
+++ b/examples/snippets/interleaved-tables/README.md
@@ -1,6 +1,146 @@
-# Sample - Read/Write transactions
+# Sample - Interleaved Tables
 
-This example shows how to use read/write transactions using the Spanner ActiveRecord adapter.
+This example shows how to use interleaved tables with the Spanner ActiveRecord adapter.
+
+See https://cloud.google.com/spanner/docs/schema-and-data-model#creating-interleaved-tables for more information
+on interleaved tables if you are not familiar with this concept.
+
+## Creating Interleaved Tables in ActiveRecord
+You can create interleaved tables using migrations in ActiveRecord by using the following Spanner ActiveRecord specific
+methods that are defined on `TableDefinition`:
+* `interleave_in`: Specifies the which parent table a child table should be interleaved in and optionally whether
+  deletes of a parent record should automatically cascade delete all child records. 
+* `parent_key`: Creates a column that is a reference to (a part of) the primary key of the parent table. Each child
+  table must include all the primary key columns of the parent table as a `parent_key`.
+  
+Cloud Spanner requires a child table to include the exact same primary key columns as the parent table in addition to
+the primary key column(s) of the child table. This means that the default `id` primary key column of ActiveRecord is
+not usable in combination with interleaved tables. Instead each primary key column should be prefixed with the table
+name of the table that it references, or use some other unique name.
+
+This example uses the following table schema:
+
+```sql
+CREATE TABLE singers (
+    singerid INT64 NOT NULL,
+    first_name STRING(MAX),
+    last_name STRING(MAX)
+) PRIMARY KEY (singerid);
+
+CREATE TABLE albums (
+    albumid INT64 NOT NULL,
+    singerid INT64 NOT NULL,
+    title STRING(MAX)
+) PRIMARY KEY (singerid, albumid), INTERLEAVE IN PARENT singers;
+
+CREATE TABLE tracks (
+    trackid INT64 NOT NULL,
+    singerid INT64 NOT NULL,
+    albumid INT64 NOT NULL,
+    title STRING(MAX),
+    duration NUMERIC
+) PRIMARY KEY (singerid, albumid, trackid), INTERLEAVE IN PARENT albums ON DELETE CASCADE;
+```
+
+This schema can be created in ActiveRecord as follows:
+
+```ruby
+create_table :singers, id: false do |t|
+    # Explicitly define the primary key with a custom name to prevent all primary key columns from being named `id`.
+    t.primary_key :singerid
+    t.string :first_name
+    t.string :last_name
+end
+
+create_table :albums, id: false do |t|
+    # Interleave the `albums` table in the parent table `singers`.
+    t.interleave_in :singers
+    t.primary_key :albumid
+    # `singerid` is defined as a `parent_key` which makes it a part of the primary key in the table definition, but
+    # it is not presented to ActiveRecord as part of the primary key, to prevent ActiveRecord from considering this
+    # to be an entity with a composite primary key (which is not supported by ActiveRecord).
+    t.parent_key :singerid
+    t.string :title
+end
+
+create_table :tracks, id: false do |t|
+    # Interleave the `tracks` table in the parent table `albums` and cascade delete all tracks that belong to an
+    # album when an album is deleted.
+    t.interleave_in :albums, :cascade
+    # `trackid` is considered the only primary key column by ActiveRecord.
+    t.primary_key :trackid
+    # `singerid` and `albumid` form the parent key of `tracks`. These are part of the primary key definition in the
+    # database, but are presented as parent keys to ActiveRecord.
+    t.parent_key :singerid
+    t.parent_key :albumid
+    t.string :title
+    t.numeric :duration
+end
+```
+
+## Models for Interleaved Tables
+An interleaved table parent/child relationship must be modelled as a `belongs_to`/`has_many` association in
+ActiveRecord. As the columns that are used to reference a parent record use a custom column name, it is required to also
+include the custom column name in the `belongs_to` and `has_many` definitions.
+
+Instances of these models can be used in the same way as any other association in ActiveRecord, but with a couple of
+inherent limitations:
+* It is not possible to change the parent record of a child record. Changing the singer of an album in the above example
+  is for example not possible, as Cloud Spanner does not allow such an update.
+* It is not possible to de-reference a parent record by setting it to null.
+* It is only possible to delete a parent record with existing child records, if the child records are also deleted. This
+  can be done by enabling ON DELETE CASCADE in Cloud Spanner, or by deleting the child records using ActiveRecord.
+
+### Example Models
+
+```ruby
+class Singer < ActiveRecord::Base
+  # `albums` is defined as INTERLEAVE IN PARENT `singers`. The primary key of `albums` is (`singerid`, `albumid`), but
+  # only `albumid` is used by ActiveRecord as the primary key. The `singerid` column is defined as a `parent_key` of
+  # `albums` (see also the `db/migrate/01_create_tables.rb` file).
+  has_many :albums, foreign_key: "singerid"
+
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `tracks` is
+  # (`singerid`, `albumid`, `trackid`), but only `trackid` is used by ActiveRecord as the primary key. The `singerid`
+  # and `albumid` columns are defined as `parent_key` of `tracks` (see also the `db/migrate/01_create_tables.rb` file).
+  # The `singerid` column can therefore be used to associate tracks with a singer without the need to go through albums.
+  # Note also that the inclusion of `singerid` as a column in `tracks` is required in order to make `tracks` a child
+  # table of `albums` which has primary key (`singerid`, `albumid`).
+  has_many :tracks, foreign_key: "singerid"
+end
+
+class Album < ActiveRecord::Base
+  # `albums` is defined as INTERLEAVE IN PARENT `singers`. The primary key of `singers` is `singerid`.
+  belongs_to :singer, foreign_key: "singerid"
+
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `albums` is (`singerid`, `albumid`), but
+  # only `albumid` is used by ActiveRecord as the primary key. The `singerid` column is defined as a `parent_key` of
+  # `albums` (see also the `db/migrate/01_create_tables.rb` file).
+  has_many :tracks, foreign_key: "albumid"
+end
+
+class Track < ActiveRecord::Base
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `albums` is ()`singerid`, `albumid`).
+  belongs_to :album, foreign_key: "albumid"
+
+  # `tracks` also has a `singerid` column should be used to associate a Track with a Singer.
+  belongs_to :singer, foreign_key: "singerid"
+
+  # Override the default initialize method to automatically set the singer attribute when an album is given.
+  def initialize attributes = nil
+    super
+    self.singer ||= album&.singer
+  end
+
+  def album=value
+    super
+    # Ensure the singer of this track is equal to the singer of the album that is set.
+    self.singer = value&.singer
+  end
+end
+```
+
+## Running the Sample
 
 The sample will automatically start a Spanner Emulator in a docker container and execute the sample
 against that emulator. The emulator will automatically be stopped when the application finishes.

--- a/examples/snippets/interleaved-tables/README.md
+++ b/examples/snippets/interleaved-tables/README.md
@@ -1,0 +1,12 @@
+# Sample - Read/Write transactions
+
+This example shows how to use read/write transactions using the Spanner ActiveRecord adapter.
+
+The sample will automatically start a Spanner Emulator in a docker container and execute the sample
+against that emulator. The emulator will automatically be stopped when the application finishes.
+
+Run the application with the command
+
+```bash
+bundle exec rake run
+```

--- a/examples/snippets/interleaved-tables/Rakefile
+++ b/examples/snippets/interleaved-tables/Rakefile
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../config/environment"
+require "sinatra/activerecord/rake"
+
+desc "Sample showing how to work with interleaved tables in ActiveRecord."
+task :run do
+  Dir.chdir("..") { sh "bundle exec rake run[interleaved-tables]" }
+end

--- a/examples/snippets/interleaved-tables/application.rb
+++ b/examples/snippets/interleaved-tables/application.rb
@@ -1,0 +1,109 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "io/console"
+require_relative "../config/environment"
+require_relative "models/singer"
+require_relative "models/album"
+require_relative "models/track"
+
+class Application
+  def self.run
+    # List all singers, albums and tracks.
+    list_singers_albums_tracks
+
+    # Create a new album with some tracks.
+    create_new_album
+
+    # Try to update the singer of an album. This is not possible as albums are interleaved in singers.
+    update_singer_of_album
+
+    # Try to delete a singer that has at least one album. This is NOT possible as albums is NOT marked with
+    # ON DELETE CASCADE.
+    delete_singer_with_albums
+
+    # Try to delete an album that has at least one track. This IS possible as tracks IS marked with
+    # ON DELETE CASCADE.
+    delete_album_with_tracks
+
+    puts ""
+    puts "Press any key to end the application"
+    STDIN.getch
+  end
+
+  def self.list_singers_albums_tracks
+    puts ""
+    puts "Listing all singers with corresponding albums and tracks"
+    Singer.all.order("last_name, first_name").each do |singer|
+      puts "#{singer.first_name} #{singer.last_name} has #{singer.albums.count} albums:"
+      singer.albums.order("title").each do |album|
+        puts "  #{album.title} has #{album.tracks.count} tracks:"
+        album.tracks.each do |track|
+          puts "    #{track.title}"
+        end
+      end
+    end
+  end
+
+  def self.create_new_album
+    # Create a new album with some tracks.
+    puts ""
+    singer = Singer.all.sample
+    puts "Creating a new album for #{singer.first_name} #{singer.last_name}"
+    album = singer.albums.build title: "New Title"
+    album.tracks.build title: "Track 1", duration: 3.5, singer: singer
+    album.tracks.build title: "Track 2", duration: 3.6, singer: singer
+    # This will save the album and corresponding tracks in one transaction.
+    album.save!
+
+    album.reload
+    puts "Album #{album.title} has #{album.tracks.count} tracks:"
+    album.tracks.order("title").each do |track|
+      puts "  #{track.title} with duration #{track.duration}"
+    end
+  end
+
+  def self.update_singer_of_album
+    # It is not possible to change the singer of an album or the album of a track. This is because the associations
+    # between these are not traditional foreign keys, but an immutable parent-child relationship.
+    album = Album.all.sample
+    new_singer = Singer.all.except(album.singer).sample
+    # This will fail as we cannot assign a new singer to an album as it is an INTERLEAVE IN PARENT relationship.
+    begin
+      album.update! singer: new_singer
+      raise StandardError, "Unexpected error: Updating the singer of an album should not be possible."
+    rescue ActiveRecord::StatementInvalid
+      puts ""
+      puts "Failed to update the singer of an album. This is expected."
+    end
+  end
+
+  def self.delete_singer_with_albums
+    # Deleting a singer that has albums is not possible, as the INTERLEAVE IN PARENT of albums is not marked with
+    # ON DELETE CASCADE.
+    singer = Album.all.sample.singer
+    begin
+      singer.delete
+      raise StandardError, "Unexpected error: Updating the singer of an album should not be possible."
+    rescue ActiveRecord::StatementInvalid
+      puts ""
+      puts "Failed to delete a singer that has #{singer.albums.count} albums. This is expected."
+    end
+  end
+
+  def self.delete_album_with_tracks
+    # Deleting an album with tracks is supported, as the INTERLEAVE IN PARENT relationship between tracks and albums is
+    # marked with ON DELETE CASCADE.
+    puts ""
+    puts "Total track count: #{Track.count}"
+    album = Track.all.sample.album
+    puts "Deleting album #{album.title} with #{album.tracks.count} tracks"
+    album.delete
+    puts "Total track count after deletion: #{Track.count}"
+  end
+end
+
+Application.run

--- a/examples/snippets/interleaved-tables/config/database.yml
+++ b/examples/snippets/interleaved-tables/config/database.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  pool: 5
+  timeout: 5000

--- a/examples/snippets/interleaved-tables/db/migrate/01_create_tables.rb
+++ b/examples/snippets/interleaved-tables/db/migrate/01_create_tables.rb
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateTables < ActiveRecord::Migration[6.0]
+  def change
+    # Execute the entire migration as one DDL batch.
+    connection.ddl_batch do
+      create_table :singers, id: false do |t|
+        # Explicitly define the primary key with a custom name to prevent all primary key columns from being named `id`.
+        t.primary_key :singerid
+        t.string :first_name
+        t.string :last_name
+      end
+
+      create_table :albums, id: false do |t|
+        # Interleave the `albums` table in the parent table `singers`.
+        t.interleave_in :singers
+        t.primary_key :albumid
+        # `singerid` is defined as a `parent_key` which makes it a part of the primary key in the table definition, but
+        # it is not presented to ActiveRecord as part of the primary key, to prevent ActiveRecord from considering this
+        # to be an entity with a composite primary key (which is not supported by ActiveRecord).
+        t.parent_key :singerid
+        t.string :title
+      end
+
+      create_table :tracks, id: false do |t|
+        # Interleave the `tracks` table in the parent table `albums` and cascade delete all tracks that belong to an
+        # album when an album is deleted.
+        t.interleave_in :albums, :cascade
+        # `trackid` is considered the only primary key column by ActiveRecord.
+        t.primary_key :trackid
+        # `singerid` and `albumid` form the parent key of `tracks`. These are part of the primary key definition in the
+        # database, but are presented as parent keys to ActiveRecord.
+        t.parent_key :singerid
+        t.parent_key :albumid
+        t.string :title
+        t.numeric :duration
+      end
+    end
+  end
+end

--- a/examples/snippets/interleaved-tables/db/schema.rb
+++ b/examples/snippets/interleaved-tables/db/schema.rb
@@ -1,0 +1,32 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 1) do
+
+  create_table "albums", primary_key: "albumid", force: :cascade do |t|
+    t.integer "singerid", limit: 8, null: false
+    t.string "title"
+  end
+
+  create_table "singers", primary_key: "singerid", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+  end
+
+  create_table "tracks", primary_key: "trackid", force: :cascade do |t|
+    t.integer "singerid", limit: 8, null: false
+    t.integer "albumid", limit: 8, null: false
+    t.string "title"
+    t.decimal "duration"
+  end
+
+end

--- a/examples/snippets/interleaved-tables/db/seeds.rb
+++ b/examples/snippets/interleaved-tables/db/seeds.rb
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../../config/environment.rb"
+require_relative "../models/singer"
+require_relative "../models/album"
+require_relative "../models/track"
+
+first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy Ruben Thomas Elly]
+last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson Aronson Tennet Courtou]
+
+adjectives = %w[daily happy blue generous cooked bad open]
+nouns = %w[windows potatoes bank street tree glass bottle]
+
+verbs = %w[operate waste package chew yield express polish stress slip want cough campaign cultivate report park refer]
+adverbs = %w[directly right hopefully personally economically privately supposedly consequently fully later urgently]
+
+durations = [3.14, 5.4, 3.3, 4.1, 5.0, 3.2, 3.0, 3.5, 4.0, 4.5, 5.5, 6.0]
+
+# This ensures all the records are inserted using one read/write transaction that will use mutations instead of DML.
+ActiveRecord::Base.transaction isolation: :buffered_mutations do
+  singers = []
+  5.times do
+    singers << Singer.create(first_name: first_names.sample, last_name: last_names.sample)
+  end
+
+  albums = []
+  20.times do
+    singer = singers.sample
+    albums << Album.create(title: "#{adjectives.sample} #{nouns.sample}", singer: singer)
+  end
+
+  200.times do
+    album = albums.sample
+    Track.create title: "#{verbs.sample} #{adverbs.sample}", duration: durations.sample, album: album
+  end
+end

--- a/examples/snippets/interleaved-tables/models/album.rb
+++ b/examples/snippets/interleaved-tables/models/album.rb
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  # `albums` is defined as INTERLEAVE IN PARENT `singers`. The primary key of `singers` is `singerid`.
+  belongs_to :singer, foreign_key: "singerid"
+
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `albums` is (`singerid`, `albumid`), but
+  # only `albumid` is used by ActiveRecord as the primary key. The `singerid` column is defined as a `parent_key` of
+  # `albums` (see also the `db/migrate/01_create_tables.rb` file).
+  has_many :tracks, foreign_key: "albumid"
+end

--- a/examples/snippets/interleaved-tables/models/singer.rb
+++ b/examples/snippets/interleaved-tables/models/singer.rb
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  # `albums` is defined as INTERLEAVE IN PARENT `singers`. The primary key of `albums` is (`singerid`, `albumid`), but
+  # only `albumid` is used by ActiveRecord as the primary key. The `singerid` column is defined as a `parent_key` of
+  # `albums` (see also the `db/migrate/01_create_tables.rb` file).
+  has_many :albums, foreign_key: "singerid"
+
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `tracks` is
+  # (`singerid`, `albumid`, `trackid`), but only `trackid` is used by ActiveRecord as the primary key. The `singerid`
+  # and `albumid` columns are defined as `parent_key` of `tracks` (see also the `db/migrate/01_create_tables.rb` file).
+  # The `singerid` column can therefore be used to associate tracks with a singer without the need to go through albums.
+  # Note also that the inclusion of `singerid` as a column in `tracks` is required in order to make `tracks` a child
+  # table of `albums` which has primary key (`singerid`, `albumid`).
+  has_many :tracks, foreign_key: "singerid"
+end

--- a/examples/snippets/interleaved-tables/models/track.rb
+++ b/examples/snippets/interleaved-tables/models/track.rb
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Track < ActiveRecord::Base
+  # `tracks` is defined as INTERLEAVE IN PARENT `albums`. The primary key of `albums` is ()`singerid`, `albumid`).
+  belongs_to :album, foreign_key: "albumid"
+
+  # `tracks` also has a `singerid` column should be used to associate a Track with a Singer.
+  belongs_to :singer, foreign_key: "singerid"
+
+  # Override the default initialize method to automatically set the singer attribute when an album is given.
+  def initialize attributes = nil
+    super
+    self.singer ||= album&.singer
+  end
+
+  def album=value
+    super
+    # Ensure the singer of this track is equal to the singer of the album that is set.
+    self.singer = value&.singer
+  end
+end

--- a/lib/active_record/connection_adapters/spanner/schema_cache.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_cache.rb
@@ -1,0 +1,35 @@
+module ActiveRecord
+  module ConnectionAdapters
+    class SpannerSchemaCache < SchemaCache
+      def initialize conn
+        @primary_and_parent_keys = {}
+        super
+      end
+
+      def initialize_dup other
+        @primary_and_parent_keys = @primary_and_parent_keys.dup
+        super
+      end
+
+      def encode_with coder
+        coder["primary_and_parent_keys"] = @primary_and_parent_keys
+        super
+      end
+
+      def init_with coder
+        @primary_and_parent_keys = coder["primary_and_parent_keys"]
+        super
+      end
+
+      def primary_and_parent_keys table_name
+        @primary_and_parent_keys[table_name] ||= data_source_exists?(table_name) ? connection.primary_and_parent_keys(table_name) : nil
+      end
+
+      def clear!
+        @primary_and_parent_keys.clear
+        super
+      end
+    end
+  end
+end
+

--- a/lib/active_record/connection_adapters/spanner/schema_cache.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_cache.rb
@@ -22,7 +22,10 @@ module ActiveRecord
       end
 
       def primary_and_parent_keys table_name
-        @primary_and_parent_keys[table_name] ||= data_source_exists?(table_name) ? connection.primary_and_parent_keys(table_name) : nil
+        @primary_and_parent_keys[table_name] ||=
+          if data_source_exists? table_name
+            connection.primary_and_parent_keys table_name
+          end
       end
 
       def clear!
@@ -32,4 +35,3 @@ module ActiveRecord
     end
   end
 end
-

--- a/lib/active_record/connection_adapters/spanner/schema_cache.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_cache.rb
@@ -1,3 +1,9 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 module ActiveRecord
   module ConnectionAdapters
     class SpannerSchemaCache < SchemaCache

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -32,11 +32,19 @@ module ActiveRecord
                            end
                            PrimaryKeyDefinition.new pk_names
                          end
-          create_sql << accept(primary_keys)
 
-          if o.interleave_in
-            create_sql << " , INTERLEAVE IN PARENT #{o.interleave_in}"
+          if o.interleave_in?
+            parent_names = o.columns.each_with_object [] do |c, r|
+              if c.type == :parent_key
+                r << c.name
+              end
+            end
+            primary_keys.name = parent_names.concat(primary_keys.name)
+            create_sql << accept(primary_keys)
+            create_sql << ", INTERLEAVE IN PARENT #{quote_table_name(o.interleave_in_parent)}"
             create_sql << " ON DELETE #{o.on_delete}" if o.on_delete
+          else
+            create_sql << accept(primary_keys)
           end
 
           create_sql

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -39,9 +39,9 @@ module ActiveRecord
                 r << c.name
               end
             end
-            primary_keys.name = parent_names.concat(primary_keys.name)
+            primary_keys.name = parent_names.concat primary_keys.name
             create_sql << accept(primary_keys)
-            create_sql << ", INTERLEAVE IN PARENT #{quote_table_name(o.interleave_in_parent)}"
+            create_sql << ", INTERLEAVE IN PARENT #{quote_table_name o.interleave_in_parent}"
             create_sql << " ON DELETE #{o.on_delete}" if o.on_delete
           else
             create_sql << accept(primary_keys)

--- a/lib/active_record/connection_adapters/spanner/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_definitions.rb
@@ -8,12 +8,23 @@ module ActiveRecord
   module ConnectionAdapters #:nodoc:
     module Spanner
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
-        def interleave_in
-          @options[:interleave_in] if @options
+        attr_reader :interleave_in_parent
+
+        def interleave_in parent, on_delete = nil
+          @interleave_in_parent = parent
+          @on_delete = on_delete
+        end
+
+        def parent_key name
+          column name, :parent_key, null: false
+        end
+
+        def interleave_in?
+          @interleave_in_parent != nil
         end
 
         def on_delete
-          @options[:on_delete] if @options
+          "CASCADE" if @on_delete == :cascade
         end
 
         def references *args, **options

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -327,6 +327,14 @@ module ActiveRecord
           columns.map(&:name)
         end
 
+        def primary_and_parent_keys table_name
+          columns = information_schema do |i|
+            i.table_primary_keys table_name, true
+          end
+
+          columns.map(&:name)
+        end
+
         # Foreign Keys
 
         def foreign_keys table_name, column: nil

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -10,6 +10,7 @@ require "spanner_client_ext"
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/spanner/database_statements"
 require "active_record/connection_adapters/spanner/schema_statements"
+require "active_record/connection_adapters/spanner/schema_cache"
 require "active_record/connection_adapters/spanner/schema_definitions"
 require "active_record/connection_adapters/spanner/type_metadata"
 require "active_record/connection_adapters/spanner/quoting"
@@ -21,6 +22,7 @@ require "activerecord_spanner_adapter/base"
 require "activerecord_spanner_adapter/connection"
 require "activerecord_spanner_adapter/errors"
 require "activerecord_spanner_adapter/information_schema"
+require "activerecord_spanner_adapter/primary_key"
 require "activerecord_spanner_adapter/transaction"
 
 module ActiveRecord
@@ -38,6 +40,14 @@ module ActiveRecord
   end
 
   module ConnectionAdapters
+    module AbstractPool
+      def get_schema_cache(connection)
+        @schema_cache ||= SpannerSchemaCache.new connection
+        @schema_cache.connection = connection
+        @schema_cache
+      end
+    end
+
     class SpannerAdapter < AbstractAdapter
       ADAPTER_NAME = "spanner".freeze
       NATIVE_DATABASE_TYPES = {

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -42,6 +42,7 @@ module ActiveRecord
       ADAPTER_NAME = "spanner".freeze
       NATIVE_DATABASE_TYPES = {
         primary_key:  "INT64",
+        parent_key:   "INT64",
         string:       { name: "STRING", limit: "MAX" },
         text:         { name: "STRING", limit: "MAX" },
         integer:      { name: "INT64" },

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -41,7 +41,7 @@ module ActiveRecord
 
   module ConnectionAdapters
     module AbstractPool
-      def get_schema_cache(connection)
+      def get_schema_cache connection
         @schema_cache ||= SpannerSchemaCache.new connection
         @schema_cache.connection = connection
         @schema_cache

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -166,12 +166,5 @@ module ActiveRecord
       Base.connection.current_spanner_transaction.buffer mutation
       1 # Affected rows
     end
-
-    # Same as `id_in_database`, but also includes any parent keys if the table is interleaved in a parent table.
-    def id_and_parent_key_in_database
-      primary_and_parent_key.each do |col|
-        attribute_in_database col
-      end
-    end
   end
 end

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -89,6 +89,11 @@ module ActiveRecordSpannerAdapter
       table_columns(table_name, column_name: column_name).first
     end
 
+    # Returns the primary key columns of the given table. By default it will only return the columns that are not part
+    # of the primary key of the parent table (if any). These are the columns that are considered the primary key by
+    # ActiveRecord. The parent primary key columns are filtered out by default to allow interleaved tables to be
+    # considered as tables with a single-column primary key by ActiveRecord. The actual primary key of the table will
+    # include both the parent primary key columns and the 'own' primary key columns of a table.
     def table_primary_keys table_name, include_parent_keys = false
       sql = +"WITH TABLE_PK_COLS AS ( "
       sql << "SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION "

--- a/lib/activerecord_spanner_adapter/primary_key.rb
+++ b/lib/activerecord_spanner_adapter/primary_key.rb
@@ -1,0 +1,30 @@
+module ActiveRecord
+  module AttributeMethods
+    module PrimaryKey
+      module ClassMethods
+        def primary_and_parent_key
+          reset_primary_and_parent_key unless defined? @primary_and_parent_key
+          @primary_and_parent_key
+        end
+
+        def reset_primary_and_parent_key
+          if base_class?
+            self.primary_and_parent_key = get_primary_and_parent_key
+          else
+            self.primary_and_parent_key = base_class.primary_and_parent_key
+          end
+        end
+
+        def get_primary_and_parent_key
+          if ActiveRecord::Base != self && table_exists?
+            connection.schema_cache.primary_and_parent_keys table_name
+          end
+        end
+
+        def primary_and_parent_key= value
+          @primary_and_parent_key = value
+        end
+      end
+    end
+  end
+end

--- a/lib/activerecord_spanner_adapter/primary_key.rb
+++ b/lib/activerecord_spanner_adapter/primary_key.rb
@@ -8,17 +8,12 @@ module ActiveRecord
         end
 
         def reset_primary_and_parent_key
-          if base_class?
-            self.primary_and_parent_key = get_primary_and_parent_key
-          else
-            self.primary_and_parent_key = base_class.primary_and_parent_key
-          end
+          self.primary_and_parent_key = base_class? ? fetch_primary_and_parent_key : base_class.primary_and_parent_key
         end
 
-        def get_primary_and_parent_key
-          if ActiveRecord::Base != self && table_exists?
-            connection.schema_cache.primary_and_parent_keys table_name
-          end
+        def fetch_primary_and_parent_key
+          return connection.schema_cache.primary_and_parent_keys table_name \
+            if ActiveRecord::Base != self && table_exists?
         end
 
         def primary_and_parent_key= value

--- a/lib/activerecord_spanner_adapter/primary_key.rb
+++ b/lib/activerecord_spanner_adapter/primary_key.rb
@@ -1,3 +1,9 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 module ActiveRecord
   module AttributeMethods
     module PrimaryKey

--- a/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
@@ -1,0 +1,150 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# frozen_string_literal: true
+
+require_relative "./model_helper"
+require_relative "../mock_server/spanner_mock_server"
+require_relative "../test_helper"
+require_relative "models/singer"
+require_relative "models/album"
+
+require "securerandom"
+
+module TestInterleavedTables
+  class InterleavedTablesTest < Minitest::Test
+    def setup
+      super
+      @server = GRPC::RpcServer.new
+      @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+      @mock = SpannerMockServer.new
+      @server.handle @mock
+      # Run the server in a separate thread
+      @server_thread = Thread.new do
+        @server.run
+      end
+      @server.wait_till_running
+      # Register INFORMATION_SCHEMA queries on the mock server.
+      TestInterleavedTables::register_select_tables_result @mock
+      TestInterleavedTables::register_singers_columns_result @mock
+      TestInterleavedTables::register_singers_primary_key_columns_result @mock
+      TestInterleavedTables::register_albums_columns_result @mock
+      TestInterleavedTables::register_albums_primary_key_columns_result @mock
+      TestInterleavedTables::register_albums_primary_and_parent_key_columns_result @mock
+      # Connect ActiveRecord to the mock server
+      ActiveRecord::Base.establish_connection(
+        adapter: "spanner",
+        emulator_host: "localhost:#{@port}",
+        project: "test-project",
+        instance: "test-instance",
+        database: "testdb",
+      )
+      ActiveRecord::Base.logger = nil
+    end
+
+    def teardown
+      ActiveRecord::Base.connection_pool.disconnect!
+      @server.stop
+      @server_thread.exit
+      super
+    end
+
+    def test_select_all_albums
+      sql = "SELECT `albums`.* FROM `albums`"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(4)
+      Album.all.each do |album|
+        refute_nil album.albumid, "albumid should not be nil"
+        refute_nil album.singerid, "singerid should not be nil"
+      end
+    end
+
+    def test_find_album
+      # Selecting a single album should only use the albumid column, and not the singerid column that is technically also
+      # part of the primary key.
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1)
+      album = Album.find 1
+      refute_nil album.albumid, "albumid should not be nil"
+      refute_nil album.singerid, "singerid should not be nil"
+    end
+
+    def test_create_album
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @singerid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_singers_result(1)
+      singer = Singer.find 1
+
+      album = Album.create singer: singer, title: "Random Title"
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :insert, mutation.operation
+      assert_equal "albums", mutation.insert.table
+
+      assert_equal 1, mutation.insert.values.length
+
+      # Note that albumid is added at the end as it is automatically calculated when the record is created.
+      assert_equal 3, mutation.insert.columns.length
+      assert_equal "singerid", mutation.insert.columns[0]
+      assert_equal "title", mutation.insert.columns[1]
+      assert_equal "albumid", mutation.insert.columns[2]
+
+      assert_equal 3, mutation.insert.values[0].length
+      assert_equal singer.singerid, mutation.insert.values[0][0].to_i
+      assert_equal "Random Title", mutation.insert.values[0][1]
+      assert_equal album.albumid, mutation.insert.values[0][2].to_i
+    end
+
+    def test_update_album
+      sql_singer = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @singerid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql_singer, TestInterleavedTables::create_random_singers_result(1)
+      singer = Singer.find 1
+
+      sql_album = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql_album, TestInterleavedTables::create_random_albums_result(1)
+      album = Album.find 1
+
+      album.update singer: singer, title: "New Title"
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :update, mutation.operation
+      assert_equal "albums", mutation.update.table
+
+      assert_equal 1, mutation.update.values.length
+
+      assert_equal 3, mutation.update.columns.length
+      assert_equal "albumid", mutation.update.columns[0]
+      assert_equal "singerid", mutation.update.columns[1]
+      assert_equal "title", mutation.update.columns[2]
+
+      assert_equal 3, mutation.update.values[0].length
+      assert_equal album.albumid, mutation.update.values[0][0].to_i
+      assert_equal singer.singerid, mutation.update.values[0][1].to_i
+      assert_equal "New Title", mutation.update.values[0][2]
+    end
+
+    def test_destroy_album
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1)
+      album = Album.find 1
+      album.destroy
+
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      refute_nil commit_request
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :delete, mutation.operation
+      assert_equal "albums", mutation.delete.table
+
+      assert_equal 1, mutation.delete.key_set.keys.length
+      # A delete mutation should use the entire primary key (i.e. singerid, albumid), and it **MUST** be in the correct
+      # primary key order, as the column names are not included in the mutation.
+      assert_equal 2, mutation.delete.key_set.keys[0].length
+      assert_equal album.singerid, mutation.delete.key_set.keys[0][0].to_i
+      assert_equal album.albumid, mutation.delete.key_set.keys[0][1].to_i
+    end
+  end
+end

--- a/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
@@ -11,6 +11,7 @@ require_relative "../mock_server/spanner_mock_server"
 require_relative "../test_helper"
 require_relative "models/singer"
 require_relative "models/album"
+require_relative "models/track"
 
 require "securerandom"
 
@@ -34,6 +35,9 @@ module TestInterleavedTables
       TestInterleavedTables::register_albums_columns_result @mock
       TestInterleavedTables::register_albums_primary_key_columns_result @mock
       TestInterleavedTables::register_albums_primary_and_parent_key_columns_result @mock
+      TestInterleavedTables::register_tracks_columns_result @mock
+      TestInterleavedTables::register_tracks_primary_key_columns_result @mock
+      TestInterleavedTables::register_tracks_primary_and_parent_key_columns_result @mock
       # Connect ActiveRecord to the mock server
       ActiveRecord::Base.establish_connection(
         adapter: "spanner",
@@ -145,6 +149,106 @@ module TestInterleavedTables
       assert_equal 2, mutation.delete.key_set.keys[0].length
       assert_equal album.singerid, mutation.delete.key_set.keys[0][0].to_i
       assert_equal album.albumid, mutation.delete.key_set.keys[0][1].to_i
+    end
+
+    def test_select_all_tracks
+      sql = "SELECT `tracks`.* FROM `tracks`"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_tracks_result(4)
+      Track.all.each do |track|
+        refute_nil track.trackid, "trackid should not be nil"
+        refute_nil track.albumid, "albumid should not be nil"
+        refute_nil track.singerid, "singerid should not be nil"
+      end
+    end
+
+    def test_find_track
+      # Selecting a single album should only use the trackid column, and not the singerid and albumid columns that are
+      # technically also part of the primary key.
+      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_tracks_result(1)
+      track = Track.find 1
+      refute_nil track.trackid, "trackid should not be nil"
+      refute_nil track.singerid, "singerid should not be nil"
+      refute_nil track.albumid, "albumid should not be nil"
+    end
+
+    def test_create_track
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @singerid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_singers_result(1, 1)
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1, 1, 1)
+      album = Album.find 1
+
+      track = Track.create album: album, title: "Random Title", duration: 5.5
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :insert, mutation.operation
+      assert_equal "tracks", mutation.insert.table
+
+      assert_equal 1, mutation.insert.values.length
+
+      # Note that trackid is added at the end as it is automatically calculated when the record is created.
+      assert_equal 5, mutation.insert.columns.length
+      assert_equal "singerid", mutation.insert.columns[0]
+      assert_equal "albumid", mutation.insert.columns[1]
+      assert_equal "title", mutation.insert.columns[2]
+      assert_equal "duration", mutation.insert.columns[3]
+      assert_equal "trackid", mutation.insert.columns[4]
+
+      assert_equal 5, mutation.insert.values[0].length
+      assert_equal track.singerid, mutation.insert.values[0][0].to_i
+      assert_equal track.albumid, mutation.insert.values[0][1].to_i
+      assert_equal "Random Title", mutation.insert.values[0][2]
+      assert_equal "5.5", mutation.insert.values[0][3]
+      assert_equal track.trackid, mutation.insert.values[0][4].to_i
+    end
+
+    def test_update_track
+      sql_track = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql_track, TestInterleavedTables::create_random_tracks_result(1, 1, 1, 1)
+      track = Track.find 1
+
+      track.update title: "New Title", duration: 3.14
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :update, mutation.operation
+      assert_equal "tracks", mutation.update.table
+
+      assert_equal 1, mutation.update.values.length
+
+      assert_equal 3, mutation.update.columns.length
+      assert_equal "trackid", mutation.update.columns[0]
+      assert_equal "title", mutation.update.columns[1]
+      assert_equal "duration", mutation.update.columns[2]
+
+      assert_equal 3, mutation.update.values[0].length
+      assert_equal track.trackid, mutation.update.values[0][0].to_i
+      assert_equal "New Title", mutation.update.values[0][1]
+      assert_equal "3.14", mutation.update.values[0][2]
+    end
+
+    def test_destroy_track
+      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, TestInterleavedTables::create_random_tracks_result(1, 1, 2, 3)
+      track = Track.find 1
+      track.destroy
+
+      commit_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.first
+      refute_nil commit_request
+      assert_equal 1, commit_request.mutations.length
+      mutation = commit_request.mutations[0]
+      assert_equal :delete, mutation.operation
+      assert_equal "tracks", mutation.delete.table
+
+      assert_equal 1, mutation.delete.key_set.keys.length
+      # A delete mutation should use the entire primary key (i.e. singerid, albumid, trackid), and it **MUST** be in the
+      # correct primary key order, as the column names are not included in the mutation.
+      assert_equal 3, mutation.delete.key_set.keys[0].length
+      assert_equal track.singerid, mutation.delete.key_set.keys[0][0].to_i
+      assert_equal track.albumid, mutation.delete.key_set.keys[0][1].to_i
+      assert_equal track.trackid, mutation.delete.key_set.keys[0][2].to_i
     end
   end
 end

--- a/test/activerecord_spanner_interleaved_table/model_helper.rb
+++ b/test/activerecord_spanner_interleaved_table/model_helper.rb
@@ -13,19 +13,16 @@ require_relative "models/album"
 
 require "securerandom"
 
-module MockServerTests
+module TestInterleavedTables
   def self.create_random_singers_result(row_count)
     first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy]
     last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson]
-    col_id = Google::Cloud::Spanner::V1::StructType::Field.new name: "id", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_singerid = Google::Cloud::Spanner::V1::StructType::Field.new name: "singerid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
     col_first_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "first_name", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
     col_last_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "last_name", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    col_last_performance = Google::Cloud::Spanner::V1::StructType::Field.new name: "last_performance", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
-    col_picture = Google::Cloud::Spanner::V1::StructType::Field.new name: "picture", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
-    col_revenues = Google::Cloud::Spanner::V1::StructType::Field.new name: "revenues", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::NUMERIC)
 
     metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push col_id, col_first_name, col_last_name, col_last_performance, col_picture, col_revenues
+    metadata.row_type.fields.push col_singerid, col_first_name, col_last_name
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
     (1..row_count).each { |_|
@@ -34,9 +31,6 @@ module MockServerTests
         Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
         Google::Protobuf::Value.new(string_value: first_names.sample),
         Google::Protobuf::Value.new(string_value: last_names.sample),
-        Google::Protobuf::Value.new(string_value: StatementResult.random_timestamp_string),
-        Google::Protobuf::Value.new(string_value: Base64.encode64(SecureRandom.alphanumeric(SecureRandom.random_number(10..200)))),
-        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000.0..1000000.0).to_s),
         )
       result_set.rows.push row
     }
@@ -48,20 +42,20 @@ module MockServerTests
     adjectives = ["daily", "happy", "blue", "generous", "cooked", "bad", "open"]
     nouns = ["windows", "potatoes", "bank", "street", "tree", "glass", "bottle"]
 
-    col_id = Google::Cloud::Spanner::V1::StructType::Field.new name: "id", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_albumid = Google::Cloud::Spanner::V1::StructType::Field.new name: "albumid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_singerid = Google::Cloud::Spanner::V1::StructType::Field.new name: "singerid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
     col_title = Google::Cloud::Spanner::V1::StructType::Field.new name: "title", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    col_singer_id = Google::Cloud::Spanner::V1::StructType::Field.new name: "singer_id", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
 
     metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push col_id, col_title, col_singer_id
+    metadata.row_type.fields.push col_albumid, col_singerid, col_title
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
     (1..row_count).each { |_|
       row = Google::Protobuf::ListValue.new
       row.values.push(
         Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
-        Google::Protobuf::Value.new(string_value: "#{adjectives.sample} #{nouns.sample}"),
-        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s)
+        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
+        Google::Protobuf::Value.new(string_value: "#{adjectives.sample} #{nouns.sample}")
       )
       result_set.rows.push row
     }
@@ -119,7 +113,7 @@ module MockServerTests
 
     row = Google::Protobuf::ListValue.new
     row.values.push(
-      Google::Protobuf::Value.new(string_value: "id"),
+      Google::Protobuf::Value.new(string_value: "singerid"),
       Google::Protobuf::Value.new(string_value: "INT64"),
       Google::Protobuf::Value.new(string_value: "NO"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
@@ -144,45 +138,40 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "3")
     )
     result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "last_performance"),
-      Google::Protobuf::Value.new(string_value: "TIMESTAMP"),
-      Google::Protobuf::Value.new(string_value: "YES"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "4")
-    )
-    result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "picture"),
-      Google::Protobuf::Value.new(string_value: "BYTES(MAX)"),
-      Google::Protobuf::Value.new(string_value: "YES"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "5")
-    )
-    result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "revenues"),
-      Google::Protobuf::Value.new(string_value: "NUMERIC"),
-      Google::Protobuf::Value.new(string_value: "YES"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "6")
-    )
-    result_set.rows.push row
 
     spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)
   end
 
   def self.register_singers_primary_key_columns_result spanner_mock_server
     sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND (T.PARENT_TABLE_NAME IS NULL OR COLUMN_NAME NOT IN (   SELECT COLUMN_NAME   FROM TABLE_PK_COLS   WHERE TABLE_NAME = T.PARENT_TABLE_NAME )) ORDER BY ORDINAL_POSITION"
-    register_key_columns_result spanner_mock_server, sql
+    register_singers_key_columns_result spanner_mock_server, sql
   end
 
   def self.register_singers_primary_and_parent_key_columns_result spanner_mock_server
-    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION"
-    register_key_columns_result spanner_mock_server, sql
+    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION"
+    register_singers_key_columns_result spanner_mock_server, sql
+  end
+
+  def self.register_singers_key_columns_result spanner_mock_server, sql
+    index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    column_ordering = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_ORDERING", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+    metadata.row_type.fields.push index_name, column_name, column_ordering, ordinal_position
+    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+      Google::Protobuf::Value.new(string_value: "singerid"),
+      Google::Protobuf::Value.new(string_value: "ASC"),
+      Google::Protobuf::Value.new(string_value: "1"),
+      )
+    result_set.rows.push row
+
+    spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)
   end
 
   def self.register_albums_columns_result spanner_mock_server
@@ -200,7 +189,7 @@ module MockServerTests
 
     row = Google::Protobuf::ListValue.new
     row.values.push(
-      Google::Protobuf::Value.new(string_value: "id"),
+      Google::Protobuf::Value.new(string_value: "albumid"),
       Google::Protobuf::Value.new(string_value: "INT64"),
       Google::Protobuf::Value.new(string_value: "NO"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
@@ -209,8 +198,8 @@ module MockServerTests
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
     row.values.push(
-      Google::Protobuf::Value.new(string_value: "title"),
-      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Google::Protobuf::Value.new(string_value: "singerid"),
+      Google::Protobuf::Value.new(string_value: "INT64"),
       Google::Protobuf::Value.new(string_value: "NO"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
       Google::Protobuf::Value.new(string_value: "2")
@@ -218,8 +207,8 @@ module MockServerTests
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
     row.values.push(
-      Google::Protobuf::Value.new(string_value: "singer_id"),
-      Google::Protobuf::Value.new(string_value: "INT64"),
+      Google::Protobuf::Value.new(string_value: "title"),
+      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
       Google::Protobuf::Value.new(string_value: "NO"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
       Google::Protobuf::Value.new(string_value: "3")
@@ -231,17 +220,15 @@ module MockServerTests
 
   def self.register_albums_primary_key_columns_result spanner_mock_server
     sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND (T.PARENT_TABLE_NAME IS NULL OR COLUMN_NAME NOT IN (   SELECT COLUMN_NAME   FROM TABLE_PK_COLS   WHERE TABLE_NAME = T.PARENT_TABLE_NAME )) ORDER BY ORDINAL_POSITION"
-    register_key_columns_result spanner_mock_server, sql
+    register_albums_key_columns_result spanner_mock_server, sql, false
   end
 
   def self.register_albums_primary_and_parent_key_columns_result spanner_mock_server
-    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION"
-    register_key_columns_result spanner_mock_server, sql
+    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION"
+    register_albums_key_columns_result spanner_mock_server, sql, true
   end
 
-  private
-
-  def self.register_key_columns_result spanner_mock_server, sql
+  def self.register_albums_key_columns_result spanner_mock_server, sql, include_parent_key
     index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
     column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
     column_ordering = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_ORDERING", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -251,13 +238,23 @@ module MockServerTests
     metadata.row_type.fields.push index_name, column_name, column_ordering, ordinal_position
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
+    if include_parent_key
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+        Google::Protobuf::Value.new(string_value: "singerid"),
+        Google::Protobuf::Value.new(string_value: "ASC"),
+        Google::Protobuf::Value.new(string_value: "1"),
+      )
+      result_set.rows.push row
+    end
     row = Google::Protobuf::ListValue.new
     row.values.push(
       Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
-      Google::Protobuf::Value.new(string_value: "id"),
+      Google::Protobuf::Value.new(string_value: "albumid"),
       Google::Protobuf::Value.new(string_value: "ASC"),
-      Google::Protobuf::Value.new(string_value: "1"),
-      )
+      Google::Protobuf::Value.new(string_value: "2"),
+    )
     result_set.rows.push row
 
     spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)

--- a/test/activerecord_spanner_interleaved_table/model_helper.rb
+++ b/test/activerecord_spanner_interleaved_table/model_helper.rb
@@ -14,7 +14,7 @@ require_relative "models/album"
 require "securerandom"
 
 module TestInterleavedTables
-  def self.create_random_singers_result(row_count)
+  def self.create_random_singers_result(row_count, start_id = nil)
     first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy]
     last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson]
     col_singerid = Google::Cloud::Spanner::V1::StructType::Field.new name: "singerid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
@@ -25,10 +25,10 @@ module TestInterleavedTables
     metadata.row_type.fields.push col_singerid, col_first_name, col_last_name
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
-    (1..row_count).each { |_|
+    (0...row_count).each { |c|
       row = Google::Protobuf::ListValue.new
       row.values.push(
-        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
+        Google::Protobuf::Value.new(string_value: (start_id ? start_id + c : SecureRandom.random_number(1000000)).to_s),
         Google::Protobuf::Value.new(string_value: first_names.sample),
         Google::Protobuf::Value.new(string_value: last_names.sample),
         )
@@ -38,7 +38,7 @@ module TestInterleavedTables
     StatementResult.new result_set
   end
 
-  def self.create_random_albums_result(row_count)
+  def self.create_random_albums_result(row_count, start_id = nil, singer_id = nil)
     adjectives = ["daily", "happy", "blue", "generous", "cooked", "bad", "open"]
     nouns = ["windows", "potatoes", "bank", "street", "tree", "glass", "bottle"]
 
@@ -50,12 +50,41 @@ module TestInterleavedTables
     metadata.row_type.fields.push col_albumid, col_singerid, col_title
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
-    (1..row_count).each { |_|
+    (0...row_count).each { |c|
       row = Google::Protobuf::ListValue.new
       row.values.push(
-        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
-        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s),
+        Google::Protobuf::Value.new(string_value: (start_id ? start_id + c : SecureRandom.random_number(1000000)).to_s),
+        Google::Protobuf::Value.new(string_value: (singer_id ? singer_id : SecureRandom.random_number(1000000)).to_s),
         Google::Protobuf::Value.new(string_value: "#{adjectives.sample} #{nouns.sample}")
+      )
+      result_set.rows.push row
+    }
+
+    StatementResult.new result_set
+  end
+
+  def self.create_random_tracks_result(row_count, start_id = nil, singer_id = nil, album_id = nil)
+    adjectives = ["prominent", "unaware", "alternative", "eventual", "single", "unfamiliar", "criminal"]
+    nouns = ["fold", "cleaner", "mass", "maintenance", "commentary", "classic", "assistant"]
+
+    col_trackid = Google::Cloud::Spanner::V1::StructType::Field.new name: "trackid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_singerid = Google::Cloud::Spanner::V1::StructType::Field.new name: "singerid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_albumid = Google::Cloud::Spanner::V1::StructType::Field.new name: "albumid", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+    col_title = Google::Cloud::Spanner::V1::StructType::Field.new name: "title", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    col_duration = Google::Cloud::Spanner::V1::StructType::Field.new name: "duration", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::NUMERIC)
+
+    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+    metadata.row_type.fields.push col_trackid, col_singerid, col_albumid, col_title, col_duration
+    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+    (0...row_count).each { |c|
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: (start_id ? start_id + c : SecureRandom.random_number(1000000)).to_s),
+        Google::Protobuf::Value.new(string_value: (singer_id ? singer_id : SecureRandom.random_number(1000000)).to_s),
+        Google::Protobuf::Value.new(string_value: (album_id ? album_id : SecureRandom.random_number(1000000)).to_s),
+        Google::Protobuf::Value.new(string_value: "#{adjectives.sample} #{nouns.sample}"),
+        Google::Protobuf::Value.new(string_value: SecureRandom.random_number(1000000).to_s)
       )
       result_set.rows.push row
     }
@@ -90,9 +119,18 @@ module TestInterleavedTables
       Google::Protobuf::Value.new(string_value: ""),
       Google::Protobuf::Value.new(string_value: ""),
       Google::Protobuf::Value.new(string_value: "albums"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "singers"),
+      Google::Protobuf::Value.new(string_value: "NO ACTION"),
     )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: ""),
+      Google::Protobuf::Value.new(string_value: ""),
+      Google::Protobuf::Value.new(string_value: "tracks"),
+      Google::Protobuf::Value.new(string_value: "albums"),
+      Google::Protobuf::Value.new(string_value: "CASCADE"),
+      )
     result_set.rows.push row
 
     spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)
@@ -255,6 +293,118 @@ module TestInterleavedTables
       Google::Protobuf::Value.new(string_value: "ASC"),
       Google::Protobuf::Value.new(string_value: "2"),
     )
+    result_set.rows.push row
+
+    spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def self.register_tracks_columns_result spanner_mock_server
+    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='tracks' ORDER BY ORDINAL_POSITION ASC"
+
+    column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
+    ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "trackid"),
+      Google::Protobuf::Value.new(string_value: "INT64"),
+      Google::Protobuf::Value.new(string_value: "NO"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "1")
+    )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "singerid"),
+      Google::Protobuf::Value.new(string_value: "INT64"),
+      Google::Protobuf::Value.new(string_value: "NO"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "2")
+    )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "albumid"),
+      Google::Protobuf::Value.new(string_value: "INT64"),
+      Google::Protobuf::Value.new(string_value: "NO"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "3")
+    )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "title"),
+      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
+      Google::Protobuf::Value.new(string_value: "NO"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "4")
+    )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "duration"),
+      Google::Protobuf::Value.new(string_value: "NUMERIC"),
+      Google::Protobuf::Value.new(string_value: "YES"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "5")
+    )
+    result_set.rows.push row
+
+    spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)
+  end
+
+  def self.register_tracks_primary_key_columns_result spanner_mock_server
+    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'tracks' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND (T.PARENT_TABLE_NAME IS NULL OR COLUMN_NAME NOT IN (   SELECT COLUMN_NAME   FROM TABLE_PK_COLS   WHERE TABLE_NAME = T.PARENT_TABLE_NAME )) ORDER BY ORDINAL_POSITION"
+    register_tracks_key_columns_result spanner_mock_server, sql, false
+  end
+
+  def self.register_tracks_primary_and_parent_key_columns_result spanner_mock_server
+    sql = "WITH TABLE_PK_COLS AS ( SELECT C.TABLE_NAME, C.COLUMN_NAME, C.INDEX_NAME, C.COLUMN_ORDERING, C.ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS C WHERE C.INDEX_TYPE = 'PRIMARY_KEY' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '') SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM TABLE_PK_COLS INNER JOIN INFORMATION_SCHEMA.TABLES T USING (TABLE_NAME) WHERE TABLE_NAME = 'tracks' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION"
+    register_tracks_key_columns_result spanner_mock_server, sql, true
+  end
+
+  def self.register_tracks_key_columns_result spanner_mock_server, sql, include_parent_key
+    index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    column_ordering = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_ORDERING", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+    ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+    metadata.row_type.fields.push index_name, column_name, column_ordering, ordinal_position
+    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+    if include_parent_key
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+        Google::Protobuf::Value.new(string_value: "singerid"),
+        Google::Protobuf::Value.new(string_value: "ASC"),
+        Google::Protobuf::Value.new(string_value: "1"),
+        )
+      result_set.rows.push row
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+        Google::Protobuf::Value.new(string_value: "albumid"),
+        Google::Protobuf::Value.new(string_value: "ASC"),
+        Google::Protobuf::Value.new(string_value: "2"),
+        )
+      result_set.rows.push row
+    end
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "PRIMARY_KEY"),
+      Google::Protobuf::Value.new(string_value: "trackid"),
+      Google::Protobuf::Value.new(string_value: "ASC"),
+      Google::Protobuf::Value.new(string_value: "3"),
+      )
     result_set.rows.push row
 
     spanner_mock_server.put_statement_result sql, StatementResult.new(result_set)

--- a/test/activerecord_spanner_interleaved_table/models/album.rb
+++ b/test/activerecord_spanner_interleaved_table/models/album.rb
@@ -6,5 +6,4 @@
 
 class Album < ActiveRecord::Base
   belongs_to :singer
-  has_many :tracks
 end

--- a/test/activerecord_spanner_interleaved_table/models/album.rb
+++ b/test/activerecord_spanner_interleaved_table/models/album.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
+module TestInterleavedTables
+  class Album < ActiveRecord::Base
+    belongs_to :singer, foreign_key: "singerid"
+  end
 end

--- a/test/activerecord_spanner_interleaved_table/models/singer.rb
+++ b/test/activerecord_spanner_interleaved_table/models/singer.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Singer < ActiveRecord::Base
-  has_many :albums
+module TestInterleavedTables
+  class Singer < ActiveRecord::Base
+    has_many :albums, foreign_key: "singerid"
+  end
 end

--- a/test/activerecord_spanner_interleaved_table/models/singer.rb
+++ b/test/activerecord_spanner_interleaved_table/models/singer.rb
@@ -4,7 +4,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
-  has_many :tracks
+class Singer < ActiveRecord::Base
+  has_many :albums
 end

--- a/test/activerecord_spanner_interleaved_table/models/track.rb
+++ b/test/activerecord_spanner_interleaved_table/models/track.rb
@@ -1,0 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+module TestInterleavedTables
+  class Track < ActiveRecord::Base
+    # Note that the actual primary key of album consists of both (singerid, albumid) columns.
+    belongs_to :album, foreign_key: "albumid"
+    belongs_to :singer, foreign_key: "singerid"
+
+    def album=value
+      self.singer = value.singer
+      super
+    end
+  end
+end

--- a/test/activerecord_spanner_mock_server/aborted_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/aborted_transaction_test.rb
@@ -8,120 +8,122 @@
 
 require_relative "./base_spanner_mock_server_test"
 
-class AbortedTransactionTest < BaseSpannerMockServerTest
-  def test_read_write_transaction_without_abort_does_not_retry
-    register_insert_singer_result
+module MockServerTests
+  class AbortedTransactionTest < BaseSpannerMockServerTest
+    def test_read_write_transaction_without_abort_does_not_retry
+      register_insert_singer_result
 
-    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      # There should only be one transaction.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+    end
+
+    def test_read_write_transaction_aborted_dml_is_automatically_retried
+      insert_sql = register_insert_singer_result
+
+      already_aborted = false
+      ActiveRecord::Base.transaction do
+        already_aborted = abort_current_transaction unless already_aborted
+        # The following statement will fail with an Aborted error. That will cause the entire
+        # transaction block to be retried.
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      # There should be two transaction attempts, two ExecuteSqlRequests and only one commit.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 2, sql_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
+    end
+
+    def test_read_write_transaction_aborted_query_is_automatically_retried
+      select_sql = register_singer_find_by_id_result
+
+      already_aborted = false
+      ActiveRecord::Base.transaction do
+        already_aborted = abort_current_transaction unless already_aborted
+        Singer.find_by id: 1
+      end
+
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
+      assert_equal 2, sql_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
+    end
+
+    def test_read_write_transaction_aborted_commit_is_automatically_retried
+      select_sql = register_singer_find_by_id_result
+
+      already_aborted = false
+      ActiveRecord::Base.transaction do
+        Singer.find_by id: 1
+        already_aborted = abort_current_transaction unless already_aborted
+      end
+
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
+      assert_equal 2, sql_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 2, commit_requests.length
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
+    end
+
+    def test_implicit_transaction_aborted_single_insert_is_automatically_retried
+      # This will abort the next transaction that is started on the mock server.
+      @mock.abort_next_transaction
+      # The following statement will automatically start a transaction, although it is not in a transaction block.
+      # The transaction is automatically retried if the transaction is aborted.
       Singer.create(first_name: "Dave", last_name: "Allison")
+
+      # There should be two transaction attempts.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_transaction_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 2, commit_requests.length
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
     end
 
-    # There should only be one transaction.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 1, begin_transaction_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-  end
+    def test_implicit_transaction_aborted_batch_insert_is_automatically_retried
+      @mock.abort_next_transaction
+      Singer.create([{first_name: "Dave", last_name: "Allison"}, {first_name: "Alice", last_name: "Becker"}])
 
-  def test_read_write_transaction_aborted_dml_is_automatically_retried
-    insert_sql = register_insert_singer_result
-
-    already_aborted = false
-    ActiveRecord::Base.transaction do
-      already_aborted = abort_current_transaction unless already_aborted
-      # The following statement will fail with an Aborted error. That will cause the entire
-      # transaction block to be retried.
-      Singer.create(first_name: "Dave", last_name: "Allison")
+      # The batch will be inserted as one transaction containing two mutations. The first attempt will abort, and
+      # the second will succeed.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_transaction_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 2, commit_requests.length
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
     end
 
-    # There should be two transaction attempts, two ExecuteSqlRequests and only one commit.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_transaction_requests.length
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
-    assert_equal 2, sql_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def test_read_write_transaction_aborted_query_is_automatically_retried
-    select_sql = register_singer_find_by_id_result
-
-    already_aborted = false
-    ActiveRecord::Base.transaction do
-      already_aborted = abort_current_transaction unless already_aborted
-      Singer.find_by id: 1
+    def register_insert_singer_result
+      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
+      @mock.put_statement_result sql, StatementResult.new(1)
+      sql
     end
 
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_transaction_requests.length
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
-    assert_equal 2, sql_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def test_read_write_transaction_aborted_commit_is_automatically_retried
-    select_sql = register_singer_find_by_id_result
-
-    already_aborted = false
-    ActiveRecord::Base.transaction do
-      Singer.find_by id: 1
-      already_aborted = abort_current_transaction unless already_aborted
+    def register_singer_find_by_id_result
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      sql
     end
-
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_transaction_requests.length
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
-    assert_equal 2, sql_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 2, commit_requests.length
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def test_implicit_transaction_aborted_single_insert_is_automatically_retried
-    # This will abort the next transaction that is started on the mock server.
-    @mock.abort_next_transaction
-    # The following statement will automatically start a transaction, although it is not in a transaction block.
-    # The transaction is automatically retried if the transaction is aborted.
-    Singer.create(first_name: "Dave", last_name: "Allison")
-
-    # There should be two transaction attempts.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_transaction_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 2, commit_requests.length
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def test_implicit_transaction_aborted_batch_insert_is_automatically_retried
-    @mock.abort_next_transaction
-    Singer.create([{first_name: "Dave", last_name: "Allison"}, {first_name: "Alice", last_name: "Becker"}])
-
-    # The batch will be inserted as one transaction containing two mutations. The first attempt will abort, and
-    # the second will succeed.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_transaction_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 2, commit_requests.length
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def register_insert_singer_result
-    sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
-    @mock.put_statement_result sql, StatementResult.new(1)
-    sql
-  end
-
-  def register_singer_find_by_id_result
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    sql
   end
 end

--- a/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
@@ -14,51 +14,53 @@ require_relative "models/album"
 
 require "securerandom"
 
-class BaseSpannerMockServerTest < Minitest::Test
-  def setup
-    super
-    @server = GRPC::RpcServer.new
-    @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
-    @mock = SpannerMockServer.new
-    @server.handle @mock
-    # Run the server in a separate thread
-    @server_thread = Thread.new do
-      @server.run
+module MockServerTests
+  class BaseSpannerMockServerTest < Minitest::Test
+    def setup
+      super
+      @server = GRPC::RpcServer.new
+      @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+      @mock = SpannerMockServer.new
+      @server.handle @mock
+      # Run the server in a separate thread
+      @server_thread = Thread.new do
+        @server.run
+      end
+      @server.wait_till_running
+      # Register INFORMATION_SCHEMA queries on the mock server.
+      MockServerTests::register_select_tables_result @mock
+      MockServerTests::register_singers_columns_result @mock
+      MockServerTests::register_singers_primary_key_columns_result @mock
+      MockServerTests::register_singers_primary_and_parent_key_columns_result @mock
+      MockServerTests::register_albums_columns_result @mock
+      MockServerTests::register_albums_primary_key_columns_result @mock
+      MockServerTests::register_albums_primary_and_parent_key_columns_result @mock
+      # Connect ActiveRecord to the mock server
+      ActiveRecord::Base.establish_connection(
+        adapter: "spanner",
+        emulator_host: "localhost:#{@port}",
+        project: "test-project",
+        instance: "test-instance",
+        database: "testdb",
+      )
+      ActiveRecord::Base.logger = nil
     end
-    @server.wait_till_running
-    # Register INFORMATION_SCHEMA queries on the mock server.
-    register_select_tables_result @mock
-    register_singers_columns_result @mock
-    register_singers_primary_key_result @mock
-    register_singer_index_columns_result @mock
-    register_albums_columns_result @mock
-    register_albums_primary_key_result @mock
-    register_albums_index_columns_result @mock
-    # Connect ActiveRecord to the mock server
-    ActiveRecord::Base.establish_connection(
-      adapter: "spanner",
-      emulator_host: "localhost:#{@port}",
-      project: "test-project",
-      instance: "test-instance",
-      database: "testdb",
-    )
-    ActiveRecord::Base.logger = nil
-  end
 
-  def teardown
-    super
-    ActiveRecord::Base.connection_pool.disconnect!
-    @server.stop
-    @server_thread.exit
-  end
+    def teardown
+      ActiveRecord::Base.connection_pool.disconnect!
+      @server.stop
+      @server_thread.exit
+      super
+    end
 
-  def abort_current_transaction
-    connection = ActiveRecord::Base.connection.instance_variable_get(:@connection)
-    current_transaction = connection.instance_variable_get(:@current_transaction)
-    transaction = current_transaction.instance_variable_get(:@grpc_transaction).instance_variable_get(:@grpc)
-    session = connection.session.instance_variable_get(:@grpc)
-    @mock.abort_transaction session["name"], transaction["id"]
-    true
-  end
+    def abort_current_transaction
+      connection = ActiveRecord::Base.connection.instance_variable_get(:@connection)
+      current_transaction = connection.instance_variable_get(:@current_transaction)
+      transaction = current_transaction.instance_variable_get(:@grpc_transaction).instance_variable_get(:@grpc)
+      session = connection.session.instance_variable_get(:@grpc)
+      @mock.abort_transaction session["name"], transaction["id"]
+      true
+    end
 
+  end
 end

--- a/test/activerecord_spanner_mock_server/models/album.rb
+++ b/test/activerecord_spanner_mock_server/models/album.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
+module MockServerTests
+  class Album < ActiveRecord::Base
+    belongs_to :singer
+  end
 end

--- a/test/activerecord_spanner_mock_server/models/singer.rb
+++ b/test/activerecord_spanner_mock_server/models/singer.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Singer < ActiveRecord::Base
-  has_many :albums
+module MockServerTests
+  class Singer < ActiveRecord::Base
+    has_many :albums
+  end
 end

--- a/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
@@ -8,83 +8,85 @@
 
 require_relative "./base_spanner_mock_server_test"
 
-class ReadOnlyTransactionTest < BaseSpannerMockServerTest
-  def test_creates_and_uses_snapshot
-    sql = register_singer_find_by_id_result
+module MockServerTests
+  class ReadOnlyTransactionTest < BaseSpannerMockServerTest
+    def test_creates_and_uses_snapshot
+      sql = register_singer_find_by_id_result
 
-    ActiveRecord::Base.transaction isolation: :read_only do
-      Singer.find_by(id: 1)
-      Singer.find_by(id: 2)
+      ActiveRecord::Base.transaction isolation: :read_only do
+        Singer.find_by(id: 1)
+        Singer.find_by(id: 2)
+      end
+
+      # There should only be one read-only transaction.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      assert begin_transaction_requests[0].options.read_only
+      assert begin_transaction_requests[0].options.read_only.return_read_timestamp
+
+      execute_sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      id = execute_sql_requests.first.transaction.id
+      execute_sql_requests.each do |req|
+        assert_equal id, req.transaction.id
+        assert_equal 0, req.seqno
+      end
+      assert_equal 2, execute_sql_requests.length
+
+      # Even though `commit` is called on the ActiveRecord transaction, that commit should not be propagated
+      # to the backend, as read-only transactions cannot be committed.
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_empty commit_requests
     end
 
-    # There should only be one read-only transaction.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 1, begin_transaction_requests.length
-    assert begin_transaction_requests[0].options.read_only
-    assert begin_transaction_requests[0].options.read_only.return_read_timestamp
+    def test_rollback_snapshot
+      ActiveRecord::Base.transaction isolation: :read_only do
+        raise ActiveRecord::Rollback
+      end
 
-    execute_sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
-    id = execute_sql_requests.first.transaction.id
-    execute_sql_requests.each do |req|
-      assert_equal id, req.transaction.id
-      assert_equal 0, req.seqno
-    end
-    assert_equal 2, execute_sql_requests.length
+      # There should only be one read-only transaction.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      assert begin_transaction_requests[0].options.read_only
 
-    # Even though `commit` is called on the ActiveRecord transaction, that commit should not be propagated
-    # to the backend, as read-only transactions cannot be committed.
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_empty commit_requests
-  end
-
-  def test_rollback_snapshot
-    ActiveRecord::Base.transaction isolation: :read_only do
-      raise ActiveRecord::Rollback
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_empty commit_requests
+      # The rollback should not be sent to the backend, as read-only transactions cannot be rolled back.
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
     end
 
-    # There should only be one read-only transaction.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 1, begin_transaction_requests.length
-    assert begin_transaction_requests[0].options.read_only
+    def test_multiple_snapshots
+      register_singer_find_by_id_result
 
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_empty commit_requests
-    # The rollback should not be sent to the backend, as read-only transactions cannot be rolled back.
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
+      ActiveRecord::Base.transaction isolation: :read_only do
+        Singer.find_by id: 1
+      end
+      ActiveRecord::Base.transaction isolation: :read_only do
+        Singer.find_by id: 1
+      end
+      ActiveRecord::Base.transaction isolation: :read_only do
+        raise ActiveRecord::Rollback
+      end
+      ActiveRecord::Base.transaction isolation: :read_only do
+        raise ActiveRecord::Rollback
+      end
+      ActiveRecord::Base.transaction isolation: :read_only do
+        Singer.find_by id: 1
+      end
 
-  def test_multiple_snapshots
-    register_singer_find_by_id_result
-
-    ActiveRecord::Base.transaction isolation: :read_only do
-      Singer.find_by id: 1
-    end
-    ActiveRecord::Base.transaction isolation: :read_only do
-      Singer.find_by id: 1
-    end
-    ActiveRecord::Base.transaction isolation: :read_only do
-      raise ActiveRecord::Rollback
-    end
-    ActiveRecord::Base.transaction isolation: :read_only do
-      raise ActiveRecord::Rollback
-    end
-    ActiveRecord::Base.transaction isolation: :read_only do
-      Singer.find_by id: 1
+      begin_transaction_requests = @mock.requests.select { |req|
+        req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && req.options.read_only }
+      assert_equal 5, begin_transaction_requests.length
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_empty commit_requests
+      rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
+      assert_empty rollback_requests
     end
 
-    begin_transaction_requests = @mock.requests.select { |req|
-      req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && req.options.read_only }
-    assert_equal 5, begin_transaction_requests.length
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_empty commit_requests
-    rollback_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::RollbackRequest }
-    assert_empty rollback_requests
-  end
-
-  def register_singer_find_by_id_result
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    sql
+    def register_singer_find_by_id_result
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      sql
+    end
   end
 end

--- a/test/activerecord_spanner_mock_server/session_not_found_test.rb
+++ b/test/activerecord_spanner_mock_server/session_not_found_test.rb
@@ -8,135 +8,137 @@
 
 require_relative "./base_spanner_mock_server_test"
 
-class SessionNotFoundTest < BaseSpannerMockServerTest
+module MockServerTests
+  class SessionNotFoundTest < BaseSpannerMockServerTest
 
-  def create_connection_with_invalidated_session
-    # Create a connection and a session, and then delete the session.
-    ActiveRecord::Base.transaction do
-    end
-    @mock.delete_all_sessions
-    @mock.requests.clear
-  end
-
-  def test_session_not_found_single_read
-    create_connection_with_invalidated_session
-    select_sql = register_singer_find_by_id_result
-
-    Singer.find_by id: 1
-
-    # The request should be executed twice on two different sessions, both times without a transaction selector.
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
-    assert_equal 2, sql_requests.length
-    refute_equal sql_requests[0].session, sql_requests[1].session
-    refute sql_requests[0].transaction
-    refute sql_requests[1].transaction
-  end
-
-  def test_session_not_found_implicit_transaction_single_insert
-    create_connection_with_invalidated_session
-    Singer.create(first_name: "Dave", last_name: "Allison")
-
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[0].session
-  end
-
-  def test_session_not_found_implicit_transaction_batch_insert
-    create_connection_with_invalidated_session
-    Singer.create([{first_name: "Dave", last_name: "Allison"}, {first_name: "Alice", last_name: "Becker"}])
-
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[0].session
-  end
-
-  def test_session_not_found_on_begin_transaction
-    create_connection_with_invalidated_session
-    Singer.create(first_name: "Dave", last_name: "Allison")
-
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[0].session
-  end
-
-  def test_session_not_found_on_dml_in_transaction
-    insert_sql = register_insert_singer_result
-
-    deleted = nil
-    Singer.transaction do
-      deleted = @mock.delete_all_sessions unless deleted
-      Singer.create(first_name: "Dave", last_name: "Allison")
+    def create_connection_with_invalidated_session
+      # Create a connection and a session, and then delete the session.
+      ActiveRecord::Base.transaction do
+      end
+      @mock.delete_all_sessions
+      @mock.requests.clear
     end
 
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
-    assert_equal 2, sql_requests.length
-    refute_equal sql_requests[0].session, sql_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[0].session
-  end
+    def test_session_not_found_single_read
+      create_connection_with_invalidated_session
+      select_sql = register_singer_find_by_id_result
 
-  def test_session_not_found_on_select_in_transaction
-    select_sql = register_singer_find_by_id_result
-
-    deleted = nil
-    Singer.transaction do
-      deleted = @mock.delete_all_sessions unless deleted
       Singer.find_by id: 1
+
+      # The request should be executed twice on two different sessions, both times without a transaction selector.
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
+      assert_equal 2, sql_requests.length
+      refute_equal sql_requests[0].session, sql_requests[1].session
+      refute sql_requests[0].transaction
+      refute sql_requests[1].transaction
     end
 
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
-    assert_equal 2, sql_requests.length
-    refute_equal sql_requests[0].session, sql_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 1, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[0].session
-  end
-
-  def test_session_not_found_on_commit
-    insert_sql = register_insert_singer_result
-
-    deleted = nil
-    Singer.transaction do
+    def test_session_not_found_implicit_transaction_single_insert
+      create_connection_with_invalidated_session
       Singer.create(first_name: "Dave", last_name: "Allison")
-      deleted = @mock.delete_all_sessions unless deleted
+
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[0].session
     end
 
-    begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 2, begin_requests.length
-    refute_equal begin_requests[0].session, begin_requests[1].session
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
-    assert_equal 2, sql_requests.length
-    refute_equal sql_requests[0].session, sql_requests[1].session
-    commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
-    assert_equal 2, commit_requests.length
-    assert_equal begin_requests[1].session, commit_requests[1].session
-  end
+    def test_session_not_found_implicit_transaction_batch_insert
+      create_connection_with_invalidated_session
+      Singer.create([{first_name: "Dave", last_name: "Allison"}, {first_name: "Alice", last_name: "Becker"}])
 
-  def register_insert_singer_result
-    sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
-    @mock.put_statement_result sql, StatementResult.new(1)
-    sql
-  end
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[0].session
+    end
 
-  def register_singer_find_by_id_result
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    sql
+    def test_session_not_found_on_begin_transaction
+      create_connection_with_invalidated_session
+      Singer.create(first_name: "Dave", last_name: "Allison")
+
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[0].session
+    end
+
+    def test_session_not_found_on_dml_in_transaction
+      insert_sql = register_insert_singer_result
+
+      deleted = nil
+      Singer.transaction do
+        deleted = @mock.delete_all_sessions unless deleted
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 2, sql_requests.length
+      refute_equal sql_requests[0].session, sql_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[0].session
+    end
+
+    def test_session_not_found_on_select_in_transaction
+      select_sql = register_singer_find_by_id_result
+
+      deleted = nil
+      Singer.transaction do
+        deleted = @mock.delete_all_sessions unless deleted
+        Singer.find_by id: 1
+      end
+
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
+      assert_equal 2, sql_requests.length
+      refute_equal sql_requests[0].session, sql_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[0].session
+    end
+
+    def test_session_not_found_on_commit
+      insert_sql = register_insert_singer_result
+
+      deleted = nil
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison")
+        deleted = @mock.delete_all_sessions unless deleted
+      end
+
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 2, begin_requests.length
+      refute_equal begin_requests[0].session, begin_requests[1].session
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 2, sql_requests.length
+      refute_equal sql_requests[0].session, sql_requests[1].session
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 2, commit_requests.length
+      assert_equal begin_requests[1].session, commit_requests[1].session
+    end
+
+    def register_insert_singer_result
+      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
+      @mock.put_statement_result sql, StatementResult.new(1)
+      sql
+    end
+
+    def register_singer_find_by_id_result
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      sql
+    end
   end
 end

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -8,387 +8,389 @@
 
 require_relative "./base_spanner_mock_server_test"
 
-class SpannerActiveRecordMockServerTest < BaseSpannerMockServerTest
+module MockServerTests
+  class SpannerActiveRecordMockServerTest < BaseSpannerMockServerTest
 
-  def test_selects_all_singers_without_transaction
-    sql = "SELECT `singers`.* FROM `singers`"
-    @mock.put_statement_result sql, create_random_singers_result(4)
-    Singer.all.each do |singer|
-      refute_nil singer.id, "singer.id should not be nil"
-      refute_nil singer.first_name, "singer.first_name should not be nil"
-      refute_nil singer.last_name, "singer.last_name should not be nil"
+    def test_selects_all_singers_without_transaction
+      sql = "SELECT `singers`.* FROM `singers`"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(4)
+      Singer.all.each do |singer|
+        refute_nil singer.id, "singer.id should not be nil"
+        refute_nil singer.first_name, "singer.first_name should not be nil"
+        refute_nil singer.last_name, "singer.last_name should not be nil"
+      end
+      # None of the requests should use a (read-only) transaction.
+      select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
+      select_requests.each do |request|
+        assert_nil request.transaction
+      end
+      # Executing a simple query should not initiate any transactions.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_empty begin_transaction_requests
     end
-    # None of the requests should use a (read-only) transaction.
-    select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
-    select_requests.each do |request|
-      assert_nil request.transaction
+
+    def test_selects_one_singer_without_transaction
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      singer = Singer.find_by id: 1
+
+      refute_nil singer
+      refute_nil singer.first_name
+      refute_nil singer.last_name
+      # None of the requests should use a (read-only) transaction.
+      select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
+      select_requests.each do |request|
+        assert_nil request.transaction
+      end
+      # Executing a simple query should not initiate any transactions.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_empty begin_transaction_requests
+
+      # Check the encoded parameters.
+      select_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      select_requests.each do |request|
+        assert_equal "1", request.params["LIMIT_2"]
+        assert_equal "1", request.params["id_1"]
+        assert_equal :INT64, request.param_types["LIMIT_2"].code
+        assert_equal :INT64, request.param_types["id_1"].code
+      end
     end
-    # Executing a simple query should not initiate any transactions.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_empty begin_transaction_requests
-  end
 
-  def test_selects_one_singer_without_transaction
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    singer = Singer.find_by id: 1
-
-    refute_nil singer
-    refute_nil singer.first_name
-    refute_nil singer.last_name
-    # None of the requests should use a (read-only) transaction.
-    select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
-    select_requests.each do |request|
-      assert_nil request.transaction
+    def test_selects_singers_with_condition
+      # This query does not use query parameters because the where clause is specified as a string.
+      # ActiveRecord sees that as a SQL fragment that will disable the usage of prepared statements.
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`last_name` LIKE 'A%'"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(2)
+      Singer.where(Singer.arel_table[:last_name].matches("A%")).each do |singer|
+        refute_nil singer.id, "singer.id should not be nil"
+        refute_nil singer.first_name, "singer.first_name should not be nil"
+        refute_nil singer.last_name, "singer.last_name should not be nil"
+      end
+      # None of the requests should use a (read-only) transaction.
+      select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
+      select_requests.each do |request|
+        assert_nil request.transaction
+      end
+      # Executing a simple query should not initiate any transactions.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_empty begin_transaction_requests
     end
-    # Executing a simple query should not initiate any transactions.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_empty begin_transaction_requests
 
-    # Check the encoded parameters.
-    select_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
-    select_requests.each do |request|
-      assert_equal "1", request.params["LIMIT_2"]
-      assert_equal "1", request.params["id_1"]
-      assert_equal :INT64, request.param_types["LIMIT_2"].code
-      assert_equal :INT64, request.param_types["id_1"].code
-    end
-  end
+    def test_update_one_singer_should_use_transaction
+      # Preferably, this use case should use mutations instead of DML, as single updates
+      # using DML are a lot slower than using mutations. Mutations can however not be
+      # read back during a transaction (no read-your-writes), but that is not needed in
+      # this case as the application is not managing the transaction itself.
+      select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result select_sql, MockServerTests::create_random_singers_result(1)
 
-  def test_selects_singers_with_condition
-    # This query does not use query parameters because the where clause is specified as a string.
-    # ActiveRecord sees that as a SQL fragment that will disable the usage of prepared statements.
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`last_name` LIKE 'A%'"
-    @mock.put_statement_result sql, create_random_singers_result(2)
-    Singer.where(Singer.arel_table[:last_name].matches("A%")).each do |singer|
-      refute_nil singer.id, "singer.id should not be nil"
-      refute_nil singer.first_name, "singer.first_name should not be nil"
-      refute_nil singer.last_name, "singer.last_name should not be nil"
-    end
-    # None of the requests should use a (read-only) transaction.
-    select_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::ExecuteSqlRequest }
-    select_requests.each do |request|
-      assert_nil request.transaction
-    end
-    # Executing a simple query should not initiate any transactions.
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_empty begin_transaction_requests
-  end
+      singer = Singer.find_by id: 1
 
-  def test_update_one_singer_should_use_transaction
-    # Preferably, this use case should use mutations instead of DML, as single updates
-    # using DML are a lot slower than using mutations. Mutations can however not be
-    # read back during a transaction (no read-your-writes), but that is not needed in
-    # this case as the application is not managing the transaction itself.
-    select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result select_sql, create_random_singers_result(1)
-
-    singer = Singer.find_by id: 1
-
-    update_sql = "UPDATE `singers` SET `first_name` = @first_name_1 WHERE `singers`.`id` = @id_2"
-    @mock.put_statement_result update_sql, StatementResult.new(1)
-
-    singer.first_name = 'Dave'
-    singer.save!
-
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 1, begin_transaction_requests.length
-    # Check the encoded parameters.
-    select_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
-    select_requests.each do |request|
-      assert_equal "Dave", request.params["first_name_1"]
-      assert_equal singer.id.to_s, request.params["id_2"]
-      assert_equal :STRING, request.param_types["first_name_1"].code
-      assert_equal :INT64, request.param_types["id_2"].code
-    end
-  end
-
-  def test_update_two_singers_should_use_transaction
-    select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` BETWEEN @id_1 AND @id_2"
-    @mock.put_statement_result select_sql, create_random_singers_result(2)
-
-    update_sql = "UPDATE `singers` SET `first_name` = @first_name_1 WHERE `singers`.`id` = @id_2"
-    ActiveRecord::Base.transaction do
-      singers = Singer.where id: 1..2
+      update_sql = "UPDATE `singers` SET `first_name` = @first_name_1 WHERE `singers`.`id` = @id_2"
       @mock.put_statement_result update_sql, StatementResult.new(1)
 
-      singers[0].update! first_name: "Name1"
-      singers[1].update! first_name: "Name2"
+      singer.first_name = 'Dave'
+      singer.save!
+
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      # Check the encoded parameters.
+      select_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
+      select_requests.each do |request|
+        assert_equal "Dave", request.params["first_name_1"]
+        assert_equal singer.id.to_s, request.params["id_2"]
+        assert_equal :STRING, request.param_types["first_name_1"].code
+        assert_equal :INT64, request.param_types["id_2"].code
+      end
     end
 
-    begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-    assert_equal 1, begin_transaction_requests.length
-    # All of the SQL requests should use a transaction.
-    sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && (req.sql.starts_with?("SELECT `singers`.*") || req.sql.starts_with?("UPDATE")) }
-    sql_requests.each do |request|
-      refute_nil request.transaction
-      @id ||= request.transaction.id
-      assert_equal @id, request.transaction.id
+    def test_update_two_singers_should_use_transaction
+      select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` BETWEEN @id_1 AND @id_2"
+      @mock.put_statement_result select_sql, MockServerTests::create_random_singers_result(2)
+
+      update_sql = "UPDATE `singers` SET `first_name` = @first_name_1 WHERE `singers`.`id` = @id_2"
+      ActiveRecord::Base.transaction do
+        singers = Singer.where id: 1..2
+        @mock.put_statement_result update_sql, StatementResult.new(1)
+
+        singers[0].update! first_name: "Name1"
+        singers[1].update! first_name: "Name2"
+      end
+
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      # All of the SQL requests should use a transaction.
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && (req.sql.starts_with?("SELECT `singers`.*") || req.sql.starts_with?("UPDATE")) }
+      sql_requests.each do |request|
+        refute_nil request.transaction
+        @id ||= request.transaction.id
+        assert_equal @id, request.transaction.id
+      end
+
+      update_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
+      assert_equal 2, update_requests.length
+
+      singers = Singer.where id: 1..2
+      update_requests.each_with_index do |request, index|
+        assert_equal "Name#{index+1}", request.params["first_name_1"]
+        assert_equal "#{singers[index].id}", request.params["id_2"]
+        assert_equal :STRING, request.param_types["first_name_1"].code
+        assert_equal :INT64, request.param_types["id_2"].code
+      end
     end
 
-    update_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
-    assert_equal 2, update_requests.length
+    def test_create_singer_with_last_performance_as_time
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `last_performance`, `id`) VALUES (@first_name_1, @last_name_2, @last_performance_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
 
-    singers = Singer.where id: 1..2
-    update_requests.each_with_index do |request, index|
-      assert_equal "Name#{index+1}", request.params["first_name_1"]
-      assert_equal "#{singers[index].id}", request.params["id_2"]
-      assert_equal :STRING, request.param_types["first_name_1"].code
-      assert_equal :INT64, request.param_types["id_2"].code
-    end
-  end
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", last_performance: ::Time.parse("2021-05-12T10:30:00+02:00"))
+      end
 
-  def test_create_singer_with_last_performance_as_time
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `last_performance`, `id`) VALUES (@first_name_1, @last_name_2, @last_performance_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
-
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", last_performance: ::Time.parse("2021-05-12T10:30:00+02:00"))
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :TIMESTAMP, request.param_types["last_performance_3"].code
+      assert_equal "2021-05-12T08:30:00.000000000Z", request.params["last_performance_3"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :TIMESTAMP, request.param_types["last_performance_3"].code
-    assert_equal "2021-05-12T08:30:00.000000000Z", request.params["last_performance_3"]
-  end
+    def test_create_singer_with_last_performance_as_non_iso_string
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `last_performance`, `id`) VALUES (@first_name_1, @last_name_2, @last_performance_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
 
-  def test_create_singer_with_last_performance_as_non_iso_string
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `last_performance`, `id`) VALUES (@first_name_1, @last_name_2, @last_performance_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
+      # This timestamp string is ambiguous without knowing the locale that it should be parsed in, as it
+      # could represent both 4th of July and 7th of April. This test verifies that it is encoded to the
+      # same value as ::Time.parse(..) would encode it to.
+      timestamp_string = "04/07/2017 2:19pm"
+      timestamp = ::Time.parse(timestamp_string)
 
-    # This timestamp string is ambiguous without knowing the locale that it should be parsed in, as it
-    # could represent both 4th of July and 7th of April. This test verifies that it is encoded to the
-    # same value as ::Time.parse(..) would encode it to.
-    timestamp_string = "04/07/2017 2:19pm"
-    timestamp = ::Time.parse(timestamp_string)
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", last_performance: timestamp_string)
+      end
 
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", last_performance: timestamp_string)
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :TIMESTAMP, request.param_types["last_performance_3"].code
+      assert_equal timestamp.utc.rfc3339(9), request.params["last_performance_3"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :TIMESTAMP, request.param_types["last_performance_3"].code
-    assert_equal timestamp.utc.rfc3339(9), request.params["last_performance_3"]
-  end
+    def test_find_singer_by_last_performance_as_non_iso_string
+      select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`last_performance` = @last_performance_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result select_sql, MockServerTests::create_random_singers_result(1)
 
-  def test_find_singer_by_last_performance_as_non_iso_string
-    select_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`last_performance` = @last_performance_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result select_sql, create_random_singers_result(1)
+      # This timestamp string is ambiguous without knowing the locale that should be used for parsing, as it
+      # could represent both 4th of July and 7th of April. This test verifies that it is encoded to the
+      # same value as ::Time.parse(..) would encode it to.
+      timestamp_string = "04/07/2017 2:19pm"
+      timestamp = ::Time.parse(timestamp_string)
+      Singer.find_by(last_performance: timestamp_string)
 
-    # This timestamp string is ambiguous without knowing the locale that should be used for parsing, as it
-    # could represent both 4th of July and 7th of April. This test verifies that it is encoded to the
-    # same value as ::Time.parse(..) would encode it to.
-    timestamp_string = "04/07/2017 2:19pm"
-    timestamp = ::Time.parse(timestamp_string)
-    Singer.find_by(last_performance: timestamp_string)
-
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }.first
-    assert_equal :TIMESTAMP, request.param_types["last_performance_1"].code
-    assert_equal timestamp.utc.rfc3339(9), request.params["last_performance_1"]
-  end
-
-  def test_create_singer_with_picture
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
-    data = StringIO.new "hello"
-
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", picture: data)
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }.first
+      assert_equal :TIMESTAMP, request.param_types["last_performance_1"].code
+      assert_equal timestamp.utc.rfc3339(9), request.params["last_performance_1"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :BYTES, request.param_types["picture_3"].code
-    assert_equal Base64.strict_encode64("hello".dup.force_encoding("ASCII-8BIT")), request.params["picture_3"]
-  end
+    def test_create_singer_with_picture
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
+      data = StringIO.new "hello"
 
-  def test_create_singer_with_picture_as_string
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
-    data = StringIO.new "hello"
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", picture: data)
+      end
 
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", picture: data.read)
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :BYTES, request.param_types["picture_3"].code
+      assert_equal Base64.strict_encode64("hello".dup.force_encoding("ASCII-8BIT")), request.params["picture_3"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :BYTES, request.param_types["picture_3"].code
-    assert_equal Base64.strict_encode64("hello".dup.force_encoding("ASCII-8BIT")), request.params["picture_3"]
-  end
+    def test_create_singer_with_picture_as_string
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
+      data = StringIO.new "hello"
 
-  def test_create_singer_with_picture_as_binary
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", picture: data.read)
+      end
 
-    data = IO.read("#{Dir.pwd}/test/activerecord_spanner_mock_server/cloudspannerlogo.png", mode: "rb")
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", picture: data)
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :BYTES, request.param_types["picture_3"].code
+      assert_equal Base64.strict_encode64("hello".dup.force_encoding("ASCII-8BIT")), request.params["picture_3"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :BYTES, request.param_types["picture_3"].code
-    assert_equal Base64.strict_encode64(data.force_encoding("ASCII-8BIT")), request.params["picture_3"]
-  end
+    def test_create_singer_with_picture_as_binary
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `picture`, `id`) VALUES (@first_name_1, @last_name_2, @picture_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
 
-  def test_create_singer_with_revenues
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `revenues`, `id`) VALUES (@first_name_1, @last_name_2, @revenues_3, @id_4)"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
+      data = IO.read("#{Dir.pwd}/test/activerecord_spanner_mock_server/cloudspannerlogo.png", mode: "rb")
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", picture: data)
+      end
 
-    Singer.transaction do
-      Singer.create(first_name: "Dave", last_name: "Allison", revenues: 42952.13)
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :BYTES, request.param_types["picture_3"].code
+      assert_equal Base64.strict_encode64(data.force_encoding("ASCII-8BIT")), request.params["picture_3"]
     end
 
-    request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
-    assert_equal :NUMERIC, request.param_types["revenues_3"].code
-    assert_equal "42952.13", request.params["revenues_3"]
-  end
+    def test_create_singer_with_revenues
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `revenues`, `id`) VALUES (@first_name_1, @last_name_2, @revenues_3, @id_4)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
 
-  def test_delete_all
-    @mock.put_statement_result"SELECT COUNT(*) FROM `singers`", StatementResult.create_single_int_result_set("C", 1)
-    assert_equal 1, Singer.count
+      Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison", revenues: 42952.13)
+      end
 
-    delete_sql = "DELETE FROM `singers` WHERE TRUE"
-    @mock.put_statement_result delete_sql, StatementResult.new(1)
-    Singer.transaction do
+      request = @mock.requests.select {|req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }.first
+      assert_equal :NUMERIC, request.param_types["revenues_3"].code
+      assert_equal "42952.13", request.params["revenues_3"]
+    end
+
+    def test_delete_all
+      @mock.put_statement_result"SELECT COUNT(*) FROM `singers`", StatementResult.create_single_int_result_set("C", 1)
+      assert_equal 1, Singer.count
+
+      delete_sql = "DELETE FROM `singers` WHERE TRUE"
+      @mock.put_statement_result delete_sql, StatementResult.new(1)
+      Singer.transaction do
+        Singer.delete_all
+      end
+
+      delete_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }
+      assert_equal 1, delete_requests.length
+
+      @mock.put_statement_result"SELECT COUNT(*) FROM `singers`", StatementResult.create_single_int_result_set("C", 0)
+      assert_equal 0, Singer.count
+    end
+
+    def test_destroy_singer
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
+      delete_sql = "DELETE FROM `singers` WHERE `singers`.`id` = @id_1"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
+      @mock.put_statement_result delete_sql, StatementResult.new(1)
+
+      singer = Singer.create(first_name: "Dave", last_name: "Allison")
+
+      Singer.transaction do
+        singer.destroy
+      end
+
+      assert_equal 2, @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.count
+      delete_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }.first
+      assert_equal singer.id.to_s, delete_request.params["id_1"]
+    end
+
+    def test_singer_albums_uses_prepared_statement
+      select_singer_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      select_albums_sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`singer_id` = @singer_id_1"
+
+      @mock.put_statement_result select_singer_sql, MockServerTests::create_random_singers_result(1)
+      @mock.put_statement_result select_albums_sql, MockServerTests::create_random_albums_result(2)
+
+      singer = Singer.find_by id: 1
+      albums = singer.albums
+
+      assert_equal 2, albums.length
+      request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_albums_sql }.first
+      assert_equal singer.id.to_s, request.params["singer_id_1"]
+      assert_equal :INT64, request.param_types["singer_id_1"].code
+    end
+
+    def test_create_singer_using_mutation
+      # Create a singer without a transaction block. This will cause the singer to be created using a mutation instead of
+      # DML, as it would be impossible to read back the update during the transaction anyways. Mutations are a lot more
+      # efficient than DML statements.
+      singer = Singer.create(first_name: "Dave", last_name: "Allison")
+      commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
+      assert_equal 1, commit_requests.length
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :insert, mutation.operation
+      assert_equal "singers", mutation.insert.table
+
+      assert_equal 1, mutation.insert.values.length
+      assert_equal 3, mutation.insert.values[0].length
+      assert_equal "Dave", mutation.insert.values[0][0]
+      assert_equal "Allison", mutation.insert.values[0][1]
+      assert_equal singer.id, mutation.insert.values[0][2].to_i
+
+      assert_equal 3, mutation.insert.columns.length
+      assert_equal "first_name", mutation.insert.columns[0]
+      assert_equal "last_name", mutation.insert.columns[1]
+      assert_equal "id", mutation.insert.columns[2]
+    end
+
+    def test_update_singer_using_mutation
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      singer = Singer.find_by id: 1
+
+      singer.update last_name: "Allison-Stevenson"
+
+      commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
+      assert_equal 1, commit_requests.length
+
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :update, mutation.operation
+      assert_equal "singers", mutation.update.table
+
+      assert_equal 1, mutation.update.values.length
+      assert_equal 2, mutation.update.values[0].length
+      assert_equal singer.id, mutation.update.values[0][0].to_i
+      assert_equal "Allison-Stevenson", mutation.update.values[0][1]
+
+      assert_equal 2, mutation.update.columns.length
+      assert_equal "id", mutation.update.columns[0]
+      assert_equal "last_name", mutation.update.columns[1]
+    end
+
+    def test_delete_all_using_mutation
       Singer.delete_all
+
+      commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
+      assert_equal 1, commit_requests.length
+
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :delete, mutation.operation
+      assert_equal "singers", mutation.delete.table
+      assert mutation.delete.key_set.all
     end
 
-    delete_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }
-    assert_equal 1, delete_requests.length
+    def test_destroy_singer_using_mutation
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+      singer = Singer.find_by id: 1
 
-    @mock.put_statement_result"SELECT COUNT(*) FROM `singers`", StatementResult.create_single_int_result_set("C", 0)
-    assert_equal 0, Singer.count
-  end
-
-  def test_destroy_singer
-    insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
-    delete_sql = "DELETE FROM `singers` WHERE `singers`.`id` = @id_1"
-    @mock.put_statement_result insert_sql, StatementResult.new(1)
-    @mock.put_statement_result delete_sql, StatementResult.new(1)
-
-    singer = Singer.create(first_name: "Dave", last_name: "Allison")
-
-    Singer.transaction do
       singer.destroy
+
+      commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
+      assert_equal 1, commit_requests.length
+
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :delete, mutation.operation
+      assert_equal "singers", mutation.delete.table
+      assert_equal 1, mutation.delete.key_set.keys.length
+      assert_equal singer.id, mutation.delete.key_set.keys[0][0].to_i
     end
 
-    assert_equal 2, @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }.count
-    delete_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }.first
-    assert_equal singer.id.to_s, delete_request.params["id_1"]
-  end
+    def test_create_multiple_singers_using_mutations
+      # Creating multiple singers without a transaction in one call should only create one transaction.
+      Singer.create(
+        [
+          { first_name: "Dave", last_name: "Allison" },
+          { first_name: "Alice", last_name: "Ericsson" },
+          { first_name: "Nancy", last_name: "Gardner" }
+        ]
+      )
 
-  def test_singer_albums_uses_prepared_statement
-    select_singer_sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    select_albums_sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`singer_id` = @singer_id_1"
-
-    @mock.put_statement_result select_singer_sql, create_random_singers_result(1)
-    @mock.put_statement_result select_albums_sql, create_random_albums_result(2)
-
-    singer = Singer.find_by id: 1
-    albums = singer.albums
-
-    assert_equal 2, albums.length
-    request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_albums_sql }.first
-    assert_equal singer.id.to_s, request.params["singer_id_1"]
-    assert_equal :INT64, request.param_types["singer_id_1"].code
-  end
-
-  def test_create_singer_using_mutation
-    # Create a singer without a transaction block. This will cause the singer to be created using a mutation instead of
-    # DML, as it would be impossible to read back the update during the transaction anyways. Mutations are a lot more
-    # efficient than DML statements.
-    singer = Singer.create(first_name: "Dave", last_name: "Allison")
-    commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
-    assert_equal 1, commit_requests.length
-    mutations = commit_requests[0].mutations
-    assert_equal 1, mutations.length
-    mutation = mutations[0]
-    assert_equal :insert, mutation.operation
-    assert_equal "singers", mutation.insert.table
-
-    assert_equal 1, mutation.insert.values.length
-    assert_equal 3, mutation.insert.values[0].length
-    assert_equal "Dave", mutation.insert.values[0][0]
-    assert_equal "Allison", mutation.insert.values[0][1]
-    assert_equal singer.id, mutation.insert.values[0][2].to_i
-
-    assert_equal 3, mutation.insert.columns.length
-    assert_equal "first_name", mutation.insert.columns[0]
-    assert_equal "last_name", mutation.insert.columns[1]
-    assert_equal "id", mutation.insert.columns[2]
-  end
-
-  def test_update_singer_using_mutation
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    singer = Singer.find_by id: 1
-
-    singer.update last_name: "Allison-Stevenson"
-
-    commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
-    assert_equal 1, commit_requests.length
-
-    mutations = commit_requests[0].mutations
-    assert_equal 1, mutations.length
-    mutation = mutations[0]
-    assert_equal :update, mutation.operation
-    assert_equal "singers", mutation.update.table
-
-    assert_equal 1, mutation.update.values.length
-    assert_equal 2, mutation.update.values[0].length
-    assert_equal singer.id, mutation.update.values[0][0].to_i
-    assert_equal "Allison-Stevenson", mutation.update.values[0][1]
-
-    assert_equal 2, mutation.update.columns.length
-    assert_equal "id", mutation.update.columns[0]
-    assert_equal "last_name", mutation.update.columns[1]
-  end
-
-  def test_delete_all_using_mutation
-    Singer.delete_all
-
-    commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
-    assert_equal 1, commit_requests.length
-
-    mutations = commit_requests[0].mutations
-    assert_equal 1, mutations.length
-    mutation = mutations[0]
-    assert_equal :delete, mutation.operation
-    assert_equal "singers", mutation.delete.table
-    assert mutation.delete.key_set.all
-  end
-
-  def test_destroy_singer_using_mutation
-    sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
-    @mock.put_statement_result sql, create_random_singers_result(1)
-    singer = Singer.find_by id: 1
-
-    singer.destroy
-
-    commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
-    assert_equal 1, commit_requests.length
-
-    mutations = commit_requests[0].mutations
-    assert_equal 1, mutations.length
-    mutation = mutations[0]
-    assert_equal :delete, mutation.operation
-    assert_equal "singers", mutation.delete.table
-    assert_equal 1, mutation.delete.key_set.keys.length
-    assert_equal singer.id, mutation.delete.key_set.keys[0][0].to_i
-  end
-
-  def test_create_multiple_singers_using_mutations
-    # Creating multiple singers without a transaction in one call should only create one transaction.
-    Singer.create(
-      [
-        { first_name: "Dave", last_name: "Allison" },
-        { first_name: "Alice", last_name: "Ericsson" },
-        { first_name: "Nancy", last_name: "Gardner" }
-      ]
-    )
-
-    # There should be one commit request with 3 mutations.
-    commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
-    assert_equal 1, commit_requests.length
-    mutations = commit_requests[0].mutations
-    assert_equal 3, mutations.length
+      # There should be one commit request with 3 mutations.
+      commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
+      assert_equal 1, commit_requests.length
+      mutations = commit_requests[0].mutations
+      assert_equal 3, mutations.length
+    end
   end
 end

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -1,0 +1,54 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
+  def change
+    # Record the current primary key prefix type to reset it after running this change.
+    current_prefix_type = ActiveRecord::Base.primary_key_prefix_type
+    begin
+      # Interleaved tables require that the child table includes the column(s) of the primary key of the parent table.
+      # That means that the tables should use a prefix for the primary key column names in order to prevent the primary
+      # key columns of both the parent and child tables to be named `id`.
+      ActiveRecord::Base.primary_key_prefix_type = :table_name
+      # Start a DDL batch that will be used for the entire change.
+      connection.start_batch_ddl
+      create_table :singers do |t|
+        t.column :first_name, :string, limit: 200
+        t.string :last_name
+      end
+
+      # To create an interleaved table we need to do the following:
+      # 1. Disable the automatic generation of a primary key. Otherwise, ActiveRecord will generate a single column
+      #    primary key named `id` or `albumid` (depending on the primary_key_prefix_type).
+      # 2. Call `t.interleave_in :table` to register the parent table.
+      # 3. Manually add the primary key columns in the correct order. In this case that is `singerid` (the primary key
+      #    of the parent table) and `albumid`.
+      create_table :albums do |t|
+        t.interleave_in :singers
+        t.parent_key :singerid
+        t.string :title
+      end
+
+      # This table will be interleaved in a table that itself is already an interleaved table. We need to include the
+      # primary key columns of all the parent tables in the hierarchy.
+      create_table :tracks do |t|
+        t.interleave_in :albums, :cascade
+        t.parent_key :singerid
+        t.parent_key :albumid
+        t.string :title
+        t.numeric :duration
+      end
+
+      # Execute the change as one DDL batch.
+      connection.run_batch
+    rescue StandardError
+      connection.abort_batch
+      raise
+    ensure
+      ActiveRecord::Base.primary_key_prefix_type = current_prefix_type
+    end
+  end
+end

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -13,327 +13,326 @@ require_relative "models/track"
 
 require "securerandom"
 
-# Tests executing a simple migration on a mock Spanner server.
-class SpannerMigrationsMockServerTest < Minitest::Test
-  def setup
-    super
-    @server = GRPC::RpcServer.new
-    @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
-    @mock = SpannerMockServer.new
-    @database_admin_mock = DatabaseAdminMockServer.new
-    @server.handle @mock
-    @server.handle @database_admin_mock
-    # Run the server in a separate thread
-    @server_thread = Thread.new do
-      @server.run
+module TestMigrationsWithMockServer
+  # Tests executing a simple migration on a mock Spanner server.
+  class SpannerMigrationsMockServerTest < Minitest::Test
+    def setup
+      super
+      @server = GRPC::RpcServer.new
+      @port = @server.add_http2_port "localhost:0", :this_port_is_insecure
+      @mock = SpannerMockServer.new
+      @database_admin_mock = DatabaseAdminMockServer.new
+      @server.handle @mock
+      @server.handle @database_admin_mock
+      # Run the server in a separate thread
+      @server_thread = Thread.new do
+        @server.run
+      end
+      @server.wait_till_running
+      # Register INFORMATION_SCHEMA queries on the mock server.
+      register_schema_migrations_table_result
+      register_schema_migrations_columns_result
+      register_ar_internal_metadata_table_result
+      register_ar_internal_metadata_columns_result
+      register_ar_internal_metadata_results
+      register_ar_internal_metadata_insert_result
+
+      ActiveRecord::Base.establish_connection(
+        adapter: "spanner",
+        emulator_host: "localhost:#{@port}",
+        project: "test-project",
+        instance: "test-instance",
+        database: "testdb"
+      )
+      ActiveRecord::Base.logger = nil
+      ActiveRecord::Migration.verbose = false
     end
-    @server.wait_till_running
-    # Register INFORMATION_SCHEMA queries on the mock server.
-    register_schema_migrations_table_result
-    register_schema_migrations_columns_result
-    register_ar_internal_metadata_table_result
-    register_ar_internal_metadata_columns_result
-    register_ar_internal_metadata_results
-    register_ar_internal_metadata_insert_result
 
-    ActiveRecord::Base.establish_connection(
-      adapter: "spanner",
-      emulator_host: "localhost:#{@port}",
-      project: "test-project",
-      instance: "test-instance",
-      database: "testdb"
-    )
-    ActiveRecord::Base.logger = nil
-    ActiveRecord::Migration.verbose = false
-  end
-
-  def teardown
-    super
-    ActiveRecord::Base.connection_pool.disconnect!
-    @server.stop
-    @server_thread.exit
-  end
-
-  def test_execute_migrations
-    context = ActiveRecord::MigrationContext.new(
-      "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
-      ActiveRecord::SchemaMigration
-    )
-
-    # Register migration result for the current version (nil) to the new version (1).
-    register_version_result nil, "1"
-
-    context.migrate 1
-
-    # The migration should create the migration tables and the singers and albums tables in one request.
-    ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
-    assert_equal 3, ddl_requests.length
-    assert_equal 1, ddl_requests[0].statements.length
-    assert ddl_requests[0].statements[0].starts_with? "CREATE TABLE `schema_migrations`"
-    assert_equal 1, ddl_requests[1].statements.length
-    assert ddl_requests[1].statements[0].starts_with? "CREATE TABLE `ar_internal_metadata`"
-    # The actual migration should be executed as one batch.
-    assert_equal 5, ddl_requests[2].statements.length
-    assert_equal(
-      "CREATE TABLE `singers` (`singerid` INT64 NOT NULL, `first_name` STRING(200), `last_name` STRING(MAX)) PRIMARY KEY (`singerid`)",
-          ddl_requests[2].statements[0]
-    )
-    assert ddl_requests[2].statements[1].starts_with? "CREATE TABLE `albums`"
-    assert ddl_requests[2].statements[2].starts_with? "ALTER TABLE `albums` ADD CONSTRAINT"
-    assert_equal "ALTER TABLE `singers` ADD COLUMN `place_of_birth` STRING(MAX)", ddl_requests[2].statements[3]
-    assert_equal(
-      "CREATE TABLE `albums_singers` (`singer_id` INT64 NOT NULL, `album_id` INT64 NOT NULL) PRIMARY KEY (`singer_id`, `album_id`)",
-      ddl_requests[2].statements[4]
-    )
-  end
-
-  def test_execute_migration_without_batching
-    context = ActiveRecord::MigrationContext.new(
-      "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
-      ActiveRecord::SchemaMigration
-    )
-
-    # Simulate upgrading from version 1 to version 2.
-    register_version_result "1", "2"
-
-    context.migrate 2
-
-    # The migration should create the migration tables and the singers and albums tables in one request.
-    ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
-    # The migration simulation also creates the two migration metadata tables.
-    assert_equal 4, ddl_requests.length
-
-    # The migration statements should not be executed in a batch.
-    assert_equal 1, ddl_requests[2].statements.length
-    assert_equal 1, ddl_requests[3].statements.length
-    assert_equal(
-      "CREATE TABLE `table1` (`id` INT64 NOT NULL, `col1` STRING(MAX), `col2` STRING(MAX)) PRIMARY KEY (`id`)",
-      ddl_requests[2].statements[0]
-    )
-    assert_equal(
-      "CREATE TABLE `table2` (`id` INT64 NOT NULL, `col1` STRING(MAX), `col2` STRING(MAX)) PRIMARY KEY (`id`)",
-      ddl_requests[3].statements[0]
-    )
-  end
-
-  def test_create_all_native_migration_types
-    context = ActiveRecord::MigrationContext.new(
-      "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
-      ActiveRecord::SchemaMigration
-    )
-
-    register_version_result "1", "3"
-
-    context.migrate 3
-
-    # The migration should create the migration tables and the singers and albums tables in one request.
-    ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
-    # The migration simulation also creates the two migration metadata tables.
-    assert_equal 3, ddl_requests.length
-    assert_equal 1, ddl_requests[2].statements.length
-
-    # CREATE TABLE `types_table` (`id` INT64 NOT NULL, `col_string` STRING(MAX), `col_text` STRING(MAX),
-    # `col_integer` INT64, `col_bigint` INT64, `col_float` FLOAT64, `col_decimal` FLOAT64, `col_numeric` numeric,
-    # `col_datetime` TIMESTAMP, `col_time` TIMESTAMP, `col_date` DATE, `col_binary` BYTES(MAX), `col_boolean` BOOL) PRIMARY KEY (`id`)
-    expectedDdl = +"CREATE TABLE `types_table` ("
-    expectedDdl << "`id` INT64 NOT NULL, "
-    expectedDdl << "`col_string` STRING(MAX), "
-    expectedDdl << "`col_text` STRING(MAX), "
-    expectedDdl << "`col_integer` INT64, "
-    expectedDdl << "`col_bigint` INT64, "
-    expectedDdl << "`col_float` FLOAT64, "
-    expectedDdl << "`col_decimal` NUMERIC, "
-    expectedDdl << "`col_numeric` NUMERIC, "
-    expectedDdl << "`col_datetime` TIMESTAMP, "
-    expectedDdl << "`col_time` TIMESTAMP, "
-    expectedDdl << "`col_date` DATE, "
-    expectedDdl << "`col_binary` BYTES(MAX), "
-    expectedDdl << "`col_boolean` BOOL) "
-    expectedDdl << "PRIMARY KEY (`id`)"
-
-    assert_equal expectedDdl, ddl_requests[2].statements[0]
-  end
-
-  def test_interleaved_table
-    context = ActiveRecord::MigrationContext.new(
-      "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
-      ActiveRecord::SchemaMigration
-    )
-
-    register_version_result "1", "4"
-
-    context.migrate 4
-
-    # The migration should create the migration tables and the singers, albums and tracks tables in one request.
-    ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
-    # The migration simulation also creates the two migration metadata tables.
-    assert_equal 3, ddl_requests.length
-    assert_equal 3, ddl_requests[2].statements.length
-
-    expectedDdl = "CREATE TABLE `singers` "
-    expectedDdl << "(`singerid` INT64 NOT NULL, `first_name` STRING(200), `last_name` STRING(MAX)) "
-    expectedDdl << "PRIMARY KEY (`singerid`)"
-    assert_equal expectedDdl, ddl_requests[2].statements[0]
-
-    expectedDdl = "CREATE TABLE `albums` "
-    expectedDdl << "(`albumid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `title` STRING(MAX)"
-    expectedDdl << ") PRIMARY KEY (`singerid`, `albumid`), INTERLEAVE IN PARENT `singers`"
-    assert_equal expectedDdl, ddl_requests[2].statements[1]
-
-    expectedDdl = "CREATE TABLE `tracks` "
-    expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC)"
-    expectedDdl << " PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
-    assert_equal expectedDdl, ddl_requests[2].statements[2]
-
-    singer = Singer.create first_name: "test", last_name: "test"
-    Album.create singer: singer, title: "foo"
-  end
-
-  def register_schema_migrations_table_result
-    sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='schema_migrations'"
-    register_empty_select_tables_result sql
-  end
-
-  def register_schema_migrations_columns_result
-    # CREATE TABLE `schema_migrations` (`version` STRING(MAX) NOT NULL) PRIMARY KEY (`version`)
-    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='schema_migrations' ORDER BY ORDINAL_POSITION ASC"
-
-    column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
-    ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
-
-    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
-    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
-
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "version"),
-      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
-      Google::Protobuf::Value.new(string_value: "NO"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "1")
-    )
-    result_set.rows.push row
-
-    @mock.put_statement_result sql, StatementResult.new(result_set)
-  end
-
-  def register_ar_internal_metadata_table_result
-    sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='ar_internal_metadata'"
-    register_empty_select_tables_result sql
-  end
-
-  def register_ar_internal_metadata_columns_result
-    # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
-    sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='ar_internal_metadata' ORDER BY ORDINAL_POSITION ASC"
-
-    column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
-    ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
-
-    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
-    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
-
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "key"),
-      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
-      Google::Protobuf::Value.new(string_value: "NO"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "1")
-    )
-    result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "value"),
-      Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
-      Google::Protobuf::Value.new(string_value: "YES"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "2")
-    )
-    result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "created_at"),
-      Google::Protobuf::Value.new(string_value: "TIMESTAMP"),
-      Google::Protobuf::Value.new(string_value: "NO"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "3")
-    )
-    result_set.rows.push row
-    row = Google::Protobuf::ListValue.new
-    row.values.push(
-      Google::Protobuf::Value.new(string_value: "updated_at"),
-      Google::Protobuf::Value.new(string_value: "TIMESTAMP"),
-      Google::Protobuf::Value.new(string_value: "NO"),
-      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "4")
-    )
-    result_set.rows.push row
-
-    @mock.put_statement_result sql, StatementResult.new(result_set)
-  end
-
-  def register_ar_internal_metadata_results
-    # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
-    sql = "SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = @key_1 LIMIT @LIMIT_2"
-
-    key = Google::Cloud::Spanner::V1::StructType::Field.new name: "key", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    value = Google::Cloud::Spanner::V1::StructType::Field.new name: "value", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    created_at = Google::Cloud::Spanner::V1::StructType::Field.new name: "created_at", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
-    updated_at = Google::Cloud::Spanner::V1::StructType::Field.new name: "updated_at", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
-
-    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push key, value, created_at, updated_at
-    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
-
-    @mock.put_statement_result sql, StatementResult.new(result_set)
-  end
-
-  def register_ar_internal_metadata_insert_result
-    sql = "INSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES (@key_1, @value_2, @created_at_3, @updated_at_4)"
-    @mock.put_statement_result sql, StatementResult.new(1)
-  end
-
-  def register_empty_select_tables_result(sql)
-    table_catalog = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_CATALOG", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    table_schema = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_SCHEMA", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    table_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    parent_table_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-    on_delete_action = Google::Cloud::Spanner::V1::StructType::Field.new name: "ON_DELETE_ACTION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-
-    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push table_catalog, table_schema, table_name, parent_table_name, on_delete_action
-    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
-
-    @mock.put_statement_result sql, StatementResult.new(result_set)
-  end
-
-  def register_version_result(from_version, to_version)
-    sql = "SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC"
-
-    version_column = Google::Cloud::Spanner::V1::StructType::Field.new name: "version", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
-
-    metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
-    metadata.row_type.fields.push version_column
-    result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
-
-    if from_version
-      (from_version...to_version).each { |version|
-        row = Google::Protobuf::ListValue.new
-        row.values.push Google::Protobuf::Value.new(string_value: version.to_s)
-        result_set.rows.push row
-      }
+    def teardown
+      ActiveRecord::Base.connection_pool.disconnect!
+      @server.stop
+      @server_thread.exit
+      super
     end
-    @mock.put_statement_result sql, StatementResult.new(result_set)
 
-    update_sql = "INSERT INTO `schema_migrations` (`version`) VALUES (@version_1)"
-    @mock.put_statement_result update_sql, StatementResult.new(1)
+    def test_execute_migrations
+      context = ActiveRecord::MigrationContext.new(
+        "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
+        ActiveRecord::SchemaMigration
+      )
+
+      # Register migration result for the current version (nil) to the new version (1).
+      register_version_result nil, "1"
+
+      context.migrate 1
+
+      # The migration should create the migration tables and the singers and albums tables in one request.
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 3, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert ddl_requests[0].statements[0].starts_with? "CREATE TABLE `schema_migrations`"
+      assert_equal 1, ddl_requests[1].statements.length
+      assert ddl_requests[1].statements[0].starts_with? "CREATE TABLE `ar_internal_metadata`"
+      # The actual migration should be executed as one batch.
+      assert_equal 5, ddl_requests[2].statements.length
+      assert_equal(
+        "CREATE TABLE `singers` (`singerid` INT64 NOT NULL, `first_name` STRING(200), `last_name` STRING(MAX)) PRIMARY KEY (`singerid`)",
+            ddl_requests[2].statements[0]
+      )
+      assert ddl_requests[2].statements[1].starts_with? "CREATE TABLE `albums`"
+      assert ddl_requests[2].statements[2].starts_with? "ALTER TABLE `albums` ADD CONSTRAINT"
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `place_of_birth` STRING(MAX)", ddl_requests[2].statements[3]
+      assert_equal(
+        "CREATE TABLE `albums_singers` (`singer_id` INT64 NOT NULL, `album_id` INT64 NOT NULL) PRIMARY KEY (`singer_id`, `album_id`)",
+        ddl_requests[2].statements[4]
+      )
+    end
+
+    def test_execute_migration_without_batching
+      context = ActiveRecord::MigrationContext.new(
+        "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
+        ActiveRecord::SchemaMigration
+      )
+
+      # Simulate upgrading from version 1 to version 2.
+      register_version_result "1", "2"
+
+      context.migrate 2
+
+      # The migration should create the migration tables and the singers and albums tables in one request.
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      # The migration simulation also creates the two migration metadata tables.
+      assert_equal 4, ddl_requests.length
+
+      # The migration statements should not be executed in a batch.
+      assert_equal 1, ddl_requests[2].statements.length
+      assert_equal 1, ddl_requests[3].statements.length
+      assert_equal(
+        "CREATE TABLE `table1` (`id` INT64 NOT NULL, `col1` STRING(MAX), `col2` STRING(MAX)) PRIMARY KEY (`id`)",
+        ddl_requests[2].statements[0]
+      )
+      assert_equal(
+        "CREATE TABLE `table2` (`id` INT64 NOT NULL, `col1` STRING(MAX), `col2` STRING(MAX)) PRIMARY KEY (`id`)",
+        ddl_requests[3].statements[0]
+      )
+    end
+
+    def test_create_all_native_migration_types
+      context = ActiveRecord::MigrationContext.new(
+        "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
+        ActiveRecord::SchemaMigration
+      )
+
+      register_version_result "1", "3"
+
+      context.migrate 3
+
+      # The migration should create the migration tables and the singers and albums tables in one request.
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      # The migration simulation also creates the two migration metadata tables.
+      assert_equal 3, ddl_requests.length
+      assert_equal 1, ddl_requests[2].statements.length
+
+      # CREATE TABLE `types_table` (`id` INT64 NOT NULL, `col_string` STRING(MAX), `col_text` STRING(MAX),
+      # `col_integer` INT64, `col_bigint` INT64, `col_float` FLOAT64, `col_decimal` FLOAT64, `col_numeric` numeric,
+      # `col_datetime` TIMESTAMP, `col_time` TIMESTAMP, `col_date` DATE, `col_binary` BYTES(MAX), `col_boolean` BOOL) PRIMARY KEY (`id`)
+      expectedDdl = +"CREATE TABLE `types_table` ("
+      expectedDdl << "`id` INT64 NOT NULL, "
+      expectedDdl << "`col_string` STRING(MAX), "
+      expectedDdl << "`col_text` STRING(MAX), "
+      expectedDdl << "`col_integer` INT64, "
+      expectedDdl << "`col_bigint` INT64, "
+      expectedDdl << "`col_float` FLOAT64, "
+      expectedDdl << "`col_decimal` NUMERIC, "
+      expectedDdl << "`col_numeric` NUMERIC, "
+      expectedDdl << "`col_datetime` TIMESTAMP, "
+      expectedDdl << "`col_time` TIMESTAMP, "
+      expectedDdl << "`col_date` DATE, "
+      expectedDdl << "`col_binary` BYTES(MAX), "
+      expectedDdl << "`col_boolean` BOOL) "
+      expectedDdl << "PRIMARY KEY (`id`)"
+
+      assert_equal expectedDdl, ddl_requests[2].statements[0]
+    end
+
+    def test_interleaved_table
+      context = ActiveRecord::MigrationContext.new(
+        "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
+        ActiveRecord::SchemaMigration
+      )
+
+      register_version_result "1", "4"
+
+      context.migrate 4
+
+      # The migration should create the migration tables and the singers, albums and tracks tables in one request.
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      # The migration simulation also creates the two migration metadata tables.
+      assert_equal 3, ddl_requests.length
+      assert_equal 3, ddl_requests[2].statements.length
+
+      expectedDdl = "CREATE TABLE `singers` "
+      expectedDdl << "(`singerid` INT64 NOT NULL, `first_name` STRING(200), `last_name` STRING(MAX)) "
+      expectedDdl << "PRIMARY KEY (`singerid`)"
+      assert_equal expectedDdl, ddl_requests[2].statements[0]
+
+      expectedDdl = "CREATE TABLE `albums` "
+      expectedDdl << "(`albumid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `title` STRING(MAX)"
+      expectedDdl << ") PRIMARY KEY (`singerid`, `albumid`), INTERLEAVE IN PARENT `singers`"
+      assert_equal expectedDdl, ddl_requests[2].statements[1]
+
+      expectedDdl = "CREATE TABLE `tracks` "
+      expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC)"
+      expectedDdl << " PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
+      assert_equal expectedDdl, ddl_requests[2].statements[2]
+    end
+
+    def register_schema_migrations_table_result
+      sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='schema_migrations'"
+      register_empty_select_tables_result sql
+    end
+
+    def register_schema_migrations_columns_result
+      # CREATE TABLE `schema_migrations` (`version` STRING(MAX) NOT NULL) PRIMARY KEY (`version`)
+      sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='schema_migrations' ORDER BY ORDINAL_POSITION ASC"
+
+      column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
+      ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "version"),
+        Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
+        Google::Protobuf::Value.new(string_value: "NO"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "1")
+      )
+      result_set.rows.push row
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_ar_internal_metadata_table_result
+      sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='ar_internal_metadata'"
+      register_empty_select_tables_result sql
+    end
+
+    def register_ar_internal_metadata_columns_result
+      # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
+      sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='ar_internal_metadata' ORDER BY ORDINAL_POSITION ASC"
+
+      column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
+      ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push column_name, spanner_type, is_nullable, column_default, ordinal_position
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "key"),
+        Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
+        Google::Protobuf::Value.new(string_value: "NO"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "1")
+      )
+      result_set.rows.push row
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "value"),
+        Google::Protobuf::Value.new(string_value: "STRING(MAX)"),
+        Google::Protobuf::Value.new(string_value: "YES"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "2")
+      )
+      result_set.rows.push row
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "created_at"),
+        Google::Protobuf::Value.new(string_value: "TIMESTAMP"),
+        Google::Protobuf::Value.new(string_value: "NO"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "3")
+      )
+      result_set.rows.push row
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: "updated_at"),
+        Google::Protobuf::Value.new(string_value: "TIMESTAMP"),
+        Google::Protobuf::Value.new(string_value: "NO"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "4")
+      )
+      result_set.rows.push row
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_ar_internal_metadata_results
+      # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
+      sql = "SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = @key_1 LIMIT @LIMIT_2"
+
+      key = Google::Cloud::Spanner::V1::StructType::Field.new name: "key", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      value = Google::Cloud::Spanner::V1::StructType::Field.new name: "value", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      created_at = Google::Cloud::Spanner::V1::StructType::Field.new name: "created_at", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
+      updated_at = Google::Cloud::Spanner::V1::StructType::Field.new name: "updated_at", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push key, value, created_at, updated_at
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_ar_internal_metadata_insert_result
+      sql = "INSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES (@key_1, @value_2, @created_at_3, @updated_at_4)"
+      @mock.put_statement_result sql, StatementResult.new(1)
+    end
+
+    def register_empty_select_tables_result(sql)
+      table_catalog = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_CATALOG", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      table_schema = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_SCHEMA", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      table_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "TABLE_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      parent_table_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      on_delete_action = Google::Cloud::Spanner::V1::StructType::Field.new name: "ON_DELETE_ACTION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push table_catalog, table_schema, table_name, parent_table_name, on_delete_action
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_version_result(from_version, to_version)
+      sql = "SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC"
+
+      version_column = Google::Cloud::Spanner::V1::StructType::Field.new name: "version", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push version_column
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      if from_version
+        (from_version...to_version).each { |version|
+          row = Google::Protobuf::ListValue.new
+          row.values.push Google::Protobuf::Value.new(string_value: version.to_s)
+          result_set.rows.push row
+        }
+      end
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+
+      update_sql = "INSERT INTO `schema_migrations` (`version`) VALUES (@version_1)"
+      @mock.put_statement_result update_sql, StatementResult.new(1)
+    end
   end
 end

--- a/test/migrations_with_mock_server/models/album.rb
+++ b/test/migrations_with_mock_server/models/album.rb
@@ -4,7 +4,9 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
-  has_many :tracks
+module TestMigrationsWithMockServer
+  class Album < ActiveRecord::Base
+    belongs_to :singer
+    has_many :tracks
+  end
 end

--- a/test/migrations_with_mock_server/models/singer.rb
+++ b/test/migrations_with_mock_server/models/singer.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Singer < ActiveRecord::Base
-  has_many :albums
+module TestMigrationsWithMockServer
+  class Singer < ActiveRecord::Base
+    has_many :albums
+  end
 end

--- a/test/migrations_with_mock_server/models/track.rb
+++ b/test/migrations_with_mock_server/models/track.rb
@@ -4,7 +4,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Album < ActiveRecord::Base
-  belongs_to :singer
-  has_many :tracks
+class Track < ActiveRecord::Base
+  belongs_to :album
 end

--- a/test/migrations_with_mock_server/models/track.rb
+++ b/test/migrations_with_mock_server/models/track.rb
@@ -4,6 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-class Track < ActiveRecord::Base
-  belongs_to :album
+module TestMigrationsWithMockServer
+  class Track < ActiveRecord::Base
+    belongs_to :album
+  end
 end


### PR DESCRIPTION
Adds support for interleaved tables to ActiveRecord. Interleaved tables in Cloud Spanner conflict with one core limitation/feature of ActiveRecord: ActiveRecord require primary keys to be single-column, while an interleaved child table is required to include all the columns of the parent table in its primary key, in addition to any 'own' columns in the primary key. This means that a child table will always have at least two columns in its primary key. This problem is circumvented in this solution by introducing the concept of a `parent_key`. A `parent_key` is a column in a child table that references a column in the primary key of the parent table. Such a column is:
1. Not considered part of the primary key by ActiveRecord. This means that ActiveRecord will not consider the table as having multiple columns for the primary key, which again means that the table can be used in a 'normal' way with ActiveRecord.
2. Technically part of the primary key definition of the table, and the Spanner ActiveRecord adapter will use it when it is required (such as for example when deleting or updating a record using mutations).

The relationship between a parent and child interleaved table can be modeled as a `has_many` / `belongs_to` association in ActiveRecord.