### PR TITLE
build: skip acceptance tests on prod when secrets are not available

### DIFF
--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,8 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
-    name: acceptance tests on production
-    if: ${{ github.repository_owner == ‘googleapis’ }}
+    if: ${{ github.repository == 'googleapis/ruby-spanner-activerecord' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -5,8 +5,20 @@ on:
   pull_request:
 name: acceptance tests on production
 jobs:
+  check-env:
+    outputs:
+      my-key: ${{ steps.project-id.outputs.defined }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: project-id
+      env:
+        GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      if: "${{ env.GCP_PROJECT_ID != '' }}"
+      run: echo "::set-output name=defined::true"
+
   test:
-    if: secrets.GCP_PROJECT_ID
+    needs: [check-env]
+    if: needs.check-env.outputs.project-id == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,6 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
+    if: github.owner == ‘cloudspannerecosystem’
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -18,7 +18,7 @@ jobs:
 
   test:
     needs: [check-env]
-    if: needs.check-env.outputs.project-id == 'true'
+    if: needs.check-env.outputs.defined == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,7 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
-    if: github.owner == ‘googleapis’
+    if: ${{ github.repository_owner == ‘googleapis’ }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,6 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
+    name: acceptance tests on production
     if: ${{ github.repository_owner == ‘googleapis’ }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,7 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
-    if: ${{ github.repository == 'googleapis/ruby-spanner-activerecord' }}
+    if: ${{ secrets.GCP_PROJECT_ID != '' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,7 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
-    if: ${{ secrets.GCP_PROJECT_ID != '' }}
+    if: secrets.GCP_PROJECT_ID
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -6,7 +6,7 @@ on:
 name: acceptance tests on production
 jobs:
   test:
-    if: github.owner == ‘cloudspannerecosystem’
+    if: github.owner == ‘googleapis’
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -7,7 +7,7 @@ name: acceptance tests on production
 jobs:
   check-env:
     outputs:
-      my-key: ${{ steps.project-id.outputs.defined }}
+      has-key: ${{ steps.project-id.outputs.defined }}
     runs-on: ubuntu-latest
     steps:
     - id: project-id
@@ -18,7 +18,7 @@ jobs:
 
   test:
     needs: [check-env]
-    if: needs.check-env.outputs.defined == 'true'
+    if: needs.check-env.outputs.has-key == 'true'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Only run acceptance tests on production when the PR actually has access to the GitHub secrets. This basically restricts the step to only PRs and pushes that are made directly to this repo, instead of in forks.

See #122 for an example of the same change from a fork. That PR skips the acceptance tests on production step as it does not have access to the secrets.