### PR TITLE
feat: support JSON data type

### DIFF
--- a/acceptance/cases/type/all_types_test.rb
+++ b/acceptance/cases/type/all_types_test.rb
@@ -65,7 +65,7 @@ module ActiveRecord
           assert_equal StringIO.new("bytes").read, record.col_bytes.read
           assert_equal ::Date.new(2021, 6, 23), record.col_date
           assert_equal ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00").utc, record.col_timestamp.utc
-          assert_equal Hash({kind=>"user_renamed", change=>%w[jack john]}),
+          assert_equal ({"kind" => "user_renamed", "change" => %w[jack john]}),
                        record.col_json unless ENV["SPANNER_EMULATOR_HOST"]
 
           assert_equal ["string1", nil, "string2"], record.col_array_string
@@ -80,9 +80,9 @@ module ActiveRecord
                             nil, \
                             ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")].map { |timestamp| timestamp&.utc },
                        record.col_array_timestamp.map { |timestamp| timestamp&.utc}
-          assert_equal [Hash({kind=>"user_renamed", change=>%w[jack john]}), \
+          assert_equal [{"kind" => "user_renamed", "change" => %w[jack john]}, \
                         nil, \
-                        Hash({kind=>"user_renamed", change=>%w[alice meredith]})],
+                        {"kind" => "user_renamed", "change" => %w[alice meredith]}],
                        record.col_array_json unless ENV["SPANNER_EMULATOR_HOST"]
         end
       end
@@ -122,7 +122,7 @@ module ActiveRecord
           assert_equal StringIO.new("new bytes").read, record.col_bytes.read
           assert_equal ::Date.new(2021, 6, 28), record.col_date
           assert_equal ::Time.new(2021, 6, 28, 11, 22, 21, "+02:00").utc, record.col_timestamp.utc
-          assert_equal Hash({kind=>"user_created", change=>%w[jack alice]}),
+          assert_equal ({"kind" => "user_created", "change" => %w[jack alice]}),
                        record.col_json unless ENV["SPANNER_EMULATOR_HOST"]
 
           assert_equal ["new string 1", "new string 2"], record.col_array_string
@@ -134,7 +134,7 @@ module ActiveRecord
                        record.col_array_bytes.map(&:read)
           assert_equal [::Date.new(2021, 6, 28)], record.col_array_date
           assert_equal [::Time.utc(2020, 12, 31, 0, 0, 0)], record.col_array_timestamp.map(&:utc)
-          assert_equal [Hash({kind=>"user_created", change=>%w[jack alice]})],
+          assert_equal [{"kind" => "user_created", "change" => %w[jack alice]}],
                        record.col_array_json unless ENV["SPANNER_EMULATOR_HOST"]
         end
       end

--- a/acceptance/cases/type/all_types_test.rb
+++ b/acceptance/cases/type/all_types_test.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         AllTypes.create col_string: "string", col_int64: 100, col_float64: 3.14, col_numeric: 6.626, col_bool: true,
           col_bytes: StringIO.new("bytes"), col_date: ::Date.new(2021, 6, 23),
           col_timestamp: ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"),
-          col_json: ENV["SPANNER_EMULATOR_HOST"] ? { kind: "user_renamed", change: %w[jack john]} : "",
+          col_json: ENV["SPANNER_EMULATOR_HOST"] ? "" : { kind: "user_renamed", change: %w[jack john]},
           col_array_string: ["string1", nil, "string2"],
           col_array_int64: [100, nil, 200],
           col_array_float64: [3.14, nil, 2.0/3.0],
@@ -40,10 +40,9 @@ module ActiveRecord
           col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24)],
           col_array_timestamp: [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), nil, \
                                 ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")],
-          col_array_json: ENV["SPANNER_EMULATOR_HOST"] ?
+          col_array_json: ENV["SPANNER_EMULATOR_HOST"] ? [""] : \
                             [{ kind: "user_renamed", change: %w[jack john]}, nil, \
-                             { kind: "user_renamed", change: %w[alice meredith]}] : \
-                             [""]
+                             { kind: "user_renamed", change: %w[alice meredith]}]
       end
 
       def test_create_record
