### PR TITLE
feat: support single stale reads

### DIFF
--- a/examples/snippets/stale-reads/README.md
+++ b/examples/snippets/stale-reads/README.md
@@ -1,0 +1,27 @@
+# Sample - Stale reads
+
+Read and query operations outside of a transaction block will by default be executed using a
+single-use read-only transaction with strong timestamp bound. This means that the read is
+guaranteed to return all data that has been committed at the time of the read. It is also possible
+to specify that the Spanner ActiveRecord provider should execute a stale read. This is done by
+specifying an optimizer hint for the read or query operation. The hints that are available are:
+
+* `max_staleness: <seconds>`
+* `exact_staleness: <seconds>`
+* `min_read_timestamp: <timestamp>`
+* `read_timestamp: <timestamp>`
+
+See https://cloud.google.com/spanner/docs/timestamp-bounds for more information on what the
+different timestamp bounds in Cloud Spanner mean.
+
+NOTE: These optimizer hints ONLY work OUTSIDE transactions. See the read-only-transactions
+samples for more information on how to specify a timestamp bound for a read-only transaction.
+
+The sample will automatically start a Spanner Emulator in a docker container and execute the sample
+against that emulator. The emulator will automatically be stopped when the application finishes.
+
+Run the application with the command
+
+```bash
+bundle exec rake run
+```

--- a/examples/snippets/stale-reads/Rakefile
+++ b/examples/snippets/stale-reads/Rakefile
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../config/environment"
+require "sinatra/activerecord/rake"
+
+desc "Sample showing how to execute stale reads on Spanner with ActiveRecord."
+task :run do
+  Dir.chdir("..") { sh "bundle exec rake run[stale-reads]" }
+end

--- a/examples/snippets/stale-reads/application.rb
+++ b/examples/snippets/stale-reads/application.rb
@@ -1,0 +1,63 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "io/console"
+require_relative "../config/environment"
+require_relative "models/singer"
+require_relative "models/album"
+
+class Application
+  def self.run # rubocop:disable Metrics/AbcSize
+    # Get a random album.
+    album = Album.all.sample
+
+    # Get a valid timestamp from the Cloud Spanner server that we can use to specify a timestamp bound.
+    timestamp = ActiveRecord::Base.connection.select_all("SELECT CURRENT_TIMESTAMP AS ts")[0]["ts"]
+
+    # Update the name of the album and then read the version of the album before the update.
+    album.update title: "New title"
+
+    # The timestamp should be specified in the format '2021-09-07T15:22:10.123456789Z'
+    timestamp_string = timestamp.xmlschema 9
+
+    # Read the album at a specific timestamp.
+    album_previous_version = Album.optimizer_hints("read_timestamp: #{timestamp_string}").find_by id: album.id
+    album = album.reload
+
+    puts ""
+    puts "Updated album title: #{album.title}"
+    puts "Previous album version title: #{album_previous_version.title}"
+
+    # Read the same album using a minimum read timestamp. It could be that we get the first version
+    # of the row, but it could also be that we get the updated row.
+    album_min_read_timestamp = Album.optimizer_hints("min_read_timestamp: #{timestamp_string}").find_by id: album.id
+    puts ""
+    puts "Updated album title: #{album.title}"
+    puts "Min-read timestamp title: #{album_min_read_timestamp.title}"
+
+    # Staleness can also be specified as a number of seconds. The number of seconds may contain a fraction.
+    # The following reads the album version at exactly 1.5 seconds ago. That will normally be nil, as the
+    # row did not yet exist at that moment.
+    album_exact_staleness = Album.optimizer_hints("exact_staleness: 1.5").find_by id: album.id
+
+    puts ""
+    puts "Updated album title: #{album.title}"
+    puts "Title 1.5 seconds ago: #{album_exact_staleness&.title}"
+
+    # You can also specify a max staleness. The server will determine the best timestamp to use for the read.
+    album_max_staleness = Album.optimizer_hints("max_staleness: 10").find_by id: album.id
+
+    puts ""
+    puts "Updated album title: #{album.title}"
+    puts "Title somewhere during the last 10 seconds: #{album_max_staleness&.title}"
+
+    puts ""
+    puts "Press any key to end the application"
+    STDIN.getch
+  end
+end
+
+Application.run

--- a/examples/snippets/stale-reads/config/database.yml
+++ b/examples/snippets/stale-reads/config/database.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  pool: 5
+  timeout: 5000

