### PR TITLE
feat: support and test multiple ActiveRecord versions

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -19,9 +19,17 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: [2.5, 2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.0, 6.1.4]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4]
         # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
         exclude:
+          - ruby: 3.0
+            ar: 6.0.0
+          - ruby: 3.0
+            ar: 6.0.1
+          - ruby: 3.0
+            ar: 6.0.2.2
+          - ruby: 3.0
+            ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
     steps:

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -19,6 +19,11 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: [2.5, 2.6, 2.7, 3.0]
+        ar: [6.0.4, 6.1.0, 6.1.4]
+        # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
+        exclude:
+          - ruby: 3.0
+            ar: 6.0.4
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -26,8 +31,10 @@ jobs:
     # (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: false
         ruby-version: ${{ matrix.ruby }}
+    - name: Set ActiveRecord version
+      run: sed -i "s/\"activerecord\", \"~> 6.1.4\"/\"activerecord\", \"${{ matrix.ar }}\"/" activerecord-spanner-adapter.gemspec
     - name: Install dependencies
       run: bundle install
     - name: Run acceptance tests on emulator

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -30,7 +30,8 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run acceptance tests on production
-      run: bundle exec rake acceptance\[,,,"exclude cases/migration"\]
+      # run: bundle exec rake acceptance\[,,,"exclude cases/migration"\]
+      run: bundle exec rake acceptance
       env:
         SPANNER_TEST_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         SPANNER_TEST_INSTANCE: ruby-activerecord-test

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -30,8 +30,7 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run acceptance tests on production
-      # run: bundle exec rake acceptance\[,,,"exclude cases/migration"\]
-      run: bundle exec rake acceptance
+      run: bundle exec rake acceptance\[,,,"exclude cases/migration"\]
       env:
         SPANNER_TEST_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         SPANNER_TEST_INSTANCE: ruby-activerecord-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,11 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: [2.5, 2.6, 2.7]
+        ar: [6.0.4, 6.1.0, 6.1.4]
+        # Exclude Ruby 3.0 and ActiveRecord 6.0.x as the latter does not support Ruby 3.0.
+        exclude:
+          - ruby: 3.0
+            ar: 6.0.4
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -20,6 +25,8 @@ jobs:
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
+    - name: Set ActiveRecord version
+      run: sed -i "s/\"activerecord\", \"~> 6.1.4\"/\"activerecord\", \"${{ matrix.ar }}\"/" activerecord-spanner-adapter.gemspec
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,17 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: [2.5, 2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.0, 6.1.4]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4]
         # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
         exclude:
+          - ruby: 3.0
+            ar: 6.0.0
+          - ruby: 3.0
+            ar: 6.0.1
+          - ruby: 3.0
+            ar: 6.0.2.2
+          - ruby: 3.0
+            ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.0]
         ar: [6.0.4, 6.1.0, 6.1.4]
-        # Exclude Ruby 3.0 and ActiveRecord 6.0.x as the latter does not support Ruby 3.0.
+        # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
         exclude:
           - ruby: 3.0
             ar: 6.0.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     # (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: false
         ruby-version: ${{ matrix.ruby }}
     - name: Set ActiveRecord version
       run: sed -i "s/\"activerecord\", \"~> 6.1.4\"/\"activerecord\", \"${{ matrix.ar }}\"/" activerecord-spanner-adapter.gemspec

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -1,9 +1,8 @@
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-name: acceptance tests on emulator
+  schedule:
+    # 06:00 UTC
+    - cron:  '0 6 * * *'
+name: nightly acceptance tests on emulator
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,19 +17,27 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: [2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.4]
+        # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
+        ruby: [2.5, 2.6, 2.7, 3.0]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4]
         # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
         exclude:
+          - ruby: 3.0
+            ar: 6.0.0
+          - ruby: 3.0
+            ar: 6.0.1
+          - ruby: 3.0
+            ar: 6.0.2.2
+          - ruby: 3.0
+            ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
-    # (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
+        # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}
     - name: Set ActiveRecord version

--- a/.github/workflows/nightly-acceptance-tests-on-production.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-production.yaml
@@ -1,0 +1,35 @@
+on:
+  schedule:
+    # 06:00 UTC
+    - cron:  '0 6 * * *'
+name: nightly acceptance tests on production
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 4
+      matrix:
+        ruby: [3.0]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
+    # (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Setup GCloud
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
+    - name: Install dependencies
+      run: bundle install
+    - name: Run acceptance tests on production
+      run: bundle exec rake acceptance
+      env:
+        SPANNER_TEST_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        SPANNER_TEST_INSTANCE: ruby-activerecord-test

--- a/.github/workflows/nightly-acceptance-tests-on-production.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-production.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # 06:00 UTC
-    - cron:  '0 6 * * *'
+    # 02:00 UTC
+    - cron:  '0 2 * * *'
 name: nightly acceptance tests on production
 jobs:
   test:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -1,28 +1,35 @@
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-name: ci
+  schedule:
+    # 05:30 UTC
+    - cron:  '30 5 * * *'
+name: nightly-unit-tests
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        ruby: [2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.4]
+        # Run unit tests all supported combinations of Ruby and ActiveRecord.
+        ruby: [2.5, 2.6, 2.7, 3.0]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4]
         # Exclude Ruby 3.0 and ActiveRecord 6.0.x as that combination is not supported.
         exclude:
+          - ruby: 3.0
+            ar: 6.0.0
+          - ruby: 3.0
+            ar: 6.0.1
+          - ruby: 3.0
+            ar: 6.0.2.2
+          - ruby: 3.0
+            ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
-    # (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
+        # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}
     - name: Set ActiveRecord version

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.14.0"
-gem "pry", "~> 0.14.0"
-gem "pry-byebug", "~> 3.8.0"
+gem "pry", "~> 0.13.0"
+gem "pry-byebug", "~> 3.9.0"
 
 # Required for samples
 gem 'docker-api'

--- a/acceptance/cases/migration/change_schema_test.rb
+++ b/acceptance/cases/migration/change_schema_test.rb
@@ -22,7 +22,9 @@ module ActiveRecord
       end
 
       def teardown
-        connection.drop_table :testings rescue nil
+        connection.ddl_batch do
+          connection.drop_table :testings rescue nil
+        end
         ActiveRecord::Base.primary_key_prefix_type = nil
         ActiveRecord::Base.clear_cache!
       end
@@ -36,8 +38,10 @@ module ActiveRecord
       end
 
       def test_create_table_adds_id
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
         end
 
         assert_equal %w[id foo].sort, connection.columns(:testings).map(&:name).sort
@@ -50,26 +54,32 @@ module ActiveRecord
       end
 
       def test_create_table_with_custom_primary_key
-        connection.create_table :testings, force: true, primary_key: :email do |t|
-          t.string :name
+        connection.ddl_batch do
+          connection.create_table :testings, force: true, primary_key: :email do |t|
+            t.string :name
+          end
         end
 
         assert_equal "email", connection.primary_key(:testings)
       end
 
       def test_create_table_with_custom_primary_key_using_options
-        connection.create_table :testings, force: true, id: false do |t|
-          t.string :phone, primary_key: true
-          t.string :name
+        connection.ddl_batch do
+          connection.create_table :testings, force: true, id: false do |t|
+            t.string :phone, primary_key: true
+            t.string :name
+          end
         end
 
         assert_equal "phone", connection.primary_key(:testings)
       end
 
       def test_create_table_with_custom_primary_key_using_type
-        connection.create_table :testings, force: true, id: false do |t|
-          t.primary_key :username, limit: 255
-          t.string :name
+        connection.ddl_batch do
+          connection.create_table :testings, force: true, id: false do |t|
+            t.primary_key :username, limit: 255
+            t.string :name
+          end
         end
 
         assert_equal "username", connection.primary_key(:testings)
@@ -81,9 +91,11 @@ module ActiveRecord
       end
 
       def test_create_table_with_custom_primary_key_type
-        connection.create_table :testings, force: true, id: false do |t|
-          t.primary_key :user_id, :integer
-          t.string :name
+        connection.ddl_batch do
+          connection.create_table :testings, force: true, id: false do |t|
+            t.primary_key :user_id, :integer
+            t.string :name
+          end
         end
 
         assert_equal "user_id", connection.primary_key(:testings)
@@ -95,8 +107,10 @@ module ActiveRecord
       end
 
       def test_create_table_with_not_null_column
-        connection.create_table :testings do |t|
-          t.column :foo, :string, null: false
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string, null: false
+          end
         end
 
         assert_raises ActiveRecord::StatementInvalid do
@@ -107,9 +121,11 @@ module ActiveRecord
       end
 
       def test_create_table_with_limits
-        connection.create_table :testings do |t|
-          t.column :foo, :string, limit: 255
-          t.column :default_int, :integer
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string, limit: 255
+            t.column :default_int, :integer
+          end
         end
 
         columns = connection.columns :testings
@@ -124,8 +140,10 @@ module ActiveRecord
       def test_create_table_with_primary_key_prefix_as_table_name_with_underscore
         ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
 
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
         end
 
         assert_equal "testing_id", connection.primary_key(:testings)
@@ -137,8 +155,10 @@ module ActiveRecord
       def test_create_table_with_primary_key_prefix_as_table_name
         ActiveRecord::Base.primary_key_prefix_type = :table_name
 
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
         end
 
         assert_equal "testingid", connection.primary_key(:testings)
@@ -149,8 +169,10 @@ module ActiveRecord
 
       def test_create_table_raises_when_redefining_primary_key_column
         error = assert_raise ArgumentError do
-          connection.create_table :testings do |t|
-            t.column :id, :string
+          connection.ddl_batch do
+            connection.create_table :testings do |t|
+              t.column :id, :string
+            end
           end
         end
 
@@ -159,8 +181,10 @@ module ActiveRecord
 
       def test_create_table_raises_when_redefining_custom_primary_key_column
         error = assert_raise ArgumentError do
-          connection.create_table :testings, primary_key: :testing_id do |t|
-            t.column :testing_id, :string
+          connection.ddl_batch do
+            connection.create_table :testings, primary_key: :testing_id do |t|
+              t.column :testing_id, :string
+            end
           end
         end
 
@@ -169,9 +193,11 @@ module ActiveRecord
 
       def test_create_table_raises_when_defining_existing_column
         error = assert_raise ArgumentError do
-          connection.create_table :testings do |t|
-            t.column :testing_column, :string
-            t.column :testing_column, :integer
+          connection.ddl_batch do
+            connection.create_table :testings do |t|
+              t.column :testing_column, :string
+              t.column :testing_column, :integer
+            end
           end
         end
 
@@ -179,8 +205,10 @@ module ActiveRecord
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns
-        connection.create_table table_name do |t|
-          t.timestamps
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.timestamps
+          end
         end
         created_columns = connection.columns table_name
 
@@ -192,8 +220,10 @@ module ActiveRecord
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns_with_options
-        connection.create_table table_name do |t|
-          t.timestamps null: true
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.timestamps null: true
+          end
         end
         created_columns = connection.columns table_name
 
@@ -210,10 +240,12 @@ module ActiveRecord
 
       def test_add_column_not_null_without_default
         skip "Unimplemented error: Cannot add NOT NULL column to existing table"
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
+          connection.add_column :testings, :bar, :string, null: false
         end