@@ -99,7 +98,7 @@ module ActiveRecord
                           col_bool: false, col_bytes: StringIO.new("new bytes"),
                           col_date: ::Date.new(2021, 6, 28),
                           col_timestamp: ::Time.new(2021, 6, 28, 11, 22, 21, "+02:00"),
-                          col_json: ENV["SPANNER_EMULATOR_HOST"] ? { kind: "user_created", change: %w[jack alice]} : "",
+                          col_json: ENV["SPANNER_EMULATOR_HOST"] ? "" : { kind: "user_created", change: %w[jack alice]},
                           col_array_string: ["new string 1", "new string 2"],
                           col_array_int64: [300, 200, 100],
                           col_array_float64: [1.1, 2.2, 3.3],
@@ -109,8 +108,8 @@ module ActiveRecord
                           col_array_date: [::Date.new(2021, 6, 28)],
                           col_array_timestamp: [::Time.utc(2020, 12, 31, 0, 0, 0)],
                           col_array_json: ENV["SPANNER_EMULATOR_HOST"] ?
-                                            [{ kind: "user_created", change: %w[jack alice]}] : \
-                                            [""]
+                                            [""] : \
+                                            [{ kind: "user_created", change: %w[jack alice]}]
           end
 
           # Verify that the record was updated.

--- a/acceptance/cases/type/json_test.rb
+++ b/acceptance/cases/type/json_test.rb
@@ -20,8 +20,8 @@ module ActiveRecord
       def test_set_json
         return if ENV["SPANNER_EMULATOR_HOST"]
 
-        expected_hash = Hash({key: "value", array_key: %w[value1 value2]})
-        record = TestTypeModel.new details: expected_hash
+        expected_hash = {"key"=>"value", "array_key"=>%w[value1 value2]}
+        record = TestTypeModel.new details: {key: "value", array_key: %w[value1 value2]}
 
         assert_equal expected_hash, record.details
 

--- a/acceptance/cases/type/json_test.rb
+++ b/acceptance/cases/type/json_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActiveRecord
+  module Type
+    class DateTest < SpannerAdapter::TestCase
+      include SpannerAdapter::Types::TestHelper
+
+      def test_convert_to_sql_type
+        assert_equal "JSON", connection.type_to_sql(:json)
+      end
+
+      def test_set_json
+        return if ENV["SPANNER_EMULATOR_HOST"]
+
+        expected_hash = Hash({key: "value", array_key: %w[value1 value2]})
+        record = TestTypeModel.new details: expected_hash
+
+        assert_equal expected_hash, record.details
+
+        record.save!
+        record.reload
+        assert_equal expected_hash, record.details
+      end
+    end
+  end
+end

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -17,6 +17,8 @@ ActiveRecord::Schema.define do
       t.column :col_bytes, :binary
       t.column :col_date, :date
       t.column :col_timestamp, :datetime
+      t.column :col_json, :json unless ENV["SPANNER_EMULATOR_HOST"]
+      t.column :col_json, :string if ENV["SPANNER_EMULATOR_HOST"]
 
       t.column :col_array_string, :string, array: true
       t.column :col_array_int64, :bigint, array: true
@@ -26,6 +28,8 @@ ActiveRecord::Schema.define do
       t.column :col_array_bytes, :binary, array: true
       t.column :col_array_date, :date, array: true
       t.column :col_array_timestamp, :datetime, array: true
+      t.column :col_array_json, :json, array: true unless ENV["SPANNER_EMULATOR_HOST"]
+      t.column :col_array_json, :string, array: true if ENV["SPANNER_EMULATOR_HOST"]
     end
 
     create_table :firms do |t|

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -208,6 +208,7 @@ module SpannerAdapter
           t.date :start_date
           t.datetime :start_datetime
           t.time :start_time