--- a/examples/snippets/stale-reads/db/migrate/01_create_tables.rb
+++ b/examples/snippets/stale-reads/db/migrate/01_create_tables.rb
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateTables < ActiveRecord::Migration[6.0]
+  def change
+    connection.ddl_batch do
+      create_table :singers do |t|
+        t.string :first_name
+        t.string :last_name
+      end
+
+      create_table :albums do |t|
+        t.string :title
+        t.references :singer, index: false, foreign_key: true
+      end
+    end
+  end
+end

--- a/examples/snippets/stale-reads/db/schema.rb
+++ b/examples/snippets/stale-reads/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 1) do
+
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
+    t.string "title"
+    t.integer "singer_id", limit: 8
+  end
+
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+  end
+
+  add_foreign_key "albums", "singers"
+end

--- a/examples/snippets/stale-reads/db/seeds.rb
+++ b/examples/snippets/stale-reads/db/seeds.rb
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../../config/environment.rb"
+require_relative "../models/singer"
+require_relative "../models/album"
+
+first_names = ["Pete", "Alice", "John", "Ethel", "Trudy", "Naomi", "Wendy", "Ruben", "Thomas", "Elly"]
+last_names = ["Wendelson", "Allison", "Peterson", "Johnson", "Henderson", "Ericsson", "Aronson", "Tennet", "Courtou"]
+
+adjectives = ["daily", "happy", "blue", "generous", "cooked", "bad", "open"]
+nouns = ["windows", "potatoes", "bank", "street", "tree", "glass", "bottle"]
+
+5.times do
+  Singer.create first_name: first_names.sample, last_name: last_names.sample
+end
+
+20.times do
+  singer_id = Singer.all.sample.id
+  Album.create title: "#{adjectives.sample} #{nouns.sample}", singer_id: singer_id
+end

--- a/examples/snippets/stale-reads/models/album.rb
+++ b/examples/snippets/stale-reads/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/examples/snippets/stale-reads/models/singer.rb
+++ b/examples/snippets/stale-reads/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -6,10 +6,21 @@
 
 module Arel # :nodoc: all
   module Visitors
+    class StalenessHint
+      attr_reader :value
+
+      def initialize value
+        @value = value
+      end
+    end
+
     class Spanner < Arel::Visitors::ToSql
       def compile node, collector = Arel::Collectors::SQLString.new
-        @index = 0
-        accept(node, collector).value
+        collector.class.module_eval { attr_accessor :hints }
+        collector.hints = {}
+        sql, binds = accept(node, collector).value
+        binds << collector.hints[:staleness] if collector.hints[:staleness]
+        [sql, binds]
       end
 
       private
@@ -22,6 +33,29 @@ module Arel # :nodoc: all
       end
 
       # rubocop:disable Naming/MethodName
+      def visit_Arel_Nodes_OptimizerHints o, collector
+        o.expr.each do |v|
+          if v.start_with? "max_staleness:"
+            collector.hints[:staleness] = \
+              StalenessHint.new max_staleness: v.delete_prefix("max_staleness:").to_f
+          end
+          if v.start_with? "exact_staleness:"
+            collector.hints[:staleness] = \
+              StalenessHint.new exact_staleness: v.delete_prefix("exact_staleness:").to_f
+          end
+          if v.start_with? "min_read_timestamp:"
+            time = Time.xmlschema v.delete_prefix("min_read_timestamp:")
+            collector.hints[:staleness] = \
+              StalenessHint.new min_read_timestamp: time
+          end
+          next unless v.start_with? "read_timestamp:"
+          time = Time.xmlschema v.delete_prefix("read_timestamp:")
+          collector.hints[:staleness] = \
+            StalenessHint.new read_timestamp: time
+        end
+        collector
+      end
+
       def visit_Arel_Nodes_BindParam o, collector
         # Do not generate a query parameter if the value should be set to the PENDING_COMMIT_TIMESTAMP(), as that is
         # not supported as a parameter value by Cloud Spanner.

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -38,15 +38,18 @@ module Arel # :nodoc: all
           if v.start_with? "max_staleness:"
             collector.hints[:staleness] = \
               StalenessHint.new max_staleness: v.delete_prefix("max_staleness:").to_f
+            next
           end
           if v.start_with? "exact_staleness:"
             collector.hints[:staleness] = \
               StalenessHint.new exact_staleness: v.delete_prefix("exact_staleness:").to_f
+            next
           end
           if v.start_with? "min_read_timestamp:"
             time = Time.xmlschema v.delete_prefix("min_read_timestamp:")
             collector.hints[:staleness] = \
               StalenessHint.new min_read_timestamp: time