-        connection.add_column :testings, :bar, :string, null: false
 
         assert_raise ActiveRecord::NotNullViolation do
           connection.transaction {
@@ -223,8 +255,10 @@ module ActiveRecord
       end
 
       def test_add_column_with_timestamp_type
-        connection.create_table :testings do |t|
-          t.column :foo, :timestamp
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :timestamp
+          end
         end
 
         column = connection.columns(:testings).find { |c| c.name == "foo" }
@@ -234,11 +268,17 @@ module ActiveRecord
       end
 
       def test_change_column_quotes_column_names
-        connection.create_table :testings do |t|
-          t.column :select, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :select, :string
+          end
+        end
+        # These two changes cannot be in one batch, as the change_column operation will check whether the column
+        # actually exists before executing any DDL statements.
+        connection.ddl_batch do
+          connection.change_column :testings, :select, :string, limit: 10
         end
 
-        connection.change_column :testings, :select, :string, limit: 10
         connection.transaction {
           connection.execute "insert into testings (#{connection.quote_column_name 'id'},"\
             "#{connection.quote_column_name 'select'}) values (#{generate_id}, '7 chars')"
@@ -246,13 +286,15 @@ module ActiveRecord
       end
 
       def test_keeping_notnull_constraints_on_change
-        connection.create_table :testings do |t|
-          t.column :title, :string
-        end
         person_klass = Class.new ActiveRecord::Base
-        person_klass.table_name = "testings"
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :title, :string
+          end
+          person_klass.table_name = "testings"
+          person_klass.connection.add_column "testings", "wealth", :integer, null: false
+        end
 
-        person_klass.connection.add_column "testings", "wealth", :integer, null: false
         person_klass.reset_column_information
         assert_equal false, person_klass.columns_hash["wealth"].null
 
@@ -263,7 +305,9 @@ module ActiveRecord
         }
 
         # change column, make it nullable
-        person_klass.connection.change_column "testings", "wealth", :integer, null: true
+        connection.ddl_batch do
+          person_klass.connection.change_column "testings", "wealth", :integer, null: true
+        end
         person_klass.reset_column_information
         assert_nil person_klass.columns_hash["wealth"].default
         assert_equal true, person_klass.columns_hash["wealth"].null
@@ -286,8 +330,10 @@ module ActiveRecord
       end
 
       def test_column_exists
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
         end
 
         assert connection.column_exists?(:testings, :foo)
@@ -295,9 +341,11 @@ module ActiveRecord
       end
 
       def test_column_exists_with_type
-        connection.create_table :testings do |t|
-          t.column :foo, :string
-          t.column :bar, :float
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+            t.column :bar, :float
+          end
         end
 
         assert connection.column_exists?(:testings, :foo, :string)
@@ -308,11 +356,13 @@ module ActiveRecord
       end
 
       def test_column_exists_with_definition
-        connection.create_table :testings do |t|
-          t.column :foo, :string, limit: 100
-          t.column :bar, :float
-          t.column :taggable_id, :integer, null: false
-          t.column :taggable_type, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string, limit: 100
+            t.column :bar, :float
+            t.column :taggable_id, :integer, null: false
+            t.column :taggable_type, :string
+          end
         end
 
         assert connection.column_exists?(:testings, :foo, :string, limit: 100)
@@ -324,8 +374,10 @@ module ActiveRecord
       end
 
       def test_column_exists_on_table_with_no_options_parameter_supplied
-        connection.create_table :testings do |t|
-          t.string :foo
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.string :foo
+          end
         end
         connection.change_table :testings do |t|
           assert t.column_exists?(:foo)
@@ -334,9 +386,13 @@ module ActiveRecord
       end
 
       def test_drop_table_if_exists
-        connection.create_table(:testings)
+        connection.ddl_batch do
+          connection.create_table(:testings)
+        end
         assert connection.table_exists?(:testings)
-        connection.drop_table(:testings, if_exists: true)
+        connection.ddl_batch do
+          connection.drop_table(:testings, if_exists: true)
+        end
         assert_not connection.table_exists?(:testings)
       end
 
@@ -345,8 +401,10 @@ module ActiveRecord
       end
 
       def test_drop_and_create_table_with_indexes
-        connection.create_table :testings, force: true do |t|
-          t.string :name, index: true
+        connection.ddl_batch do
+          connection.create_table :testings, force: true do |t|
+            t.string :name, index: true
+          end
         end
 
         assert_nothing_raised {
@@ -362,8 +420,10 @@ module ActiveRecord
       private
 
       def testing_table_with_only_foo_attribute
-        connection.create_table :testings do |t|
-          t.column :foo, :string
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
         end
 
         yield

--- a/acceptance/cases/migration/change_table_test.rb
+++ b/acceptance/cases/migration/change_table_test.rb
@@ -28,57 +28,6 @@ module ActiveRecord
         yield ActiveRecord::Base.connection.update_table_definition(:delete_me, @connection)
       end
 
-      def test_references_column_type_adds_id
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_reference, nil, [:delete_me, :customer, {}]
-          else
-            @connection.expect :add_reference, nil, [:delete_me, :customer]
-          end
-          t.references :customer
-        end
-      end
-
-      def test_remove_references_column_type_removes_id
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :remove_reference, nil, [:delete_me, :customer, {}]
-          else
-            @connection.expect :remove_reference, nil, [:delete_me, :customer]
-          end
-          t.remove_references :customer
-        end
-      end
-
-      def test_add_belongs_to_works_like_add_references
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_reference, nil, [:delete_me, :customer, {}]
-          else
-            @connection.expect :add_reference, nil, [:delete_me, :customer]
-          end
-          t.belongs_to :customer
-        end
-      end
-
-      def test_remove_belongs_to_works_like_remove_references
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :remove_reference, nil, [:delete_me, :customer, {}]
-          else
-            @connection.expect :remove_reference, nil, [:delete_me, :customer]
-          end
-          t.remove_belongs_to :customer
-        end
-      end
-
-      def test_references_column_type_with_polymorphic_adds_type
-        with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true]
-          t.references :taggable, polymorphic: true
-        end
-      end
-
       def test_remove_references_column_type_with_polymorphic_removes_type
         with_change_table do |t|
           @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true]
@@ -135,93 +84,6 @@ module ActiveRecord
         end
       end
 
-      def test_integer_creates_integer_column
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :foo, :integer, {}]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer, {}]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :foo, :integer]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
-          end
-          t.integer :foo, :bar
-        end
-      end
-
-      def test_bigint_creates_bigint_column
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :foo, :bigint, {}]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :bigint, {}]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :foo, :bigint]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :bigint]
-          end
-          t.bigint :foo, :bar
-        end
-      end
-
-      def test_string_creates_string_column
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :foo, :string, {}]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :string, {}]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :foo, :string]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :string]
-          end
-          t.string :foo, :bar
-        end
-      end
-
-      def test_column_creates_column
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer, {}]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
-          end
-          t.column :bar, :integer
-        end
-      end
-
-      def test_column_creates_column_with_options
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer, { null: false }]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer, { null: false }]
-          end
-          t.column :bar, :integer, null: false
-        end
-      end
-
-      def test_column_creates_column_with_index
-        with_change_table do |t|
-          if RUBY_VERSION < "2.7"
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer, {}]
-          else
-            @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
-          end
-          @connection.expect :add_index, nil, [:delete_me, :bar, {}]
-          t.column :bar, :integer, index: true
-        end
-      end
-
-      def test_index_creates_index
-        with_change_table do |t|
-          @connection.expect :add_index, nil, [:delete_me, :bar, {}]
-          t.index :bar
-        end
-      end
-
-      def test_index_creates_index_with_options
-        with_change_table do |t|
-          @connection.expect :add_index, nil, [:delete_me, :bar, { unique: true }]
-          t.index :bar, unique: true
-        end
-      end
-
       def test_index_exists
         with_change_table do |t|
           @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
@@ -236,49 +98,6 @@ module ActiveRecord
         end
       end
 
-      def test_rename_index_renames_index
-        with_change_table do |t|
-          @connection.expect :rename_index, nil, [:delete_me, :bar, :baz]
-          t.rename_index :bar, :baz
-        end
-      end
-
-      def test_change_changes_column
-        with_change_table do |t|
-          @connection.expect :change_column, nil, [:delete_me, :bar, :string, {}]
-          t.change :bar, :string
-        end
-      end
-
-      def test_change_changes_column_with_options
-        with_change_table do |t|
-          @connection.expect :change_column, nil, [:delete_me, :bar, :string, { null: true }]
-          t.change :bar, :string, null: true
-        end
-      end
-
-
-      def test_change_default_changes_column
-        with_change_table do |t|
-          @connection.expect :change_column_default, nil, [:delete_me, :bar, :string]
-          t.change_default :bar, :string
-        end
-      end
-
-      def test_remove_drops_single_column
-        with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar]
-          t.remove :bar
-        end
-      end
-
-      def test_remove_drops_multiple_columns
-        with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz]
-          t.remove :bar, :baz
-        end
-      end
-
       def test_remove_drops_multiple_columns_when_column_options_are_given
         with_change_table do |t|
           @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz, type: :string, null: false]
@@ -288,7 +107,7 @@ module ActiveRecord
 
       def test_remove_index_removes_index_with_options
         with_change_table do |t|
-          @connection.expect :remove_index, nil, [:delete_me, :bar]
+          @connection.expect :remove_index, nil, [:delete_me, :bar, **{}]
           t.remove_index :bar
         end
       end

--- a/acceptance/cases/migration/change_table_test.rb
+++ b/acceptance/cases/migration/change_table_test.rb
@@ -105,13 +105,6 @@ module ActiveRecord
         end
       end
 
-      def test_remove_index_removes_index_with_options
-        with_change_table do |t|
-          @connection.expect :remove_index, nil, [:delete_me, :bar, **{}]
-          t.remove_index :bar
-        end
-      end
-
       def test_table_name_set
         with_change_table do |t|
           assert_equal :delete_me, t.name

--- a/acceptance/cases/migration/column_attributes_test.rb
+++ b/acceptance/cases/migration/column_attributes_test.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "bigdecimal"
 
 module ActiveRecord
   class Migration
@@ -74,20 +75,23 @@ module ActiveRecord
       end
 
       def test_native_types
-        add_column "test_models", "first_name", :string
-        add_column "test_models", "last_name", :string
-        add_column "test_models", "bio", :text
-        add_column "test_models", "age", :integer
-        add_column "test_models", "height", :float
-        add_column "test_models", "birthday", :datetime
-        add_column "test_models", "favorite_day", :date
-        add_column "test_models", "moment_of_truth", :datetime
-        add_column "test_models", "male", :boolean
+        connection.ddl_batch do
+          add_column "test_models", "first_name", :string
+          add_column "test_models", "last_name", :string
+          add_column "test_models", "bio", :text
+          add_column "test_models", "age", :integer
+          add_column "test_models", "height", :float
+          add_column "test_models", "birthday", :datetime
+          add_column "test_models", "favorite_day", :date
+          add_column "test_models", "moment_of_truth", :datetime
+          add_column "test_models", "male", :boolean
+          add_column "test_models", "weight", :decimal
+        end
 
         TestModel.create first_name: "bob", last_name: "bobsen",
           bio: "I was born ....", age: 18, height: 1.78,
           birthday: 18.years.ago, favorite_day: 10.days.ago,
