### PR TITLE
fix: add_foreign_key def was changed in 6.0.3

### DIFF
--- a/acceptance/cases/migration/command_recorder_test.rb
+++ b/acceptance/cases/migration/command_recorder_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       include SpannerAdapter::Migration::TestHelper
 
       VERSION_6_1_0 = Gem::Version.create('6.1.0')
+      VERSION_6_0_3 = Gem::Version.create "6.0.3"
 
       def setup
         skip_test_table_create!
@@ -314,7 +315,11 @@ module ActiveRecord
 
       def test_invert_add_foreign_key
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
-        assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
+        if ActiveRecord.gem_version < VERSION_6_0_3
+          assert_equal [:remove_foreign_key, [:dogs, :people]], enable
+        else
+          assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
+        end
       end
 
       def test_invert_remove_foreign_key
@@ -324,7 +329,11 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
-        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
+        if ActiveRecord.gem_version < VERSION_6_0_3
+          assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
+        else
+          assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
+        end
       end
 
       def test_invert_remove_foreign_key_with_column
@@ -334,7 +343,11 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column_and_name
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
-        assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
+        if ActiveRecord.gem_version < VERSION_6_0_3
+          assert_equal [:remove_foreign_key, [:dogs, { name: "fk" }]], enable
+        else
+          assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
+        end
       end
 
       def test_invert_remove_foreign_key_with_column_and_name

--- a/acceptance/cases/migration/command_recorder_test.rb
+++ b/acceptance/cases/migration/command_recorder_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
     class CommandRecorderTest < SpannerAdapter::TestCase
       include SpannerAdapter::Migration::TestHelper
 
-      VERSION_6_1_0 = Gem::Version.create('6.1.0')
+      VERSION_6_1_0 = Gem::Version.create "6.1.0"
       VERSION_6_0_3 = Gem::Version.create "6.0.3"
 
       def setup

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -21,6 +21,7 @@ module ActiveRecord
       #
       module SchemaStatements
         VERSION_6_1_0 = Gem::Version.create "6.1.0"
+        VERSION_6_0_3 = Gem::Version.create "6.0.3"
 
         def current_database
           @connection.database_id
@@ -337,7 +338,17 @@ module ActiveRecord
           end
         end
 
-        def add_foreign_key from_table, to_table, options = {}
+        if ActiveRecord.gem_version < VERSION_6_0_3
+          def add_foreign_key from_table, to_table, options = {}
+            _add_foreign_key from_table, to_table, **options
+          end
+        else
+          def add_foreign_key from_table, to_table, **options
+            _add_foreign_key from_table, to_table, **options
+          end
+        end
+
+        def _add_foreign_key from_table, to_table, **options
           options = foreign_key_options from_table, to_table, options
           at = create_alter_table from_table
           at.add_foreign_key to_table, options
@@ -487,7 +498,7 @@ module ActiveRecord
             remove_foreign_key table_name, name: fk.name
             options = fk.options.except :column, :name
             options[:column] = new_column_name
-            add_foreign_key table_name, fk.to_table, options
+            add_foreign_key table_name, fk.to_table, **options
           end
         end
 


### PR DESCRIPTION
There was a change in the method definition for `add_foreign_key` between versions [6.0.2](https://github.com/rails/rails/blob/f675cb30ce813a99b52b139a93e048330922fd9a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L991) and [6.0.3](https://github.com/rails/rails/blob/b738f1930f3c82f51741ef7241c1fee691d7deb2/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L991) in ActiveRecord.

Should fix the build error in https://github.com/googleapis/ruby-spanner-activerecord/runs/3101059202?check_suite_focus=true