+            next
           end
           next unless v.start_with? "read_timestamp:"
           time = Time.xmlschema v.delete_prefix("read_timestamp:")

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -35,6 +35,31 @@ module Google
           Convert.timestamp_to_time resp.commit_timestamp
         end
 
+        # Create a single-use transaction selector.
+        def single_use_transaction opts
+          return nil if opts.nil? || opts.empty?
+
+          exact_timestamp = Convert.time_to_timestamp \
+            opts[:timestamp] || opts[:read_timestamp]
+          exact_staleness = Convert.number_to_duration \
+            opts[:staleness] || opts[:exact_staleness]
+          bounded_timestamp = Convert.time_to_timestamp \
+            opts[:bounded_timestamp] || opts[:min_read_timestamp]
+          bounded_staleness = Convert.number_to_duration \
+            opts[:bounded_staleness] || opts[:max_staleness]
+
+          V1::TransactionSelector.new(single_use:
+            V1::TransactionOptions.new(read_only:
+              V1::TransactionOptions::ReadOnly.new({
+                strong: opts[:strong],
+                read_timestamp: exact_timestamp,
+                exact_staleness: exact_staleness,
+                min_read_timestamp: bounded_timestamp,
+                max_staleness: bounded_staleness,
+                return_read_timestamp: true
+              }.delete_if { |_, v| v.nil? })))
+        end
+
         def create_snapshot strong: nil,
                             timestamp: nil, read_timestamp: nil,
                             staleness: nil, exact_staleness: nil

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -39,14 +39,10 @@ module Google
         def self.single_use_transaction opts
           return nil if opts.nil? || opts.empty?
 
-          exact_timestamp = Convert.time_to_timestamp \
-            opts[:timestamp] || opts[:read_timestamp]
-          exact_staleness = Convert.number_to_duration \
-            opts[:staleness] || opts[:exact_staleness]
-          bounded_timestamp = Convert.time_to_timestamp \
-            opts[:bounded_timestamp] || opts[:min_read_timestamp]
-          bounded_staleness = Convert.number_to_duration \
-            opts[:bounded_staleness] || opts[:max_staleness]
+          exact_timestamp = Convert.time_to_timestamp opts[:read_timestamp]
+          exact_staleness = Convert.number_to_duration opts[:exact_staleness]
+          min_read_timestamp = Convert.time_to_timestamp opts[:min_read_timestamp]
+          max_staleness = Convert.number_to_duration opts[:max_staleness]
 
           V1::TransactionSelector.new(single_use:
             V1::TransactionOptions.new(read_only:
@@ -54,8 +50,8 @@ module Google
                 strong: opts[:strong],
                 read_timestamp: exact_timestamp,
                 exact_staleness: exact_staleness,
-                min_read_timestamp: bounded_timestamp,
-                max_staleness: bounded_staleness,
+                min_read_timestamp: min_read_timestamp,
+                max_staleness: max_staleness,
                 return_read_timestamp: true
               }.delete_if { |_, v| v.nil? })))
         end

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -36,7 +36,7 @@ module Google
         end
 
         # Create a single-use transaction selector.
-        def single_use_transaction opts
+        def self.single_use_transaction opts
           return nil if opts.nil? || opts.empty?
 
           exact_timestamp = Convert.time_to_timestamp \

--- a/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/read_only_transaction_test.rb
@@ -170,7 +170,7 @@ module MockServerTests
     def register_singer_find_by_id_result with_hints = false
       res = MockServerTests::create_random_singers_result(1)
       sql = "SELECT  `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2" if with_hints
-      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2" unless  with_hints
+      sql = "SELECT `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2" unless with_hints
       @mock.put_statement_result sql, res
       sql
     end

--- a/test/mock_server/spanner_mock_server.rb
+++ b/test/mock_server/spanner_mock_server.rb
@@ -80,7 +80,7 @@ class SpannerMockServer < Google::Cloud::Spanner::V1::Spanner::Service
   def do_execute_sql request, streaming
     @requests << request
     validate_session request.session
-    validate_transaction request.session, request.transaction.id if request.transaction&.id
+    validate_transaction request.session, request.transaction.id if request.transaction&.id && request.transaction&.id != ""
     result = get_statement_result request.sql
     if result.result_type == StatementResult::EXCEPTION
       raise result.result


### PR DESCRIPTION
Adds support for executing stale reads outside transactions. This feature uses the `optimizer_hints` feature that was introduced in ActiveRecord 6. The specific optimizer hints are not translated into actual hints for Spanner, but are translated into a specific single use transaction option for the query.