-          moment_of_truth: "1782-10-10 21:40:18", male: true
+          moment_of_truth: "1782-10-10 21:40:18", male: true, weight: BigDecimal("75.6", 1)
 
         bob = TestModel.first
         assert_equal "bob", bob.first_name
@@ -96,6 +100,7 @@ module ActiveRecord
         assert_equal 18, bob.age
         assert_equal 1.78, bob.height
         assert_equal true, bob.male?
+        assert_equal BigDecimal("75.6", 1), bob.weight
 
         assert_equal String, bob.first_name.class
         assert_equal String, bob.last_name.class
@@ -105,6 +110,7 @@ module ActiveRecord
         assert_equal Time, bob.birthday.class
         assert_equal Date, bob.favorite_day.class
         assert_instance_of TrueClass, bob.male?
+        assert_equal BigDecimal, bob.weight.class
       end
 
       def test_add_column_and_ignore_limit

--- a/acceptance/cases/migration/column_positioning_test.rb
+++ b/acceptance/cases/migration/column_positioning_test.rb
@@ -17,15 +17,19 @@ module ActiveRecord
         skip_test_table_create!
         super
 
-        connection.create_table :testing_columns_position, id: false, force: true do |t|
-          t.column :first, :integer
-          t.column :second, :integer
-          t.column :third, :integer
+        connection.ddl_batch do
+          connection.create_table :testing_columns_position, id: false, force: true do |t|
+            t.column :first, :integer
+            t.column :second, :integer
+            t.column :third, :integer
+          end
         end
       end
 
       def teardown
-        connection.drop_table :testing_columns_position rescue nil
+        connection.ddl_batch do
+          connection.drop_table :testing_columns_position
+        end rescue nil
         ActiveRecord::Base.primary_key_prefix_type = nil
       end
 
@@ -34,7 +38,9 @@ module ActiveRecord
       end
 
       def test_add_column_with_positioning
-        connection.add_column :testing_columns_position, :fourth, :integer
+        connection.ddl_batch do
+          connection.add_column :testing_columns_position, :fourth, :integer
+        end
         assert_equal %w(first second third fourth), connection.columns(:testing_columns_position).map(&:name)
       end
     end

--- a/acceptance/cases/migration/columns_test.rb
+++ b/acceptance/cases/migration/columns_test.rb
@@ -104,7 +104,7 @@ module ActiveRecord
 
       def test_change_column_with_long_index_name
         table_name_prefix = "test_models_"
-        long_index_name = table_name_prefix + ("x" * (connection.allowed_index_name_length - table_name_prefix.length))
+        long_index_name = table_name_prefix + ("x" * (connection.index_name_length - table_name_prefix.length))
         add_column "test_models", "category", :string
         add_index :test_models, :category, name: long_index_name
 