+          t.json :details unless ENV["SPANNER_EMULATOR_HOST"]
         end
       end
 

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.4"
+  spec.add_dependency "google-cloud-spanner", "~> 2.10"
   spec.add_runtime_dependency "activerecord", "~> 6.1.4"
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -65,7 +65,8 @@ module ActiveRecord
         time:         { name: "TIMESTAMP" },
         date:         { name: "DATE" },
         binary:       { name: "BYTES", limit: "MAX" },
-        boolean:      { name: "BOOL" }
+        boolean:      { name: "BOOL" },
+        json:         { name: "JSON" }
       }.freeze
 
       include Spanner::Quoting
@@ -190,6 +191,7 @@ module ActiveRecord
         m.register_type "INT64", Type::Integer.new(limit: 8)
         register_class_with_limit m, %r{^STRING}i, Type::String
         m.register_type "TIMESTAMP", ActiveRecord::Type::Spanner::Time.new
+        m.register_type "JSON", ActiveRecord::Type::Json.new
 
         register_array_types m
       end
@@ -203,6 +205,7 @@ module ActiveRecord
         m.register_type %r{^ARRAY<INT64>}i, Type::Spanner::Array.new(Type::Integer.new(limit: 8))
         m.register_type %r{^ARRAY<STRING\((MAX|d+)\)>}i, Type::Spanner::Array.new(Type::String.new)
         m.register_type %r{^ARRAY<TIMESTAMP>}i, Type::Spanner::Array.new(ActiveRecord::Type::Spanner::Time.new)
+        m.register_type %r{^ARRAY<JSON>}i, Type::Spanner::Array.new(ActiveRecord::Type::Json.new)
       end
 
       def extract_limit sql_type

--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -23,6 +23,7 @@ module ActiveRecord
           when ActiveModel::Type::Decimal then :NUMERIC
           when ActiveModel::Type::DateTime, ActiveModel::Type::Time, ActiveRecord::Type::Spanner::Time then :TIMESTAMP
           when ActiveModel::Type::Date then :DATE
+          when ActiveRecord::Type::Json then :JSON
           when ActiveRecord::Type::Spanner::Array then [convert_active_model_type_to_spanner(type.element_type)]
           end
         end

--- a/test/activerecord_spanner_adapter/connection_mock_server_test.rb
+++ b/test/activerecord_spanner_adapter/connection_mock_server_test.rb
@@ -69,6 +69,7 @@ class SpannerMockServerConnectionTest
         _(row.fields[:ColBytes]).must_equal :BYTES
         _(row.fields[:ColDate]).must_equal :DATE
         _(row.fields[:ColTimestamp]).must_equal :TIMESTAMP
+        _(row.fields[:ColJson]).must_equal :JSON
 
         _(row.fields[0]).must_equal :BOOL
         _(row.fields[1]).must_equal :INT64
@@ -78,6 +79,7 @@ class SpannerMockServerConnectionTest
         _(row.fields[5]).must_equal :BYTES
         _(row.fields[6]).must_equal :DATE
         _(row.fields[7]).must_equal :TIMESTAMP
+        _(row.fields[8]).must_equal :JSON
         row_count += 1
       end
       connection.disconnect!

--- a/test/activerecord_spanner_adapter/table/column_test.rb
+++ b/test/activerecord_spanner_adapter/table/column_test.rb
@@ -101,4 +101,12 @@ class InformationSchemaTableColumnTest < TestHelper::MockActiveRecordTest
     column = new_table_column type: "TIMESTAMP", limit: 1024
     assert_equal column.spanner_type, "TIMESTAMP"
   end
+
+  def test_spanner_type_for_json
+    column = new_table_column type: "JSON"
+    assert_equal column.spanner_type, "JSON"
+
+    column = new_table_column type: "JSON", limit: 1024
+    assert_equal column.spanner_type, "JSON"
+  end
 end

--- a/test/activerecord_spanner_mock_server/model_helper.rb
+++ b/test/activerecord_spanner_mock_server/model_helper.rb
@@ -392,6 +392,15 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "9")
     )
     result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "col_json"),
