### PR TITLE
feat: support stale reads in read-only transactions

### DIFF
--- a/examples/snippets/read-only-transactions/db/schema.rb
+++ b/examples/snippets/read-only-transactions/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,12 +12,12 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -11,7 +11,7 @@ module ActiveRecordSpannerAdapter
     def initialize connection, isolation
       @connection = connection
       @isolation = isolation
-      @committable = true unless [:read_only, :pdml].include?(isolation) || isolation.is_a?(Hash)
+      @committable = ![:read_only, :pdml].include?(isolation) && !isolation.is_a?(Hash)
       @state = :INITIALIZED
       @sequence_number = 0
       @mutations = []

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -11,6 +11,7 @@ module ActiveRecordSpannerAdapter
     def initialize connection, isolation
       @connection = connection
       @isolation = isolation
+      @committable = true unless [:read_only, :pdml].include?(isolation) || isolation.is_a?(Hash)
       @state = :INITIALIZED
       @sequence_number = 0
       @mutations = []
@@ -34,6 +35,16 @@ module ActiveRecordSpannerAdapter
       begin
         @grpc_transaction =
           case @isolation
+          when Hash
+            if @isolation[:timestamp]
+              @connection.session.create_snapshot timestamp: @isolation[:timestamp]
+            elsif @isolation[:staleness]
+              @connection.session.create_snapshot staleness: @isolation[:staleness]
+            elsif @isolation[:strong]
+              @connection.session.create_snapshot strong: true
+            else
+              raise "Invalid snapshot argument: #{@isolation}"
+            end
           when :read_only
             @connection.session.create_snapshot strong: true
           when :pdml
@@ -56,15 +67,14 @@ module ActiveRecordSpannerAdapter
     end
 
     def next_sequence_number
-      @sequence_number += 1 unless @isolation == :read_only
+      @sequence_number += 1 if @committable
     end
 
     def commit
       raise "This transaction is not active" unless active?
 
       begin
-        @connection.session.commit_transaction @grpc_transaction, @mutations \
-            unless [:read_only, :pdml].include? @isolation
+        @connection.session.commit_transaction @grpc_transaction, @mutations if @committable
         @state = :COMMITTED
       rescue Google::Cloud::NotFoundError => e
         if @connection.session_not_found? e
@@ -94,7 +104,7 @@ module ActiveRecordSpannerAdapter
     end
 
     def shoot_and_forget_rollback
-      @connection.session.rollback @grpc_transaction.transaction_id unless @isolation == :read_only
+      @connection.session.rollback @grpc_transaction.transaction_id if @committable
     rescue StandardError # rubocop:disable Lint/HandleExceptions
       # Ignored
     end


### PR DESCRIPTION
Adds support for setting a timestamp bound when executing a read-only transaction. This allows users to use a read-only transaction to read stale data instead of the most recent data, which can be more efficient when direct consistency is not required.