--- a/acceptance/cases/migration/command_recorder_test.rb
+++ b/acceptance/cases/migration/command_recorder_test.rb
@@ -314,11 +314,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
-        if ActiveRecord::gem_version < VERSION_6_1_0
-          assert_equal [:remove_foreign_key, [:dogs, :people]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
       end
 
       def test_invert_remove_foreign_key
@@ -328,11 +324,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
-        if ActiveRecord::gem_version < VERSION_6_1_0
-          assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column
@@ -342,11 +334,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column_and_name
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
-        if ActiveRecord::gem_version < VERSION_6_1_0
-          assert_equal [:remove_foreign_key, [:dogs, { name: "fk" }]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column_and_name

--- a/acceptance/cases/migration/create_join_table_test.rb
+++ b/acceptance/cases/migration/create_join_table_test.rb
@@ -27,70 +27,92 @@ module ActiveRecord
       end
 
       def test_create_join_table
-        connection.create_join_table :artists, :musics
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics
+        end
 
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
       end
 
       def test_create_join_table_set_not_null_by_default
-        connection.create_join_table :artists, :musics
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics
+        end
 
         assert_equal [false, false], connection.columns(:artists_musics).map(&:null)
       end
 
       def test_create_join_table_with_strings
-        connection.create_join_table "artists", "musics"
+        connection.ddl_batch do
+          connection.create_join_table "artists", "musics"
+        end
 
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
       end
 
       def test_create_join_table_with_symbol_and_string
-        connection.create_join_table :artists, "musics"
+        connection.ddl_batch do
+          connection.create_join_table :artists, "musics"
+        end
 
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
       end
 
       def test_create_join_table_with_the_proper_order
-        connection.create_join_table :videos, :musics
+        connection.ddl_batch do
+          connection.create_join_table :videos, :musics
+        end
 
         assert_equal %w(music_id video_id), connection.columns(:musics_videos).map(&:name).sort
       end
 
       def test_create_join_table_with_the_table_name
-        connection.create_join_table :artists, :musics, table_name: :catalog
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, table_name: :catalog
+        end
 
         assert_equal %w(artist_id music_id), connection.columns(:catalog).map(&:name).sort
       end
 
       def test_create_join_table_with_the_table_name_as_string
-        connection.create_join_table :artists, :musics, table_name: "catalog"
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, table_name: "catalog"
+        end
 
         assert_equal %w(artist_id music_id), connection.columns(:catalog).map(&:name).sort
       end
 
       def test_create_join_table_with_column_options
-        connection.create_join_table :artists, :musics, column_options: { null: true }
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, column_options: { null: true }
+        end
 
         assert_equal [true, true], connection.columns(:artists_musics).map(&:null)
       end
 
       def test_create_join_table_without_indexes
-        connection.create_join_table :artists, :musics
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics
+        end
 
         assert_predicate connection.indexes(:artists_musics), :blank?
       end
 
       def test_create_join_table_with_index
-        connection.create_join_table :artists, :musics do |t|
-          t.index [:artist_id, :music_id]
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics do |t|
+            t.index [:artist_id, :music_id]
+          end
         end
 
         assert_equal [%w(artist_id music_id)], connection.indexes(:artists_musics).map(&:columns)
       end
 
       def test_create_join_table_respects_reference_key_type
-        connection.create_join_table :artists, :musics do |t|
-          t.references :video
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics do |t|
+            t.references :video
+          end
         end
 
         artist_id, music_id, video_id = connection.columns(:artists_musics).sort_by(&:name)
@@ -100,43 +122,67 @@ module ActiveRecord
       end
 
       def test_drop_join_table
-        connection.create_join_table :artists, :musics
-        connection.drop_join_table :artists, :musics
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics
+        end
+        connection.ddl_batch do
+          connection.drop_join_table :artists, :musics
+        end
 
         assert_not connection.table_exists?("artists_musics")
       end
 
       def test_drop_join_table_with_strings
-        connection.create_join_table :artists, :musics
-        connection.drop_join_table "artists", "musics"
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics
+        end
+        connection.ddl_batch do
+          connection.drop_join_table "artists", "musics"
+        end
 
         assert_not connection.table_exists?("artists_musics")
       end
 
       def test_drop_join_table_with_the_proper_order
-        connection.create_join_table :videos, :musics
-        connection.drop_join_table :videos, :musics
+        connection.ddl_batch do
+          connection.create_join_table :videos, :musics
+        end
+        connection.ddl_batch do
+          connection.drop_join_table :videos, :musics
+        end
 
         assert_not connection.table_exists?("musics_videos")
       end
 
       def test_drop_join_table_with_the_table_name
-        connection.create_join_table :artists, :musics, table_name: :catalog
-        connection.drop_join_table :artists, :musics, table_name: :catalog
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, table_name: :catalog
+        end
+        connection.ddl_batch do
+          connection.drop_join_table :artists, :musics, table_name: :catalog
+        end
 
         assert_not connection.table_exists?("catalog")
       end
 
       def test_drop_join_table_with_the_table_name_as_string
-        connection.create_join_table :artists, :musics, table_name: "catalog"
-        connection.drop_join_table :artists, :musics, table_name: "catalog"
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, table_name: "catalog"
+        end
+        connection.ddl_batch do
+          connection.drop_join_table :artists, :musics, table_name: "catalog"
+        end
 
         assert_not connection.table_exists?("catalog")
       end
 
       def test_drop_join_table_with_column_options
-        connection.create_join_table :artists, :musics, column_options: { null: true }
-        connection.drop_join_table :artists, :musics, column_options: { null: true }
+        connection.ddl_batch do
+          connection.create_join_table :artists, :musics, column_options: { null: true }
+        end
+        connection.ddl_batch do
+          connection.drop_join_table :artists, :musics, column_options: { null: true }
+        end
 
         assert_not connection.table_exists?("artists_musics")
       end
@@ -159,8 +205,10 @@ module ActiveRecord
       ensure
         tables_after = connection.data_sources - tables_before
 
-        tables_after.each do |table|
-          connection.drop_table table
+        connection.ddl_batch do
+          tables_after.each do |table|
+            connection.drop_table table
+          end
         end
       end
     end

--- a/acceptance/cases/migration/index_test.rb
+++ b/acceptance/cases/migration/index_test.rb
@@ -21,25 +21,31 @@ module ActiveRecord
 
         @table_name = :testings
 
-        connection.create_table table_name do |t|
-          t.column :foo, :string, limit: 100
-          t.column :bar, :string, limit: 100
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.column :foo, :string, limit: 100
+            t.column :bar, :string, limit: 100
 
-          t.string :first_name
-          t.string :last_name, limit: 100
-          t.string :key,       limit: 100
-          t.boolean :administrator
+            t.string :first_name
+            t.string :last_name, limit: 100
+            t.string :key,       limit: 100
+            t.boolean :administrator
+          end
         end
       end
 
       def teardown
-        connection.drop_table :testings rescue nil
+        connection.ddl_batch do
+          connection.drop_table :testings
+        end rescue nil
         ActiveRecord::Base.primary_key_prefix_type = nil
       end
 
       def test_rename_index
         connection.add_index(table_name, [:foo], name: "old_idx")
-        connection.rename_index(table_name, "old_idx", "new_idx")
+        connection.ddl_batch do
+          connection.rename_index(table_name, "old_idx", "new_idx")
+        end
 
         assert_not connection.index_name_exists?(table_name, "old_idx")
         assert connection.index_name_exists?(table_name, "new_idx")

--- a/acceptance/cases/migration/index_test.rb
+++ b/acceptance/cases/migration/index_test.rb
@@ -51,7 +51,7 @@ module ActiveRecord
         e = assert_raises(ArgumentError) {
           connection.rename_index(table_name, "old_idx", too_long_index_name)
         }
-        assert_match(/too long; the limit is #{connection.allowed_index_name_length} characters/, e.message)
+        assert_match(/too long; the limit is #{connection.index_name_length} characters/, e.message)
 
         assert connection.index_name_exists?(table_name, "old_idx")
       end
@@ -73,7 +73,7 @@ module ActiveRecord
         e = assert_raises(ArgumentError) {
           connection.add_index(table_name, "foo", name: too_long_index_name)
         }
-        assert_match(/too long; the limit is #{connection.allowed_index_name_length} characters/, e.message)
+        assert_match(/too long; the limit is #{connection.index_name_length} characters/, e.message)
 
         assert_not connection.index_name_exists?(table_name, too_long_index_name)
         connection.add_index(table_name, "foo", name: good_index_name)
@@ -198,7 +198,7 @@ module ActiveRecord
 
       private
       def good_index_name
-        "x" * connection.allowed_index_name_length
+        "x" * connection.index_name_length
       end
     end
   end

--- a/acceptance/cases/migration/references_index_test.rb
+++ b/acceptance/cases/migration/references_index_test.rb
@@ -23,37 +23,47 @@ module ActiveRecord
       end
 
       def teardown
-        connection.drop_table :testings rescue nil
+        connection.ddl_batch do
+          connection.drop_table :testings
+        end rescue nil
       end
 
       def test_creates_index
-        connection.create_table table_name do |t|
-          t.references :foo, index: true
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.references :foo, index: true
+          end
         end
 
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
       def test_creates_index_by_default_even_if_index_option_is_not_passed
-        connection.create_table table_name do |t|
-          t.references :foo
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.references :foo
+          end
         end
 
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
       def test_does_not_create_index_explicit
-        connection.create_table table_name do |t|
-          t.references :foo, index: false
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.references :foo, index: false
+          end
         end
 
         assert_not connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
       def test_creates_index_with_options
-        connection.create_table table_name do |t|
-          t.references :foo, index: { name: :index_testings_on_yo_momma }
-          t.references :bar, index: { unique: true }
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.references :foo, index: { name: :index_testings_on_yo_momma }
+            t.references :bar, index: { unique: true }
+          end
         end
 
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_yo_momma)
@@ -61,8 +71,10 @@ module ActiveRecord
       end
 
       def test_creates_polymorphic_index
-        connection.create_table table_name do |t|
-          t.references :foo, polymorphic: true, index: true
+        connection.ddl_batch do
+          connection.create_table table_name do |t|
+            t.references :foo, polymorphic: true, index: true
+          end
         end
 
         if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
@@ -73,35 +85,43 @@ module ActiveRecord
       end
 
       def test_creates_index_for_existing_table
-        connection.create_table table_name
-        connection.change_table table_name do |t|
-          t.references :foo, index: true
+        connection.ddl_batch do
+          connection.create_table table_name
+          connection.change_table table_name do |t|
+            t.references :foo, index: true
+          end
         end
 
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
       def test_creates_index_for_existing_table_even_if_index_option_is_not_passed
-        connection.create_table table_name
-        connection.change_table table_name do |t|
-          t.references :foo
+        connection.ddl_batch do
+          connection.create_table table_name
+          connection.change_table table_name do |t|
+            t.references :foo
+          end
         end
 
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
       def test_does_not_create_index_for_existing_table_explicit
-        connection.create_table table_name
-        connection.change_table table_name do |t|
-          t.references :foo, index: false
+        connection.ddl_batch do
+          connection.create_table table_name
+          connection.change_table table_name do |t|
+            t.references :foo, index: false
+          end
         end
         assert_not connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo)
       end
 
       def test_creates_polymorphic_index_for_existing_table
-        connection.create_table table_name
-        connection.change_table table_name do |t|
-          t.references :foo, polymorphic: true, index: true
+        connection.ddl_batch do
+          connection.create_table table_name
+          connection.change_table table_name do |t|
+            t.references :foo, polymorphic: true, index: true
+          end
         end
 
         if ActiveRecord::gem_version < Gem::Version.create('6.1.0')

--- a/acceptance/cases/migration/references_index_test.rb
+++ b/acceptance/cases/migration/references_index_test.rb
@@ -65,7 +65,11 @@ module ActiveRecord
           t.references :foo, polymorphic: true, index: true
         end
 
-        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
+          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+        else
+          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+        end
       end
 
       def test_creates_index_for_existing_table
@@ -91,8 +95,7 @@ module ActiveRecord
         connection.change_table table_name do |t|
           t.references :foo, index: false
         end
-
-        assert_not connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
+        assert_not connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo)
       end
 
       def test_creates_polymorphic_index_for_existing_table
@@ -101,7 +104,11 @@ module ActiveRecord
           t.references :foo, polymorphic: true, index: true
         end
 
-        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
+          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+        else
+          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+        end
       end
     end
   end

--- a/acceptance/cases/migration/references_statements_test.rb
+++ b/acceptance/cases/migration/references_statements_test.rb
@@ -19,76 +19,104 @@ module ActiveRecord
         super
         @table_name = :test_models
 
-        add_column table_name, :supplier_id, :integer, index: true
+        connection.ddl_batch do
+          add_column table_name, :supplier_id, :integer, index: true
+        end
       end
 
       def test_creates_reference_id_column
-        add_reference table_name, :user
+        connection.ddl_batch do
+          add_reference table_name, :user
+        end
         assert column_exists?(table_name, :user_id, :integer)
       end
 
       def test_does_not_create_reference_type_column
-        add_reference table_name, :taggable
+        connection.ddl_batch do
+          add_reference table_name, :taggable
+        end
         assert_not column_exists?(table_name, :taggable_type, :string)
       end
 
       def test_creates_reference_type_column
-        add_reference table_name, :taggable, polymorphic: true
+        connection.ddl_batch do
+          add_reference table_name, :taggable, polymorphic: true
+        end
         assert column_exists?(table_name, :taggable_id, :integer)
         assert column_exists?(table_name, :taggable_type, :string)
       end
 
       def test_does_not_create_reference_id_index_if_index_is_false
-        add_reference table_name, :user, index: false
+        connection.ddl_batch do
+          add_reference table_name, :user, index: false
+        end
         assert_not index_exists?(table_name, :user_id)
       end
 
       def test_create_reference_id_index_even_if_index_option_is_not_passed
-        add_reference table_name, :user
+        connection.ddl_batch do
+          add_reference table_name, :user
+        end
         assert index_exists?(table_name, :user_id)
       end
 
       def test_creates_polymorphic_index
-        add_reference table_name, :taggable, polymorphic: true, index: true
+        connection.ddl_batch do
+          add_reference table_name, :taggable, polymorphic: true, index: true
+        end
         assert index_exists?(table_name, [:taggable_type, :taggable_id])
       end
 
       def test_creates_reference_type_column_with_not_null
-        connection.create_table table_name, force: true do |t|
-          t.references :taggable, null: false, polymorphic: true
+        connection.ddl_batch do
+          connection.create_table table_name, force: true do |t|
+            t.references :taggable, null: false, polymorphic: true
+          end
         end
         assert column_exists?(table_name, :taggable_id, :integer, null: false)
         assert column_exists?(table_name, :taggable_type, :string, null: false)
       end
 
       def test_creates_named_index
-        add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id" }
+        connection.ddl_batch do
+          add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id" }
+        end
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id")
       end
 
       def test_creates_named_unique_index
-        add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id", unique: true }
+        connection.ddl_batch do
+          add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id", unique: true }
+        end
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id", unique: true)
       end
 
       def test_creates_reference_id_with_specified_type
-        add_reference table_name, :user, type: :string
+        connection.ddl_batch do
+          add_reference table_name, :user, type: :string
+        end
         assert column_exists?(table_name, :user_id, :string)
       end
 
       def test_deletes_reference_id_column
-        remove_reference table_name, :supplier
+        connection.ddl_batch do
+          remove_reference table_name, :supplier
+        end
         assert_not column_exists?(table_name, :supplier_id, :string)
       end
 
       def test_deletes_reference_id_index
-        remove_reference table_name, :supplier
+        connection.ddl_batch do
+          remove_reference table_name, :supplier
+        end
         assert_not index_exists?(table_name, :supplier_id)
       end
 
       def test_does_not_delete_reference_type_column
         with_polymorphic_column do
-          remove_reference table_name, :supplier
+          connection.ddl_batch do
+            remove_reference table_name, :supplier
+          end
 
           assert_not column_exists?(table_name, :supplier_id, :string)
           assert column_exists?(table_name, :supplier_type, :string)
@@ -110,20 +138,26 @@ module ActiveRecord
       end
 
       def test_add_belongs_to_alias
-        add_belongs_to table_name, :user
+        connection.ddl_batch do
+          add_belongs_to table_name, :user
+        end
         assert column_exists?(table_name, :user_id, :integer)
       end
 
       def test_remove_belongs_to_alias
-        remove_belongs_to table_name, :supplier
+        connection.ddl_batch do
+          remove_belongs_to table_name, :supplier
+        end
         assert_not column_exists?(table_name, :supplier_id, :integer)
       end
 
       private
 
       def with_polymorphic_column
-        add_column table_name, :supplier_type, :string
-        add_index table_name, [:supplier_id, :supplier_type]
+        connection.ddl_batch do
+          add_column table_name, :supplier_type, :string
+          add_index table_name, [:supplier_id, :supplier_type]
+        end
 
         yield
       end

--- a/acceptance/cases/migration/rename_column_test.rb
+++ b/acceptance/cases/migration/rename_column_test.rb
@@ -33,7 +33,11 @@ module ActiveRecord
 
         connection.create_table(:rename_column_comments) do |t|
           t.string :comment
-          t.references :rename_column_post, index: true, foreign_key: true
+          # The Spanner ActiveRecord adapter does not support creating an index on a column that also has a foreign key,
+          # as Cloud Spanner automatically creates a managed index for the foreign key. The index is therefore created
+          # separately.
+          t.references :rename_column_post, foreign_key: true
+          t.index :rename_column_post_id
         end
 
         RenameColumnPost.reset_column_information

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.4"
-  spec.add_runtime_dependency "activerecord", "~> 6.1.4"
+  spec.add_runtime_dependency "activerecord", "~> 6.1.0"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Rails ActiveRecord connector for Google Spanner Database}
   spec.description   = %q{Rails ActiveRecord connector for Google Spanner Database}
-  spec.homepage      = "https://github.com/orijtech/spanner-activerecord"
+  spec.homepage      = "https://github.com/googleapis/ruby-spanner-activerecord"
   spec.license       = "MIT"
 
   # Specify which files should be added to the gem when it is released.
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.4"
-  spec.add_runtime_dependency "activerecord", "~> 6.0.3.4"
+  spec.add_runtime_dependency "activerecord", "~> 6.1.4"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.4"
-  spec.add_runtime_dependency "activerecord", "~> 6.1.0"
+  spec.add_runtime_dependency "activerecord", "~> 6.1.4"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -190,6 +190,7 @@ module ActiveRecord
                      .convert_active_model_type_to_spanner(bind.type)
             end
             [
+              # Generates binds for named parameters in the format `@p1, @p2, ...`
               "p#{i + 1}", type
             ]
           end.to_h
@@ -199,7 +200,6 @@ module ActiveRecord
             value = type.serialize bind.value, :dml if type.respond_to?(:serialize) && type.method(:serialize).arity < 0
             value = type.serialize bind.value if type.respond_to?(:serialize) && type.method(:serialize).arity >= 0
 
-            # ["#{v.name}_#{i + 1}", value]
             ["p#{i + 1}", value]
           end.to_h
           [types, params]
@@ -241,7 +241,8 @@ module ActiveRecord
           )
         end
 
-        COMMENT_REGEX = %r{(?:--.*\n)*|/\*(?:[^*]|\*[^/])*\*/}m.freeze
+        COMMENT_REGEX = %r{(?:--.*\n)*|/\*(?:[^*]|\*[^/])*\*/}m.freeze \
+            unless defined? ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX
         COMMENT_REGEX = ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX \
             if defined? ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX
 

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -15,29 +15,28 @@ module ActiveRecord
         def execute sql, name = nil, binds = []
           statement_type = sql_statement_type sql
 
-          if preventing_writes? && statement_type == :dml
+          if preventing_writes? && (statement_type == :dml || statement_type == :ddl)
             raise ActiveRecord::ReadOnlyError(
               "Write query attempted while in readonly mode: #{sql}"
             )
           end
 
           if statement_type == :ddl
-            @connection.ddl_statements << sql
-            return
-          end
+            execute_ddl sql
+          else
+            transaction_required = statement_type == :dml
+            materialize_transactions
 
-          transaction_required = statement_type == :dml
-          materialize_transactions
-
-          log sql, name do
-            types, params = to_types_and_params binds
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              if transaction_required
-                transaction do
+            log sql, name do
+              types, params = to_types_and_params binds
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                if transaction_required
+                  transaction do
+                    @connection.execute_query sql, params: params, types: types
+                  end
+                else
                   @connection.execute_query sql, params: params, types: types
                 end
-              else
-                @connection.execute_query sql, params: params, types: types
               end
             end
           end
@@ -176,15 +175,26 @@ module ActiveRecord
         # Translates binds to Spanner types and params.
         def to_types_and_params binds
           types = binds.enum_for(:each_with_index).map do |bind, i|
+            type = :INT64
+            if bind.respond_to?(:type)
+              type = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+                       .convert_active_model_type_to_spanner(bind.type)
+            end
             [
-              "#{bind.name}_#{i + 1}",
-              ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                .convert_active_model_type_to_spanner(bind.type)
+              # "#{bind.name}_#{i + 1}",
+              "p#{i + 1}", type
             ]
           end.to_h
-          params = binds.enum_for(:each_with_index).map do |v, i|
-            value = v.type.method(:serialize).arity < 0 ? v.type.serialize(v.value, :dml) : v.type.serialize(v.value)
-            ["#{v.name}_#{i + 1}", value]
+          params = binds.enum_for(:each_with_index).map do |bind, i|
+            type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
+            if type.respond_to?(:serialize)
+              value = type.method(:serialize).arity < 0 ? type.serialize(bind.value, :dml) : type.serialize(bind.value)
+            else
+              value = bind
+            end
+
+            # ["#{v.name}_#{i + 1}", value]
+            ["p#{i + 1}", value]
           end.to_h
           [types, params]
         end
@@ -211,20 +221,34 @@ module ActiveRecord
           unless arel.ast.wheres.empty?
             raise "A delete mutation can only be created without a WHERE clause"
           end
+          table_name = arel.ast.relation.name if arel.ast.relation.is_a?(Arel::Table)
+          table_name = arel.ast.relation.left.name if arel.ast.relation.is_a?(Arel::Nodes::JoinSource)
+          unless table_name
+            raise "Could not find table for delete mutation"
+          end
 
           Google::Cloud::Spanner::V1::Mutation.new(
             delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
-              table: arel.ast.relation.name,
+              table: table_name,
               key_set: { all: true }
             )
           )
         end
 