+      Google::Protobuf::Value.new(string_value: "JSON"),
+      Google::Protobuf::Value.new(string_value: "YES"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "10")
+    )
+    result_set.rows.push row
 
     row = Google::Protobuf::ListValue.new
     row.values.push(
@@ -399,7 +408,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<STRING(MAX)>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "10")
+      Google::Protobuf::Value.new(string_value: "11")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -408,7 +417,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<INT64>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "11")
+      Google::Protobuf::Value.new(string_value: "12")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -417,7 +426,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<FLOAT64>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "12")
+      Google::Protobuf::Value.new(string_value: "13")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -426,7 +435,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<NUMERIC>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "13")
+      Google::Protobuf::Value.new(string_value: "14")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -435,7 +444,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<BOOL>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "14")
+      Google::Protobuf::Value.new(string_value: "15")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -444,7 +453,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<BYTES(MAX)>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "15")
+      Google::Protobuf::Value.new(string_value: "16")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -453,7 +462,7 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<DATE>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "16")
+      Google::Protobuf::Value.new(string_value: "17")
     )
     result_set.rows.push row
     row = Google::Protobuf::ListValue.new
@@ -462,7 +471,16 @@ module MockServerTests
       Google::Protobuf::Value.new(string_value: "ARRAY<TIMESTAMP>"),
       Google::Protobuf::Value.new(string_value: "YES"),
       Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
-      Google::Protobuf::Value.new(string_value: "17")
+      Google::Protobuf::Value.new(string_value: "18")
+    )
+    result_set.rows.push row
+    row = Google::Protobuf::ListValue.new
+    row.values.push(
+      Google::Protobuf::Value.new(string_value: "col_array_json"),
+      Google::Protobuf::Value.new(string_value: "ARRAY<JSON>"),
+      Google::Protobuf::Value.new(string_value: "YES"),
+      Google::Protobuf::Value.new(null_value: "NULL_VALUE"),
+      Google::Protobuf::Value.new(string_value: "19")
     )
     result_set.rows.push row
 

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -509,6 +509,11 @@ module MockServerTests
           nil,
           "2021-06-24T15:08:21.000000000Z"
         ]), mutation.insert.values[0][value_index += 1]
+      json_list = create_list_value([
+                                      "{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}",
+                                      nil,
+                                      "{\"kind\":\"user_renamed\",\"change\":[\"alice\",\"meredith\"]}"
+                                    ])
       assert_equal create_list_value([
           "{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}",
           nil,

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -437,6 +437,7 @@ module MockServerTests
       AllTypes.create col_string: "string", col_int64: 100, col_float64: 3.14, col_numeric: 6.626, col_bool: true,
                       col_bytes: StringIO.new("bytes"), col_date: ::Date.new(2021, 6, 23),
                       col_timestamp: ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"),
+                      col_json: { kind: "user_renamed", change: %w[jack john]},
                       col_array_string: ["string1", nil, "string2"],
                       col_array_int64: [100, nil, 200],
                       col_array_float64: [3.14, nil, 2.0/3.0],
@@ -445,7 +446,9 @@ module MockServerTests
                       col_array_bytes: [StringIO.new("bytes1"), nil, StringIO.new("bytes2")],
                       col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24)],
                       col_array_timestamp: [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), nil, \
-                                            ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")]
+                                            ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")],
+                      col_array_json: [{ kind: "user_renamed", change: %w[jack john]}, nil, \
+                                       { kind: "user_renamed", change: %w[alice meredith]}]
 
       commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
       assert_equal 1, commit_requests.length
@@ -464,6 +467,7 @@ module MockServerTests
       assert_equal "col_bytes", mutation.insert.columns[col_index += 1]
       assert_equal "col_date", mutation.insert.columns[col_index += 1]
       assert_equal "col_timestamp", mutation.insert.columns[col_index += 1]
+      assert_equal "col_json", mutation.insert.columns[col_index += 1]
 
       assert_equal "col_array_string", mutation.insert.columns[col_index += 1]
       assert_equal "col_array_int64", mutation.insert.columns[col_index += 1]
