### PR TITLE
Fix wrong exception was raised when db:create

### DIFF
--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         @connection.create_database
       rescue Google::Cloud::Error => error
         if error.instance_of? Google::Cloud::AlreadyExistsError
-          raise ActiveRecord::Tasks::DatabaseAlreadyExists
+          raise ActiveRecord::DatabaseAlreadyExists
         end
 
         raise error


### PR DESCRIPTION
## Summary

`activerecord-spanner-adapter` raises `ActiveRecord::Tasks::DatabaseAlreadyExists` when `db:create` was failed, but `ActiveRecord::DatabaseAlreadyExists` is correct.

see: https://api.rubyonrails.org/classes/ActiveRecord/DatabaseAlreadyExists.html