-        DDL_REGX = ActiveRecord::ConnectionAdapters::AbstractAdapter
-                   .build_read_query_regexp(:create, :alter, :drop).freeze
+        if defined? ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX
+          COMMENT_REGEX = ActiveRecord::ConnectionAdapters::AbstractAdapter::COMMENT_REGEX
+        else
+          COMMENT_REGEX = %r{(?:--.*\n)*|/\*(?:[^*]|\*[^/])*\*/}m
+        end
 
-        DML_REGX = ActiveRecord::ConnectionAdapters::AbstractAdapter
-                   .build_read_query_regexp(:insert, :delete, :update).freeze
+        def self.build_sql_statement_regexp(*parts) # :nodoc:
+          parts = parts.map { |part| /#{part}/i }
+          /\A(?:[\(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
+        end
+
+        DDL_REGX = build_sql_statement_regexp(:create, :alter, :drop).freeze
+
+        DML_REGX = build_sql_statement_regexp(:insert, :delete, :update).freeze
 
         def sql_statement_type sql
           case sql

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -7,7 +7,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Spanner
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < SchemaCreation
         private
 
         # rubocop:disable Naming/MethodName, Metrics/AbcSize
@@ -79,7 +79,7 @@ module ActiveRecord
         end
 
         def visit_DropIndexDefinition o
-          "DROP INDEX #{quote_column_name o.name}"
+          "DROP INDEX #{quote_table_name o.name}"
         end
 
         def visit_IndexDefinition o

--- a/lib/active_record/connection_adapters/spanner/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_definitions.rb
@@ -58,8 +58,10 @@ module ActiveRecord
             **options
           @name = name
           @polymorphic = polymorphic
-          @index = index
           @foreign_key = foreign_key
+          # Only add an index if there is no foreign key, as Cloud Spanner will automatically add a managed index when
+          # a foreign key is added.
+          @index = index unless foreign_key
           @type = type
           @options = options
 

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -158,7 +158,6 @@ module ActiveRecord
         end
 
         def _remove_columns table_name, *column_names
-          # def remove_columns table_name, *column_names
           if column_names.empty?
             raise ArgumentError, "You must specify at least one column name. "\
               "Example: remove_columns(:people, :first_name)"

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -189,7 +189,7 @@ module ActiveRecord
         m.register_type "DATE", Type::Date.new
         m.register_type "FLOAT64", Type::Float.new
         m.register_type "NUMERIC", Type::Decimal.new
-        m.register_type "INT64", Type::Integer.new({ limit: 8 })
+        m.register_type "INT64", Type::Integer.new(limit: 8)
         register_class_with_limit m, %r{^STRING}i, Type::String
         m.register_type "TIMESTAMP", ActiveRecord::Type::Spanner::Time.new
 

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -113,7 +113,7 @@ module ActiveRecord
       alias reconnect! reset!
 
       # Spanner Connection API
-      delegate :ddl_batch, :start_batch_ddl, :abort_batch, :run_batch, to: :@connection
+      delegate :ddl_batch, :ddl_batch?, :start_batch_ddl, :abort_batch, :run_batch, to: :@connection
 
       def current_spanner_transaction
         @connection.current_transaction

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -73,8 +73,6 @@ module ActiveRecord
       include Spanner::SchemaStatements
 
       def initialize connection, logger, connection_options, config
-        # Use prepared statements by default if the user has not specified anything else.
-        # config[:prepared_statements] = config[:prepared_statements].nil? ? true : config[:prepared_statements]
         super connection, logger, config
         @connection_options = connection_options
       end

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -74,7 +74,7 @@ module ActiveRecord
 
       def initialize connection, logger, connection_options, config
         # Use prepared statements by default if the user has not specified anything else.
-        config[:prepared_statements] = config[:prepared_statements].nil? ? true : config[:prepared_statements]
+        # config[:prepared_statements] = config[:prepared_statements].nil? ? true : config[:prepared_statements]
         super connection, logger, config
         @connection_options = connection_options
       end
@@ -189,7 +189,7 @@ module ActiveRecord
         m.register_type "DATE", Type::Date.new
         m.register_type "FLOAT64", Type::Float.new
         m.register_type "NUMERIC", Type::Decimal.new
-        m.register_type "INT64", Type::Integer.new(limit: 8)
+        m.register_type "INT64", Type::Integer.new({ limit: 8 })
         register_class_with_limit m, %r{^STRING}i, Type::String
         m.register_type "TIMESTAMP", ActiveRecord::Type::Spanner::Time.new
 

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -5,6 +5,12 @@
 # https://opensource.org/licenses/MIT.
 
 module ActiveRecord
+  class TableMetadata # :nodoc:
+    # This attr_reader is private in ActiveRecord 6.0.x and public in 6.1.x. This makes sure it is always available in
+    # the Spanner adapter.
+    attr_reader :arel_table
+  end
+
   class Base
     # Creates an object (or multiple objects) and saves it to the database. This method will use mutations instead
     # of DML if there is no active transaction, or if the active transaction has been created with the option
@@ -92,7 +98,7 @@ module ActiveRecord
       values.each_pair do |k, v|
         type = metadata.type k
         serialized_values << (type.method(:serialize).arity < 0 ? type.serialize(v, :mutation) : type.serialize(v))
-        columns << metadata.arel_attribute(k).name
+        columns << metadata.arel_table[k].name
       end
       [columns, Google::Protobuf::Value.new(list_value:
         Google::Protobuf::ListValue.new(
@@ -143,7 +149,7 @@ module ActiveRecord
           type = metadata.type k
           has_serialize_options = type.method(:serialize).arity < 0
           all_serialized_values << (has_serialize_options ? type.serialize(v, :mutation) : type.serialize(v))
-          all_columns << metadata.arel_attribute(k).name
+          all_columns << metadata.arel_table[k].name
         end
       end
       [all_columns, Google::Protobuf::Value.new(list_value:

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -135,7 +135,16 @@ module ActiveRecordSpannerAdapter
       rescue StandardError
         abort_batch
         raise
+      ensure
+        @ddl_batch = nil
       end
+    end
+
+    ##
+    # Returns true if this connection is currently executing a DDL batch, and otherwise false.
+    def ddl_batch?
+      return true if @ddl_batch
+      false
     end
 
     ##

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -17,7 +17,9 @@ module Arel # :nodoc: all
       BIND_BLOCK = proc { |i| "@p#{i}" }
       private_constant :BIND_BLOCK
 
-      def bind_block; BIND_BLOCK; end
+      def bind_block
+        BIND_BLOCK
+      end
 
       # rubocop:disable Naming/MethodName
       def visit_Arel_Nodes_BindParam o, collector

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -14,15 +14,21 @@ module Arel # :nodoc: all
 
       private
 
+      BIND_BLOCK = proc { |i| "@p#{i}" }
+      private_constant :BIND_BLOCK
+
+      def bind_block; BIND_BLOCK; end
+
       # rubocop:disable Naming/MethodName
       def visit_Arel_Nodes_BindParam o, collector
         # Do not generate a query parameter if the value should be set to the PENDING_COMMIT_TIMESTAMP(), as that is
         # not supported as a parameter value by Cloud Spanner.
         return collector << "PENDING_COMMIT_TIMESTAMP()" \
           if o.value.type.is_a?(ActiveRecord::Type::Spanner::Time) && o.value.value == :commit_timestamp
+        collector.add_bind(o.value, &bind_block)
 
-        @index += 1
-        collector.add_bind(o.value) { "@#{o.value.name}_#{@index}" }
+        # @index += 1
+        # collector.add_bind(o.value) { "@#{o.value.name}_#{@index}" }
       end
       # rubocop:enable Naming/MethodName
     end

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -28,9 +28,6 @@ module Arel # :nodoc: all
         return collector << "PENDING_COMMIT_TIMESTAMP()" \
           if o.value.type.is_a?(ActiveRecord::Type::Spanner::Time) && o.value.value == :commit_timestamp
         collector.add_bind(o.value, &bind_block)
-
-        # @index += 1
-        # collector.add_bind(o.value) { "@#{o.value.name}_#{@index}" }
       end
       # rubocop:enable Naming/MethodName
     end

--- a/test/activerecord_spanner_adapter_test.rb
+++ b/test/activerecord_spanner_adapter_test.rb
@@ -9,7 +9,7 @@ require "test_helper"
 describe ActiveRecordSpannerAdapter do
   describe "#version" do
     it "check gem has a version number" do
-      ActiveRecordSpannerAdapter::VERSION.wont_be_nil
+      _(ActiveRecordSpannerAdapter::VERSION).wont_be_nil
     end
   end
 end

--- a/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
@@ -68,7 +68,7 @@ module TestInterleavedTables
     def test_find_album
       # Selecting a single album should only use the albumid column, and not the singerid column that is technically also
       # part of the primary key.
-      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1)
       album = Album.find 1
       refute_nil album.albumid, "albumid should not be nil"
@@ -76,7 +76,7 @@ module TestInterleavedTables
     end
 
     def test_create_album
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @singerid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_singers_result(1)
       singer = Singer.find 1
 
@@ -102,7 +102,7 @@ module TestInterleavedTables
     end
 
     def test_update_album
-      sql_album = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      sql_album = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql_album, TestInterleavedTables::create_random_albums_result(1)
       album = Album.find 1
 
@@ -127,7 +127,7 @@ module TestInterleavedTables
     end
 
     def test_destroy_album
-      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1)
       album = Album.find 1
       album.destroy
@@ -160,7 +160,7 @@ module TestInterleavedTables
     def test_find_track
       # Selecting a single album should only use the trackid column, and not the singerid and albumid columns that are
       # technically also part of the primary key.
-      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_tracks_result(1)
       track = Track.find 1
       refute_nil track.trackid, "trackid should not be nil"
@@ -169,9 +169,9 @@ module TestInterleavedTables
     end
 
     def test_create_track
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @singerid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`singerid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_singers_result(1, 1)
-      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @albumid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `albums`.* FROM `albums` WHERE `albums`.`albumid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_albums_result(1, 1, 1)
       album = Album.find 1
 
@@ -201,7 +201,7 @@ module TestInterleavedTables
     end
 
     def test_update_track
-      sql_track = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      sql_track = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql_track, TestInterleavedTables::create_random_tracks_result(1, 1, 1, 1)
       track = Track.find 1
 
@@ -230,7 +230,7 @@ module TestInterleavedTables
     end
 
     def test_destroy_track
-      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @trackid_1 LIMIT @LIMIT_2"
+      sql = "SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`trackid` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, TestInterleavedTables::create_random_tracks_result(1, 1, 2, 3)
       track = Track.find 1
       track.destroy

--- a/test/activerecord_spanner_mock_server/aborted_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/aborted_transaction_test.rb
@@ -115,13 +115,13 @@ module MockServerTests
     end
 
     def register_insert_singer_result
-      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
+      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@p1, @p2, @p3)"
       @mock.put_statement_result sql, StatementResult.new(1)
       sql
     end
 
     def register_singer_find_by_id_result
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
       sql
     end

--- a/test/activerecord_spanner_mock_server/optimistic_locking_test.rb
+++ b/test/activerecord_spanner_mock_server/optimistic_locking_test.rb
@@ -23,8 +23,8 @@ module MockServerTests
       request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }.first
       assert request
       # Ensure that the update statement sets the new lock version to 3 and verifies that the current value is 2.
-      assert_equal "3", request.params["lock_version_2"]
-      assert_equal "2", request.params["lock_version_4"]
+      assert_equal "3", request.params["p2"]
+      assert_equal "2", request.params["p4"]
     end
 
     def test_versioned_update_using_dml_stale_object
@@ -42,8 +42,8 @@ module MockServerTests
 
       request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }.first
       assert request
-      assert_equal "4", request.params["lock_version_2"]
-      assert_equal "3", request.params["lock_version_4"]
+      assert_equal "4", request.params["p2"]
+      assert_equal "3", request.params["p4"]
     end
 
     def test_versioned_delete_using_dml
@@ -58,7 +58,7 @@ module MockServerTests
 
       request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }.first
       assert request
-      assert_equal "2", request.params["lock_version_2"]
+      assert_equal "2", request.params["p2"]
     end
 
     def test_versioned_delete_using_dml_stale_object
@@ -75,7 +75,7 @@ module MockServerTests
 
       request = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == delete_sql }.first
       assert request
-      assert_equal "3", request.params["lock_version_2"]
+      assert_equal "3", request.params["p2"]
     end
 
     def test_versioned_update_using_implicit_transaction
@@ -276,27 +276,27 @@ module MockServerTests
 
     def register_insert_versioned_singer_result
       sql = "INSERT INTO `versioned_singers` (`first_name`, `last_name`, `lock_version`, `id`) " \
-            "VALUES (@first_name_1, @last_name_2, @lock_version_3, @id_4)"
+            "VALUES (@p1, @p2, @p3, @p4)"
       @mock.put_statement_result sql, StatementResult.new(1)
       sql
     end
 
     def register_update_versioned_singer_result update_count
-      sql = "UPDATE `versioned_singers` SET `last_name` = @last_name_1, `lock_version` = @lock_version_2 " \
-            "WHERE `versioned_singers`.`id` = @id_3 AND `versioned_singers`.`lock_version` = @lock_version_4"
+      sql = "UPDATE `versioned_singers` SET `last_name` = @p1, `lock_version` = @p2 " \
+            "WHERE `versioned_singers`.`id` = @p3 AND `versioned_singers`.`lock_version` = @p4"
       @mock.put_statement_result sql, StatementResult.new(update_count)
       sql
     end
 
     def register_delete_versioned_singer_result update_count
       sql = "DELETE FROM `versioned_singers` " \
-            "WHERE `versioned_singers`.`id` = @id_1 AND `versioned_singers`.`lock_version` = @lock_version_2"
+            "WHERE `versioned_singers`.`id` = @p1 AND `versioned_singers`.`lock_version` = @p2"
       @mock.put_statement_result sql, StatementResult.new(update_count)
       sql
     end
 
     def register_versioned_singer_find_by_id_result lock_version
-      sql = "SELECT `versioned_singers`.* FROM `versioned_singers` WHERE `versioned_singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      sql = "SELECT `versioned_singers`.* FROM `versioned_singers` WHERE `versioned_singers`.`id` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1, lock_version)
       sql
     end

--- a/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
@@ -84,7 +84,7 @@ module MockServerTests
     end
 
     def register_singer_find_by_id_result
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
       sql
     end

--- a/test/activerecord_spanner_mock_server/session_not_found_test.rb
+++ b/test/activerecord_spanner_mock_server/session_not_found_test.rb
@@ -130,13 +130,13 @@ module MockServerTests
     end
 
     def register_insert_singer_result
-      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@first_name_1, @last_name_2, @id_3)"
+      sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@p1, @p2, @p3)"
       @mock.put_statement_result sql, StatementResult.new(1)
       sql
     end
 
     def register_singer_find_by_id_result
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @id_1 LIMIT @LIMIT_2"
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2"
       @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
       sql
     end

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -600,7 +600,7 @@ module MockServerTests
     end
 
     def test_pdml
