### PR TITLE
feat: support PDML transactions

### DIFF
--- a/acceptance/cases/transactions/read_write_transactions_test.rb
+++ b/acceptance/cases/transactions/read_write_transactions_test.rb
@@ -232,6 +232,17 @@ module ActiveRecord
           assert organization.last_updated > current_timestamp
         end
       end
+
+      def test_pdml
+        create_test_records
+        assert Comment.count > 0
+
+        Comment.transaction isolation: :pdml do
+          Comment.delete_all
+        end
+
+        assert_equal 0, Comment.count
+      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -146,13 +146,16 @@ module ActiveRecord
         # Begins a transaction on the database with the specified isolation level. Cloud Spanner only supports
         # isolation level :serializable, but also defines two additional 'isolation levels' that can be used
         # to start specific types of Spanner transactions:
-        # * :read_only: Starts a read-only snapshot transaction using a strong timestamp bound. TODO: Implement
+        # * :read_only: Starts a read-only snapshot transaction using a strong timestamp bound.
         # * :buffered_mutations: Starts a read/write transaction that will use mutations instead of DML for single-row
         #                        inserts/updates/deletes. Mutations are buffered locally until the transaction is
         #                        committed, and any changes during a transaction cannot be read by the application.
+        # * :pdml: Starts a Partitioned DML transaction. Executing multiple DML statements in one PDML transaction
+        #          block is NOT supported A PDML transaction is not guaranteed to be atomic.
+        #          See https://cloud.google.com/spanner/docs/dml-partitioned for more information.
         def begin_isolated_db_transaction isolation
           raise "Unsupported isolation level: #{isolation}" unless \
-              [:serializable, :read_only, :buffered_mutations].include? isolation
+              [:serializable, :read_only, :buffered_mutations, :pdml].include? isolation
 
           log "BEGIN #{isolation}" do
             @connection.begin_transaction isolation

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -74,6 +74,9 @@ module ActiveRecord
 
         def exec_update sql, name = "SQL", binds = []
           result = execute sql, name, binds
+          # Make sure that we consume the entire result stream before trying to get the stats.
+          result.rows.each do |_row|
+          end
           return result.row_count if result.row_count
 
           raise ActiveRecord::StatementInvalid.new(

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -77,7 +77,7 @@ module ActiveRecord
           return result.row_count if result.row_count
 
           raise ActiveRecord::StatementInvalid.new(
-            "DML statement is invalid.", sql
+            "DML statement is invalid.", sql: sql
           )
         end
         alias exec_delete exec_update

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -50,6 +50,12 @@ module Google
           Snapshot.from_grpc snp_grpc, self
         end
 
+        def create_pdml
+          ensure_service!
+          pdml_grpc = service.create_pdml path
+          Transaction.from_grpc pdml_grpc, self
+        end
+
         private
 
         ##

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -607,7 +607,9 @@ module MockServerTests
         Singer.delete_all
       end
 
-      begin_request = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }.first
+      begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_requests.length
+      begin_request = begin_requests.first
       assert begin_request&.options&.partitioned_dml
       delete_request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }.first
       assert delete_request&.transaction&.id


### PR DESCRIPTION
Adds support for PDML transactions. These can be used for updates of large amounts of data, such as for example when copying the data from column to another.