@@ -473,6 +477,7 @@ module MockServerTests
       assert_equal "col_array_bytes", mutation.insert.columns[col_index += 1]
       assert_equal "col_array_date", mutation.insert.columns[col_index += 1]
       assert_equal "col_array_timestamp", mutation.insert.columns[col_index += 1]
+      assert_equal "col_array_json", mutation.insert.columns[col_index += 1]
 
       value_index = -1
       assert_equal 1, mutation.insert.values.length
@@ -484,6 +489,7 @@ module MockServerTests
       assert_equal Base64.urlsafe_encode64("bytes"), mutation.insert.values[0][value_index += 1]
       assert_equal "2021-06-23", mutation.insert.values[0][value_index += 1]
       assert_equal "2021-06-23T15:08:21.000000000Z", mutation.insert.values[0][value_index += 1]
+      assert_equal "{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}", mutation.insert.values[0][value_index += 1]
 
       assert_equal create_list_value(["string1", nil, "string2"]), mutation.insert.values[0][value_index += 1]
       assert_equal create_list_value(["100", nil, "200"]), mutation.insert.values[0][value_index += 1]
@@ -503,22 +509,29 @@ module MockServerTests
           nil,
           "2021-06-24T15:08:21.000000000Z"
         ]), mutation.insert.values[0][value_index += 1]
+      assert_equal create_list_value([
+          "{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}",
+          nil,
+          "{\"kind\":\"user_renamed\",\"change\":[\"alice\",\"meredith\"]}"
+        ]), mutation.insert.values[0][value_index += 1]
     end
 
     def test_create_all_types_using_dml
       sql = "INSERT INTO `all_types` (`col_string`, `col_int64`, `col_float64`, `col_numeric`, `col_bool`, " \
-            "`col_bytes`, `col_date`, `col_timestamp`, `col_array_string`, `col_array_int64`, `col_array_float64`, "\
-            "`col_array_numeric`, `col_array_bool`, `col_array_bytes`, `col_array_date`, `col_array_timestamp`, `id`) "\
+            "`col_bytes`, `col_date`, `col_timestamp`, `col_json`, `col_array_string`, `col_array_int64`, " \
+            "`col_array_float64`, `col_array_numeric`, `col_array_bool`, `col_array_bytes`, `col_array_date`, "\
+            "`col_array_timestamp`, `col_array_json`, `id`) "\
             "VALUES (@p1, @p2, @p3, @p4, @p5, @p6, " \
             "@p7, @p8, @p9, @p10, @p11, " \
             "@p12, @p13, @p14, @p15, " \
-            "@p16, @p17)"
+            "@p16, @p17, @p18, @p19)"
       @mock.put_statement_result sql, StatementResult.new(1)
 
       AllTypes.transaction do
         AllTypes.create col_string: "string", col_int64: 100, col_float64: 3.14, col_numeric: 6.626, col_bool: true,
                         col_bytes: StringIO.new("bytes"), col_date: ::Date.new(2021, 6, 23),
                         col_timestamp: ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"),
+                        col_json: { kind: "user_renamed", change: %w[jack john]},
                         col_array_string: ["string1", nil, "string2"],
                         col_array_int64: [100, nil, 200],
                         col_array_float64: [3.14, nil, 2.0/3.0],
@@ -527,7 +540,9 @@ module MockServerTests
                         col_array_bytes: [StringIO.new("bytes1"), nil, StringIO.new("bytes2")],
                         col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24)],
                         col_array_timestamp: [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), nil, \
-                                              ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")]
+                                              ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")],
+                        col_array_json: [{ kind: "user_renamed", change: %w[jack john]}, nil, \
+                                         { kind: "user_renamed", change: %w[alice meredith]}]
       end
 
       commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
@@ -553,33 +568,42 @@ module MockServerTests
       assert_equal :DATE, request.param_types["p7"].code
       assert_equal "2021-06-23T15:08:21.000000000Z", request.params["p8"]
       assert_equal :TIMESTAMP, request.param_types["p8"].code