-      update_sql = "UPDATE `singers` SET `last_name` = @last_name_1 WHERE TRUE"
+      update_sql = "UPDATE `singers` SET `last_name` = @p1 WHERE TRUE"
       @mock.put_statement_result update_sql, StatementResult.new(1)
 
       Singer.transaction isolation: :pdml do

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -16,6 +16,8 @@ require_relative "models/track"
 module TestMigrationsWithMockServer
   # Tests executing a simple migration on a mock Spanner server.
   class SpannerMigrationsMockServerTest < Minitest::Test
+    VERSION_6_1_0 = Gem::Version.create('6.1.0')
+
     def setup
       super
       @server = GRPC::RpcServer.new
@@ -30,6 +32,7 @@ module TestMigrationsWithMockServer
       end
       @server.wait_till_running
       # Register INFORMATION_SCHEMA queries on the mock server.
+      register_empty_select_tables_result "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=''"
       register_schema_migrations_table_result
       register_schema_migrations_columns_result
       register_ar_internal_metadata_table_result
@@ -55,6 +58,10 @@ module TestMigrationsWithMockServer
       super
     end
 
+    def with_change_table table_name
+      yield ActiveRecord::Base.connection.update_table_definition(table_name, ActiveRecord::Base.connection)
+    end
+
     def test_execute_migrations
       context = ActiveRecord::MigrationContext.new(
         "#{Dir.pwd}/test/migrations_with_mock_server/db/migrate",
@@ -70,17 +77,17 @@ module TestMigrationsWithMockServer
       ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
       assert_equal 3, ddl_requests.length
       assert_equal 1, ddl_requests[0].statements.length
-      assert ddl_requests[0].statements[0].starts_with? "CREATE TABLE `schema_migrations`"
+      assert ddl_requests[0].statements[0].start_with? "CREATE TABLE `schema_migrations`"
       assert_equal 1, ddl_requests[1].statements.length
-      assert ddl_requests[1].statements[0].starts_with? "CREATE TABLE `ar_internal_metadata`"
+      assert ddl_requests[1].statements[0].start_with? "CREATE TABLE `ar_internal_metadata`"
       # The actual migration should be executed as one batch.
       assert_equal 5, ddl_requests[2].statements.length
       assert_equal(
         "CREATE TABLE `singers` (`singerid` INT64 NOT NULL, `first_name` STRING(200), `last_name` STRING(MAX)) PRIMARY KEY (`singerid`)",
             ddl_requests[2].statements[0]
       )
-      assert ddl_requests[2].statements[1].starts_with? "CREATE TABLE `albums`"
-      assert ddl_requests[2].statements[2].starts_with? "ALTER TABLE `albums` ADD CONSTRAINT"
+      assert ddl_requests[2].statements[1].start_with? "CREATE TABLE `albums`"
+      assert ddl_requests[2].statements[2].start_with? "ALTER TABLE `albums` ADD CONSTRAINT"
       assert_equal "ALTER TABLE `singers` ADD COLUMN `place_of_birth` STRING(MAX)", ddl_requests[2].statements[3]
       assert_equal(
         "CREATE TABLE `albums_singers` (`singer_id` INT64 NOT NULL, `album_id` INT64 NOT NULL) PRIMARY KEY (`singer_id`, `album_id`)",
@@ -319,6 +326,488 @@ module TestMigrationsWithMockServer
       assert_equal expectedDdl, ddl_requests[2].statements[0]
     end
 
+    def test_references_column_type_adds_column_and_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='albums'"
+      register_single_select_tables_result select_table_sql, "albums"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_column_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_column_sql
+
+      [:references, :belongs_to].each do |method|
+        ActiveRecord::Base.connection.ddl_batch do
+          with_change_table :albums do |t|
+            t.method(method).call :singer
+          end
+        end
+
+        ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+        assert_equal 1, ddl_requests.length
+        assert_equal 2, ddl_requests[0].statements.length
+        assert_equal "ALTER TABLE `albums` ADD COLUMN `singer_id` INT64", ddl_requests[0].statements[0]
+        # ActiveRecord by default does not create a FOREIGN KEY CONSTRAINT when it creates a reference.
+        assert_equal "CREATE INDEX `index_albums_on_singer_id` ON `albums` (`singer_id`)", ddl_requests[0].statements[1]
+        @database_admin_mock.requests.clear
+      end
+    end
+
+    def test_references_column_adds_foreign_key_and_no_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='albums'"
+      register_single_select_tables_result select_table_sql, "albums"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_column_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_column_sql
+
+      [:references, :belongs_to].each do |method|
+        ActiveRecord::Base.connection.ddl_batch do
+          with_change_table :albums do |t|
+            # The `index: true` below will be ignored by the Spanner adapter, because Cloud Spanner automatically creates
+            # a managed index for a foreign key. Creating an additional non-managed index would only cause additional
+            # writes and no performance gain.
+            t.method(method).call :singer, foreign_key: true, index: true
+          end
+        end
+
+        ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+        assert_equal 1, ddl_requests.length
+        assert_equal 2, ddl_requests[0].statements.length
+        assert_equal "ALTER TABLE `albums` ADD COLUMN `singer_id` INT64", ddl_requests[0].statements[0]
+        fk_def = "ALTER TABLE `albums` ADD CONSTRAINT `fk_rails_df791b93c8`\n"
+        fk_def << "FOREIGN KEY (`singer_id`)\n"
+        fk_def << "  REFERENCES `singers` (`id`)\n"
+        assert_equal fk_def, ddl_requests[0].statements[1]
+        @database_admin_mock.requests.clear
+      end
+    end
+
+    def test_remove_references_column_removes_index_and_column
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='albums'"
+      register_single_select_tables_result select_table_sql, "albums"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' AND SPANNER_IS_MANAGED=FALSE"
+      register_single_select_indexes_result select_index_sql, "index_albums_on_singer_id"
+      select_all_indexes_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_single_select_indexes_result select_all_indexes_sql, "index_albums_on_singer_id"
+      select_index_column_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_index_columns_result select_index_column_sql, "index_albums_on_singer_id", "singer_id"
+      select_all_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_index_columns_result select_all_index_columns_sql, "index_albums_on_singer_id", "singer_id"
+      select_fk_sql = "SELECT cc.table_name AS to_table,\n"
+      select_fk_sql << "       cc.column_name AS primary_key,\n"
+      select_fk_sql << "       fk.column_name as column,\n"
+      select_fk_sql << "       fk.constraint_name AS name,\n"
+      select_fk_sql << "       rc.update_rule AS on_update,\n"
+      select_fk_sql << "       rc.delete_rule AS on_delete\n"
+      select_fk_sql << "FROM information_schema.referential_constraints rc\n"
+      select_fk_sql << "INNER JOIN information_schema.key_column_usage fk ON rc.constraint_name = fk.constraint_name\n"
+      select_fk_sql << "INNER JOIN information_schema.constraint_column_usage cc ON rc.constraint_name = cc.constraint_name\n"
+      select_fk_sql << "WHERE fk.table_name = 'albums'\n"
+      select_fk_sql << "  AND fk.constraint_schema = ''\n"
+      register_empty_select_foreign_key_result select_fk_sql
+
+      [:remove_references, :remove_belongs_to].each do |method|
+        ActiveRecord::Base.connection.ddl_batch do
+          with_change_table :albums do |t|
+            t.method(method).call :singer
+          end
+        end
+
+        # The migration should first drop the index on the column and then drop the column.
+        ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+        assert_equal 1, ddl_requests.length
+        assert_equal 2, ddl_requests[0].statements.length
+        assert_equal "DROP INDEX `index_albums_on_singer_id`", ddl_requests[0].statements[0]
+        assert_equal "ALTER TABLE `albums` DROP COLUMN `singer_id`", ddl_requests[0].statements[1]
+        @database_admin_mock.requests.clear
+      end
+    end
+
+    def test_remove_references_column_removes_foreign_key_and_column
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='albums'"
+      register_single_select_tables_result select_table_sql, "albums"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_all_indexes_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_all_indexes_sql
+      select_index_column_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_albums_on_singer_id' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_column_sql
+      select_all_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='albums' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_all_index_columns_sql
+      select_fk_sql = "SELECT cc.table_name AS to_table,\n"
+      select_fk_sql << "       cc.column_name AS primary_key,\n"
+      select_fk_sql << "       fk.column_name as column,\n"
+      select_fk_sql << "       fk.constraint_name AS name,\n"
+      select_fk_sql << "       rc.update_rule AS on_update,\n"
+      select_fk_sql << "       rc.delete_rule AS on_delete\n"
+      select_fk_sql << "FROM information_schema.referential_constraints rc\n"
+      select_fk_sql << "INNER JOIN information_schema.key_column_usage fk ON rc.constraint_name = fk.constraint_name\n"
+      select_fk_sql << "INNER JOIN information_schema.constraint_column_usage cc ON rc.constraint_name = cc.constraint_name\n"
+      select_fk_sql << "WHERE fk.table_name = 'albums'\n"
+      select_fk_sql << "  AND fk.constraint_schema = ''\n"
+      register_single_select_foreign_key_result select_fk_sql, "singers", "singer_id", "singer_id", "fk_albums_singer"
+
+      [:remove_references, :remove_belongs_to].each do |method|
+        ActiveRecord::Base.connection.ddl_batch do
+          with_change_table :albums do |t|
+            t.method(method).call :singer
+          end
+        end
+
+        # The migration should first drop the index on the column and then drop the column.
+        ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+        assert_equal 1, ddl_requests.length
+        assert_equal 2, ddl_requests[0].statements.length
+        assert_equal "ALTER TABLE `albums` DROP CONSTRAINT `fk_albums_singer`", ddl_requests[0].statements[0]
+        assert_equal "ALTER TABLE `albums` DROP COLUMN `singer_id`", ddl_requests[0].statements[1]
+        @database_admin_mock.requests.clear
+      end
+    end
+
+    def test_references_column_with_polymorphic_adds_type
+      index_name = ActiveRecord::gem_version < VERSION_6_1_0 \
+                     ? "index_singers_on_person_type_and_person_id"
+                     : "index_singers_on_person"
+
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "albums"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='#{index_name}' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_column_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='#{index_name}' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_column_sql
+
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.references :person, polymorphic: true
+        end
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 3, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `person_type` STRING(255)", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `person_id` INT64", ddl_requests[0].statements[1]
+      assert_equal "CREATE INDEX `#{index_name}` ON `singers` (`person_type`, `person_id`)", ddl_requests[0].statements[2]
+    end
+
+    def test_references_column_with_polymorphic_and_foreign_key_fails
+      err = assert_raises do
+        with_change_table :singers do |t|
+          t.references :person, polymorphic: true, foreign_key: true
+        end
+      end
+      assert err&.message&.include? "Cannot add a foreign key to a polymorphic relation"
+    end
+
+    def test_integer_creates_integer_column
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.integer :foo, :bar
+        end
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `foo` INT64", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `bar` INT64", ddl_requests[0].statements[1]
+    end
+
+    def test_bigint_creates_integer_column
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.bigint :foo, :bar
+        end
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `foo` INT64", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `bar` INT64", ddl_requests[0].statements[1]
+    end
+
+    def test_string_creates_string_column
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.string :foo, :bar
+        end
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `foo` STRING(MAX)", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `bar` STRING(MAX)", ddl_requests[0].statements[1]
+    end
+
+    def test_drop_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_TYPE='INDEX' AND SPANNER_IS_MANAGED=FALSE"
+      register_single_select_indexes_result select_index_sql, "full_name-index"
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_index_columns_result select_index_columns_sql, "full_name-index", "full_name"
+
+      with_change_table :singers do |t|
+        t.remove_index :full_name
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+
+      expectedDdl = "DROP INDEX `full_name-index`"
+      assert_equal expectedDdl, ddl_requests[0].statements[0]
+    end
+
+    def test_drop_index_with_name
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_TYPE='INDEX' AND SPANNER_IS_MANAGED=FALSE"
+      register_single_select_indexes_result select_index_sql, "some-index"
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_index_columns_result select_index_columns_sql, "some-index", "some-column"
+
+      with_change_table :singers do |t|
+        t.remove_index name: "some-index"
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+
+      expectedDdl = "DROP INDEX `some-index`"
+      assert_equal expectedDdl, ddl_requests[0].statements[0]
+    end
+
+    def test_column_creates_column
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.column :age, :integer
+        end
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `age` INT64", ddl_requests[0].statements[0]
+    end
+
+    def test_column_creates_column_with_options
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.column :age, :integer, null: false
+        end
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      # Note that Cloud Spanner does currently not support adding a NOT NULL column to an existing table. It does
+      # however allow altering an existing column to from nullable to NOT NULL. This migration therefore generates two
+      # commands.
+      assert_equal 2, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `age` INT64", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` ALTER COLUMN `age` INT64 NOT NULL", ddl_requests[0].statements[1]
+    end
+
+    def test_column_creates_column_with_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.column :age, :integer, index: true
+        end
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+
+      assert_equal "ALTER TABLE `singers` ADD COLUMN `age` INT64", ddl_requests[0].statements[0]
+      assert_equal "CREATE INDEX `index_singers_on_age` ON `singers` (`age`)", ddl_requests[0].statements[1]
+    end
+
+    def test_index_creates_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      with_change_table :singers do |t|
+        t.index :age
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "CREATE INDEX `index_singers_on_age` ON `singers` (`age`)", ddl_requests[0].statements[0]
+    end
+
+    def test_index_creates_index_with_options
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_singers_on_age' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      with_change_table :singers do |t|
+        t.index :age, unique: true
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "CREATE UNIQUE INDEX `index_singers_on_age` ON `singers` (`age`)", ddl_requests[0].statements[0]
+    end
+
+    def test_rename_index_renames_index
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_full_name' AND SPANNER_IS_MANAGED=FALSE"
+      register_single_select_indexes_result select_index_sql, "index_full_name"
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='index_full_name' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_index_columns_result select_index_columns_sql, "index_full_name", "full_name"
+
+      ActiveRecord::Base.connection.ddl_batch do
+        with_change_table :singers do |t|
+          t.rename_index :index_full_name, :index_singers_full_name
+        end
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+      # Cloud Spanner does not support renaming an index, so the index is dropped and recreated.
+      assert_equal "DROP INDEX `index_full_name`", ddl_requests[0].statements[0]
+      assert_equal "CREATE INDEX `index_singers_full_name` ON `singers` (`full_name`)", ddl_requests[0].statements[1]
+    end
+
+    def test_remove_drops_single_column
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+      select_fk_sql = "SELECT cc.table_name AS to_table,\n"
+      select_fk_sql << "       cc.column_name AS primary_key,\n"
+      select_fk_sql << "       fk.column_name as column,\n"
+      select_fk_sql << "       fk.constraint_name AS name,\n"
+      select_fk_sql << "       rc.update_rule AS on_update,\n"
+      select_fk_sql << "       rc.delete_rule AS on_delete\n"
+      select_fk_sql << "FROM information_schema.referential_constraints rc\n"
+      select_fk_sql << "INNER JOIN information_schema.key_column_usage fk ON rc.constraint_name = fk.constraint_name\n"
+      select_fk_sql << "INNER JOIN information_schema.constraint_column_usage cc ON rc.constraint_name = cc.constraint_name\n"
+      select_fk_sql << "WHERE fk.table_name = 'singers'\n"
+      select_fk_sql << "  AND fk.constraint_schema = ''\n"
+      register_empty_select_foreign_key_result select_fk_sql
+
+      with_change_table :singers do |t|
+        t.remove :age
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` DROP COLUMN `age`", ddl_requests[0].statements[0]
+    end
+
+    def test_remove_drops_multiple_columns
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+      select_fk_sql = "SELECT cc.table_name AS to_table,\n"
+      select_fk_sql << "       cc.column_name AS primary_key,\n"
+      select_fk_sql << "       fk.column_name as column,\n"
+      select_fk_sql << "       fk.constraint_name AS name,\n"
+      select_fk_sql << "       rc.update_rule AS on_update,\n"
+      select_fk_sql << "       rc.delete_rule AS on_delete\n"
+      select_fk_sql << "FROM information_schema.referential_constraints rc\n"
+      select_fk_sql << "INNER JOIN information_schema.key_column_usage fk ON rc.constraint_name = fk.constraint_name\n"
+      select_fk_sql << "INNER JOIN information_schema.constraint_column_usage cc ON rc.constraint_name = cc.constraint_name\n"
+      select_fk_sql << "WHERE fk.table_name = 'singers'\n"
+      select_fk_sql << "  AND fk.constraint_schema = ''\n"
+      register_empty_select_foreign_key_result select_fk_sql
+      with_change_table :singers do |t|
+        t.remove :age, :full_name
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 2, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` DROP COLUMN `age`", ddl_requests[0].statements[0]
+      assert_equal "ALTER TABLE `singers` DROP COLUMN `full_name`", ddl_requests[0].statements[1]
+    end
+
+    def test_change_changes_column
+      select_column_sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='singers' AND COLUMN_NAME='picture' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_columns_result select_column_sql, "picture", "BYTES(MAX)"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      with_change_table :singers do |t|
+        t.change :picture, :string
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ALTER COLUMN `picture` STRING(MAX)", ddl_requests[0].statements[0]
+    end
+
+    def test_change_changes_column_with_options
+      select_column_sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='singers' AND COLUMN_NAME='picture' ORDER BY ORDINAL_POSITION ASC"
+      register_single_select_columns_result select_column_sql, "picture", "BYTES(MAX)"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      with_change_table :singers do |t|
+        t.change :picture, :string, null: false
+      end
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      assert_equal 1, ddl_requests.length
+      assert_equal 1, ddl_requests[0].statements.length
+      assert_equal "ALTER TABLE `singers` ALTER COLUMN `picture` STRING(MAX) NOT NULL", ddl_requests[0].statements[0]
+    end
+
+    def test_change_default_not_supported
+      err = assert_raises do
+        with_change_table :singers do |t|
+          t.change_default :picture, :binary
+        end
+      end
+      assert err.is_a? ActiveRecordSpannerAdapter::NotSupportedError
+    end
+
+    def test_creates_polymorphic_index_for_existing_table
+      index_name = "index_singers_on_foo" unless ActiveRecord::gem_version < Gem::Version.create('6.1.0')
+      index_name = "index_singers_on_foo_type_and_foo_id" if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
+
+      select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
+      register_single_select_tables_result select_table_sql, "singers"
+      select_index_sql = "SELECT INDEX_NAME, INDEX_TYPE, IS_UNIQUE, IS_NULL_FILTERED, PARENT_TABLE_NAME, INDEX_STATE FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='#{index_name}' AND SPANNER_IS_MANAGED=FALSE"
+      register_empty_select_indexes_result select_index_sql
+      select_index_columns_sql = "SELECT INDEX_NAME, COLUMN_NAME, COLUMN_ORDERING, ORDINAL_POSITION FROM INFORMATION_SCHEMA.INDEX_COLUMNS WHERE TABLE_NAME='singers' AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '' AND INDEX_NAME='#{index_name}' ORDER BY ORDINAL_POSITION ASC"
+      register_empty_select_index_columns_result select_index_columns_sql
+
+      ActiveRecord::Base.connection.change_table :singers do |t|
+        t.references :foo, polymorphic: true, index: true
+      end
+
+      ddl_requests = @database_admin_mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest) }
+      # The migration simulation also creates the two migration metadata tables.
+      assert_equal 3, ddl_requests.length
+      assert_equal 1, ddl_requests[2].statements.length
+
+      expectedDdl = "CREATE INDEX `#{index_name}` ON `singers` (`foo_type`, `foo_id`)"
+      assert_equal expectedDdl, ddl_requests[2].statements[0]
+    end
+
     def register_schema_migrations_table_result
       sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='schema_migrations'"
       register_empty_select_tables_result sql