+      assert_equal "{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}", request.params["p9"]
+      assert_equal :JSON, request.param_types["p9"].code
 
-      assert_equal create_list_value(["string1", nil, "string2"]), request.params["p9"]
-      assert_equal :ARRAY, request.param_types["p9"].code
-      assert_equal :STRING, request.param_types["p9"].array_element_type.code
-      assert_equal create_list_value(["100", nil, "200"]), request.params["p10"]
+      assert_equal create_list_value(["string1", nil, "string2"]), request.params["p10"]
       assert_equal :ARRAY, request.param_types["p10"].code
-      assert_equal :INT64, request.param_types["p10"].array_element_type.code
-      assert_equal create_list_value([3.14, nil, 2.0/3.0]), request.params["p11"]
+      assert_equal :STRING, request.param_types["p10"].array_element_type.code
+      assert_equal create_list_value(["100", nil, "200"]), request.params["p11"]
       assert_equal :ARRAY, request.param_types["p11"].code
-      assert_equal :FLOAT64, request.param_types["p11"].array_element_type.code
-      assert_equal create_list_value(["6.626", nil, "3.2"]), request.params["p12"]
+      assert_equal :INT64, request.param_types["p11"].array_element_type.code
+      assert_equal create_list_value([3.14, nil, 2.0/3.0]), request.params["p12"]
       assert_equal :ARRAY, request.param_types["p12"].code
-      assert_equal :NUMERIC, request.param_types["p12"].array_element_type.code
-      assert_equal create_list_value([true, nil, false]), request.params["p13"]
+      assert_equal :FLOAT64, request.param_types["p12"].array_element_type.code
+      assert_equal create_list_value(["6.626", nil, "3.2"]), request.params["p13"]
       assert_equal :ARRAY, request.param_types["p13"].code
-      assert_equal :BOOL, request.param_types["p13"].array_element_type.code
-      assert_equal create_list_value([Base64.urlsafe_encode64("bytes1"), nil, Base64.urlsafe_encode64("bytes2")]),
-                   request.params["p14"]
+      assert_equal :NUMERIC, request.param_types["p13"].array_element_type.code
+      assert_equal create_list_value([true, nil, false]), request.params["p14"]
       assert_equal :ARRAY, request.param_types["p14"].code
-      assert_equal :BYTES, request.param_types["p14"].array_element_type.code
-      assert_equal create_list_value(["2021-06-23", nil, "2021-06-24"]), request.params["p15"]
+      assert_equal :BOOL, request.param_types["p14"].array_element_type.code
+      assert_equal create_list_value([Base64.urlsafe_encode64("bytes1"), nil, Base64.urlsafe_encode64("bytes2")]),
+                   request.params["p15"]
       assert_equal :ARRAY, request.param_types["p15"].code
-      assert_equal :DATE, request.param_types["p15"].array_element_type.code
-      assert_equal create_list_value(["2021-06-23T15:08:21.000000000Z", nil, "2021-06-24T15:08:21.000000000Z"]),
-                   request.params["p16"]
+      assert_equal :BYTES, request.param_types["p15"].array_element_type.code
+      assert_equal create_list_value(["2021-06-23", nil, "2021-06-24"]), request.params["p16"]
       assert_equal :ARRAY, request.param_types["p16"].code
-      assert_equal :TIMESTAMP, request.param_types["p16"].array_element_type.code
+      assert_equal :DATE, request.param_types["p16"].array_element_type.code
+      assert_equal create_list_value(["2021-06-23T15:08:21.000000000Z", nil, "2021-06-24T15:08:21.000000000Z"]),
+                   request.params["p17"]
+      assert_equal :ARRAY, request.param_types["p17"].code
+      assert_equal :TIMESTAMP, request.param_types["p17"].array_element_type.code
+      assert_equal create_list_value(["2021-06-23T15:08:21.000000000Z", nil, "2021-06-24T15:08:21.000000000Z"]),
+                   request.params["p17"]
+      assert_equal :ARRAY, request.param_types["p18"].code
+      assert_equal :JSON, request.param_types["p18"].array_element_type.code
+      assert_equal create_list_value(["{\"kind\":\"user_renamed\",\"change\":[\"jack\",\"john\"]}", nil, \
+                                      "{\"kind\":\"user_renamed\",\"change\":[\"alice\",\"meredith\"]}"]),
+                   request.params["p18"]
     end
 
     def test_delete_associated_records

--- a/test/migrations_with_mock_server/db/migrate/03_create_all_native_migration_types.rb
+++ b/test/migrations_with_mock_server/db/migrate/03_create_all_native_migration_types.rb
@@ -21,6 +21,7 @@ class CreateAllNativeMigrationTypes < ActiveRecord::Migration[6.0]
       t.column :col_date, :date
       t.column :col_binary, :binary
       t.column :col_boolean, :boolean
+      t.column :col_json, :json
 
       t.column :col_array_string, :string, array: true
       t.column :col_array_text, :text, array: true
@@ -34,6 +35,7 @@ class CreateAllNativeMigrationTypes < ActiveRecord::Migration[6.0]
       t.column :col_array_date, :date, array: true
       t.column :col_array_binary, :binary, array: true
       t.column :col_array_boolean, :boolean, array: true
+      t.column :col_array_json, :json, array: true
     end
   end
 end

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -142,11 +142,12 @@ module TestMigrationsWithMockServer
 
       # CREATE TABLE `types_table` (`id` INT64 NOT NULL, `col_string` STRING(MAX), `col_text` STRING(MAX),
       # `col_integer` INT64, `col_bigint` INT64, `col_float` FLOAT64, `col_decimal` FLOAT64, `col_numeric` numeric,
-      # `col_datetime` TIMESTAMP, `col_time` TIMESTAMP, `col_date` DATE, `col_binary` BYTES(MAX), `col_boolean` BOOL
-      # `col_array_string` ARRAY<STRING(MAX)>, `col_array_text` ARRAY<STRING(MAX)>, `col_array_integer` ARRAY<INT64>,
-      # `col_array_bigint` ARRAY<INT64>, `col_array_float` ARRAY<FLOAT64>, `col_array_decimal` ARRAY<FLOAT64>,
-      # `col_array_numeric` ARRAY<NUMERIC>, `col_array_datetime` ARRAY<TIMESTAMP>, `col_array_time` ARRAY<TIMESTAMP>,
-      # `col_array_date` ARRAY<DATE>, `col_array_binary` ARRAY<BYTES(MAX)>, `col_array_boolean` ARRAY<BOOL>,
+      # `col_datetime` TIMESTAMP, `col_time` TIMESTAMP, `col_date` DATE, `col_binary` BYTES(MAX), `col_boolean` BOOL,
+      # `col_json` JSON, `col_array_string` ARRAY<STRING(MAX)>, `col_array_text` ARRAY<STRING(MAX)>,
+      # `col_array_integer` ARRAY<INT64>, `col_array_bigint` ARRAY<INT64>, `col_array_float` ARRAY<FLOAT64>,
+      # `col_array_decimal` ARRAY<FLOAT64>, `col_array_numeric` ARRAY<NUMERIC>, `col_array_datetime` ARRAY<TIMESTAMP>,
+      # `col_array_time` ARRAY<TIMESTAMP>, `col_array_date` ARRAY<DATE>, `col_array_binary` ARRAY<BYTES(MAX)>,
+      # `col_array_boolean` ARRAY<BOOL>, `col_array_json` ARRAY<JSON>
       # ) PRIMARY KEY (`id`)
       expectedDdl = +"CREATE TABLE `types_table` ("
       expectedDdl << "`id` INT64 NOT NULL, "
@@ -162,6 +163,7 @@ module TestMigrationsWithMockServer
       expectedDdl << "`col_date` DATE, "
       expectedDdl << "`col_binary` BYTES(MAX), "
       expectedDdl << "`col_boolean` BOOL, "