@@ -412,7 +901,7 @@ module TestMigrationsWithMockServer
 
     def register_ar_internal_metadata_results
       # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
-      sql = "SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = @key_1 LIMIT @LIMIT_2"
+      sql = "SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = @p1 LIMIT @p2"
 
       key = Google::Cloud::Spanner::V1::StructType::Field.new name: "key", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       value = Google::Cloud::Spanner::V1::StructType::Field.new name: "value", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -427,7 +916,7 @@ module TestMigrationsWithMockServer
     end
 
     def register_ar_internal_metadata_insert_result
-      sql = "INSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES (@key_1, @value_2, @created_at_3, @updated_at_4)"
+      sql = "INSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES (@p1, @p2, @p3, @p4)"
       @mock.put_statement_result sql, StatementResult.new(1)
     end
 
@@ -477,6 +966,30 @@ module TestMigrationsWithMockServer
       @mock.put_statement_result sql, StatementResult.new(result_set)
     end
 
+    def register_single_select_columns_result sql, column_name, spanner_type, is_nullable = true
+      col_column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_column_default = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_DEFAULT", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
+      col_ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push col_column_name, col_spanner_type, col_is_nullable, col_column_default, col_ordinal_position
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: column_name),
+        Google::Protobuf::Value.new(string_value: spanner_type),
+        Google::Protobuf::Value.new(string_value: is_nullable ? "YES" : "NO"),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "1")
+      )
+      result_set.rows.push row
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
     def register_empty_select_indexes_result sql
       col_index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       col_index_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -492,6 +1005,31 @@ module TestMigrationsWithMockServer
       @mock.put_statement_result sql, StatementResult.new(result_set)
     end
 