+      expectedDdl << "`col_json` JSON, "
       expectedDdl << "`col_array_string` ARRAY<STRING(MAX)>, "
       expectedDdl << "`col_array_text` ARRAY<STRING(MAX)>, "
       expectedDdl << "`col_array_integer` ARRAY<INT64>, "
@@ -173,7 +175,8 @@ module TestMigrationsWithMockServer
       expectedDdl << "`col_array_time` ARRAY<TIMESTAMP>, "
       expectedDdl << "`col_array_date` ARRAY<DATE>, "
       expectedDdl << "`col_array_binary` ARRAY<BYTES(MAX)>, "
-      expectedDdl << "`col_array_boolean` ARRAY<BOOL>) "
+      expectedDdl << "`col_array_boolean` ARRAY<BOOL>, "
+      expectedDdl << "`col_array_json` ARRAY<JSON>) "
       expectedDdl << "PRIMARY KEY (`id`)"
 
       assert_equal expectedDdl, ddl_requests[2].statements[0]

--- a/test/mock_server/spanner_mock_server_test.rb
+++ b/test/mock_server/spanner_mock_server_test.rb
@@ -117,10 +117,10 @@ describe "Spanner Mock Server" do
 
   it "can create a random result set" do
     result = StatementResult.create_random_result 100
-    _(result.result.metadata.row_type.fields.length).must_equal 8
+    _(result.result.metadata.row_type.fields.length).must_equal 9
     _(result.result.rows.length).must_equal 100
     result.each do |partial|
-      _(partial.values.length).must_equal 8 # Number values in partial result set
+      _(partial.values.length).must_equal 9 # Number values in partial result set
     end
   end
 
@@ -132,7 +132,7 @@ describe "Spanner Mock Server" do
     stream = @client.execute_streaming_sql Google::Cloud::Spanner::V1::ExecuteSqlRequest.new session: session.name, sql: sql
     row_count = 0
     stream.each do |partial|
-      _(partial.values.length).must_equal 8 # Number values in partial result set
+      _(partial.values.length).must_equal 9 # Number values in partial result set
       row_count += 1
     end
     _(row_count).must_equal 100

--- a/test/mock_server/statement_result.rb
+++ b/test/mock_server/statement_result.rb
@@ -39,10 +39,11 @@ class StatementResult
     col_bytes = Google::Cloud::Spanner::V1::StructType::Field.new name: "ColBytes", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::BYTES)
     col_date = Google::Cloud::Spanner::V1::StructType::Field.new name: "ColDate", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::DATE)
     col_timestamp = Google::Cloud::Spanner::V1::StructType::Field.new name: "ColTimestamp", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::TIMESTAMP)
+    col_json = Google::Cloud::Spanner::V1::StructType::Field.new name: "ColJson", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::JSON)
 
     metadata = Google::Cloud::Spanner::V1::ResultSetMetadata.new row_type: Google::Cloud::Spanner::V1::StructType.new
     metadata.row_type.fields.push(col_bool, col_int64, col_float64, col_numeric, col_string, col_bytes, col_date,
-                                  col_timestamp)
+                                  col_timestamp, col_json)
     result_set = Google::Cloud::Spanner::V1::ResultSet.new metadata: metadata
 
     (1..row_count).each { |i|
@@ -59,7 +60,8 @@ class StatementResult
                                                   SecureRandom.random_number(1..12),
                                                   SecureRandom.random_number(1..28))
         ), 10),
-        random_value_or_null(Google::Protobuf::Value.new(string_value: random_timestamp_string),10)
+        random_value_or_null(Google::Protobuf::Value.new(string_value: random_timestamp_string),10),
+        random_value_or_null(Google::Protobuf::Value.new(string_value: "{\"key\": \"#{SecureRandom.alphanumeric(SecureRandom.random_number(10..200))}\"}"), 10),
       )
       result_set.rows.push row
     }


### PR DESCRIPTION
Adds support for the JSON data type to the ActiveRecord provider.

Note: Acceptance tests for JSON are skipped on the emulator, as the emulator does not yet support this data type. This also means that we cannot yet add a standalone sample for how to use this data type.