+    def register_single_select_indexes_result sql, index_name
+      col_index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_index_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_is_unique = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_UNIQUE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BOOL)
+      col_is_null_filtered = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULL_FILTERED", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BOOL)
+      col_parent_table_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "PARENT_TABLE_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_index_state = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_STATE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push col_index_name, col_index_type, col_is_unique, col_is_null_filtered, col_parent_table_name, col_index_state
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: index_name),
+        Google::Protobuf::Value.new(string_value: "INDEX"),
+        Google::Protobuf::Value.new(bool_value: false),
+        Google::Protobuf::Value.new(bool_value: false),
+        Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+        Google::Protobuf::Value.new(string_value: "READ_WRITE"),
+      )
+      result_set.rows.push row
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
     def register_empty_select_index_columns_result sql
       col_index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       col_column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -501,6 +1039,67 @@ module TestMigrationsWithMockServer
       metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
       metadata.row_type.fields.push col_index_name, col_column_name, col_column_ordering, col_ordinal_position
       result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_single_select_index_columns_result sql, index_name, column_name
+      col_index_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "INDEX_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_column_ordering = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_ORDERING", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_ordinal_position = Google::Cloud::Spanner::V1::StructType::Field.new name: "ORDINAL_POSITION", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::INT64)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push col_index_name, col_column_name, col_column_ordering, col_ordinal_position
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: index_name),
+        Google::Protobuf::Value.new(string_value: column_name),
+        Google::Protobuf::Value.new(string_value: "ASC"),
+        Google::Protobuf::Value.new(string_value: "1"),
+      )
+      result_set.rows.push row
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_empty_select_foreign_key_result sql
+      col_to_table = Google::Cloud::Spanner::V1::StructType::Field.new name: "to_table", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_primary_key = Google::Cloud::Spanner::V1::StructType::Field.new name: "primary_key", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_column = Google::Cloud::Spanner::V1::StructType::Field.new name: "column", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "name", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_on_update = Google::Cloud::Spanner::V1::StructType::Field.new name: "on_update", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_on_delete = Google::Cloud::Spanner::V1::StructType::Field.new name: "on_delete", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push col_to_table, col_primary_key, col_column, col_name, col_on_update, col_on_delete
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+
+      @mock.put_statement_result sql, StatementResult.new(result_set)
+    end
+
+    def register_single_select_foreign_key_result sql, to_table, pk_column_name, fk_column_name, constraint_name
+      col_to_table = Google::Cloud::Spanner::V1::StructType::Field.new name: "to_table", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_primary_key = Google::Cloud::Spanner::V1::StructType::Field.new name: "primary_key", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_column = Google::Cloud::Spanner::V1::StructType::Field.new name: "column", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "name", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_on_update = Google::Cloud::Spanner::V1::StructType::Field.new name: "on_update", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+      col_on_delete = Google::Cloud::Spanner::V1::StructType::Field.new name: "on_delete", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
+
+      metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
+      metadata.row_type.fields.push col_to_table, col_primary_key, col_column, col_name, col_on_update, col_on_delete
+      result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
+      row = Google::Protobuf::ListValue.new
+      row.values.push(
+        Google::Protobuf::Value.new(string_value: to_table),
+        Google::Protobuf::Value.new(string_value: pk_column_name),
+        Google::Protobuf::Value.new(string_value: fk_column_name),
+        Google::Protobuf::Value.new(string_value: constraint_name),
+        Google::Protobuf::Value.new(string_value: "NO_ACTION"),
+        Google::Protobuf::Value.new(string_value: "NO_ACTION")
+      )
+      result_set.rows.push row
 
       @mock.put_statement_result sql, StatementResult.new(result_set)
     end
@@ -523,7 +1122,7 @@ module TestMigrationsWithMockServer
       end
       @mock.put_statement_result sql, StatementResult.new(result_set)
 
-      update_sql = "INSERT INTO `schema_migrations` (`version`) VALUES (@version_1)"
+      update_sql = "INSERT INTO `schema_migrations` (`version`) VALUES (@p1)"
       @mock.put_statement_result update_sql, StatementResult.new(1)
     end
   end

--- a/test/mock_server/spanner_mock_server.rb
+++ b/test/mock_server/spanner_mock_server.rb
@@ -161,7 +161,7 @@ class SpannerMockServer < Google::Cloud::Spanner::V1::Spanner::Service
   def get_statement_result sql
     unless @statement_results.has_key? sql
       @statement_results.each do |key,value|
-        if key.ends_with?("%") && sql.starts_with?(key.chop)
+        if key.end_with?("%") && sql.start_with?(key.chop)
           return value
         end
       end


### PR DESCRIPTION
This PR ensures that the adapter works with all supported versions of Ruby and ActiveRecord.. This PR does not introduce any new features. The biggest change that is 'visible' to a user is that the generated queries will no longer use parameters in the form `@id_1, @name_2, ..., @param_name_n`, but will no use parameters that only contain an index (`@p1, @p2, ..., @pn`). The reason for that change is that some versions of ActiveRecord generate queries without a name for the parameter available for the adapter.

The main list of changes are:
- Adds test matrices for all supported Ruby [2.5, 2.6, 2.7, 3.0] and ActiveRecord [6.0.x, 6.1.x] versions. A subset of all supported combinations are tested during presubmits. All supported combinations are tested during nightly builds.
- Adds nightly builds, including a nightly build that will also execute all migration tests on production.
- Migration tests are modified to __always__ use DDL batches when possible.
- Some (public) method definitions are conditioned based on whether the version is `< 6.1.0` or not, as there are a couple of API changes between versions 6.0.x and 6.1.x.