### PR TITLE
feat: add support for query hints

### DIFF
--- a/acceptance/cases/models/query_test.rb
+++ b/acceptance/cases/models/query_test.rb
@@ -142,6 +142,30 @@ module ActiveRecord
 
         assert_equal [post], posts.to_a
       end
+
+      def test_statement_hint
+        post = Post.optimizer_hints("statement_hint: @{USE_ADDITIONAL_PARALLELISM=TRUE}")
+                   .select(:title).to_a.first
+
+        assert_nil post.id
+        assert_equal "Title - 1", post.title
+      end
+
+      def test_table_hint
+        post = Post.optimizer_hints("table_hint: posts@{FORCE_INDEX=_BASE_TABLE}")
+                   .select(:title).to_a.first
+
+        assert_nil post.id
+        assert_equal "Title - 1", post.title
+      end
+
+      def test_join_hint
+        post = Post.joins("inner join @{JOIN_TYPE=HASH_JOIN} comments on posts.id=comments.post_id")
+                   .select(:title).to_a.first
+
+        assert_nil post.id
+        assert_equal "Title - 1", post.title
+      end
     end
   end
 end

--- a/examples/snippets/hints/README.md
+++ b/examples/snippets/hints/README.md
@@ -1,0 +1,19 @@
+# Sample - Query Hints
+
+This example shows how to use query hints Spanner ActiveRecord adapter. Statement hints and
+table hints can be specified using the optimizer_hints method. Join hints must be specified
+in a join string.
+
+See https://cloud.google.com/spanner/docs/query-syntax#sql_syntax for more information on
+the supported query hints.
+
+## Running the Sample
+
+The sample will automatically start a Spanner Emulator in a docker container and execute the sample
+against that emulator. The emulator will automatically be stopped when the application finishes.
+
+Run the application with the command
+
+```bash
+bundle exec rake run
+```

--- a/examples/snippets/hints/Rakefile
+++ b/examples/snippets/hints/Rakefile
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../config/environment"
+require "sinatra/activerecord/rake"
+
+desc "Sample showing how to work with generated columns in ActiveRecord."
+task :run do
+  Dir.chdir("..") { sh "bundle exec rake run[hints]" }
+end

--- a/examples/snippets/hints/application.rb
+++ b/examples/snippets/hints/application.rb
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "io/console"
+require_relative "../config/environment"
+require_relative "models/singer"
+require_relative "models/album"
+
+class Application
+  def self.run
+    puts ""
+    puts "Listing all singers using additional parallelism:"
+    # A statement hint must be prefixed with 'statement_hint:'
+    Singer.optimizer_hints("statement_hint: @{USE_ADDITIONAL_PARALLELISM=TRUE}")
+          .order("last_name, first_name").each do |singer|
+      puts singer.full_name
+    end
+
+    puts ""
+    puts "Listing all singers using the index on full_name:"
+    # All table hints must be prefixed with 'table_hint:'.
+    # Queries may contain multiple table hints.
+    Singer.optimizer_hints("table_hint: singers@{FORCE_INDEX=index_singers_on_full_name}")
+          .order("full_name").each do |singer|
+      puts singer.full_name
+    end
+
+    puts ""
+    puts "Listing all singers with at least one album that starts with 'blue':"
+    # Join hints cannot be specified using an optimizer_hint. Instead, the join can
+    # be specified using a string that includes the join hint.
+    Singer.joins("INNER JOIN @{JOIN_METHOD=HASH_JOIN} albums " \
+                 "on singers.id=albums.singer_id AND albums.title LIKE 'blue%'")
+          .distinct.order("last_name, first_name").each do |singer|
+      puts singer.full_name
+    end
+
+    puts ""
+    puts "Press any key to end the application"
+    STDIN.getch
+  end
+end
+
+Application.run

--- a/examples/snippets/hints/config/database.yml
+++ b/examples/snippets/hints/config/database.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  pool: 5
+  timeout: 5000

--- a/examples/snippets/hints/db/migrate/01_create_tables.rb
+++ b/examples/snippets/hints/db/migrate/01_create_tables.rb
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateTables < ActiveRecord::Migration[6.0]
+  def change
+    connection.ddl_batch do
+      create_table :singers do |t|
+        t.string :first_name, limit: 100
+        t.string :last_name, limit: 200, null: false
+        t.string :full_name, limit: 300, null: false, as: "COALESCE(first_name || ' ', '') || last_name", stored: true
+        t.index [:full_name], name: "index_singers_on_full_name"
+      end
+
+      create_table :albums do |t|
+        t.string :title
+        t.references :singer, index: false, foreign_key: true
+      end
+    end
+  end
+end

--- a/examples/snippets/hints/db/schema.rb
+++ b/examples/snippets/hints/db/schema.rb
@@ -12,10 +12,17 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
+    t.string "title"
+    t.integer "singer_id", limit: 8
+  end
+
   create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name", limit: 100
     t.string "last_name", limit: 200, null: false
     t.string "full_name", limit: 300, null: false
+    t.index ["full_name"], name: "index_singers_on_full_name", order: { full_name: :asc }
   end
 
+  add_foreign_key "albums", "singers"
 end

--- a/examples/snippets/hints/db/seeds.rb
+++ b/examples/snippets/hints/db/seeds.rb
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../../config/environment.rb"
+require_relative "../models/singer"
+require_relative "../models/album"
+
+first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy Ruben Thomas Elly]
+last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson Aronson Tennet Courtou]
+
+adjectives = %w[daily happy blue generous cooked bad open]
+nouns = %w[windows potatoes bank street tree glass bottle]
+
+# This ensures all the records are inserted using one read/write transaction that will use mutations instead of DML.
+ActiveRecord::Base.transaction isolation: :buffered_mutations do
+  singers = []
+  5.times do
+    singers << Singer.create(first_name: first_names.sample, last_name: last_names.sample)
+  end
+
+  albums = []
+  20.times do
+    singer = singers.sample
+    albums << Album.create(title: "#{adjectives.sample} #{nouns.sample}", singer: singer)
+  end
+end

--- a/examples/snippets/hints/models/album.rb
+++ b/examples/snippets/hints/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/examples/snippets/hints/models/singer.rb
+++ b/examples/snippets/hints/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -695,6 +695,94 @@ module MockServerTests
       refute commit_request
     end
 
+    def test_statement_hint
+      sql = " @{USE_ADDITIONAL_PARALLELISM=true, OPTIMIZER_STATISTICS_PACKAGE='stats-package-1'}SELECT  `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      Singer.optimizer_hints("statement_hint: @{USE_ADDITIONAL_PARALLELISM=true, OPTIMIZER_STATISTICS_PACKAGE='stats-package-1'}").find_by(id: 1)
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+    end
+
+    def test_statement_and_staleness_hint
+      sql = " @{USE_ADDITIONAL_PARALLELISM=true}SELECT  `singers`.* FROM `singers` WHERE `singers`.`id` = @p1 LIMIT @p2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      Singer
+        .optimizer_hints("statement_hint: @{USE_ADDITIONAL_PARALLELISM=true}")
+        .optimizer_hints("min_read_timestamp: 2021-09-07T14:33:30.1123Z")
+        .find_by(id: 1)
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+      single_use = execute_sql_request.transaction.single_use
+      assert single_use
+      assert single_use.read_only.return_read_timestamp
+      assert single_use.read_only.min_read_timestamp
+      time = Google::Cloud::Spanner::Convert.time_to_timestamp Time.xmlschema("2021-09-07T14:33:30.1123Z")
+      assert_equal time, single_use.read_only.min_read_timestamp
+    end
+
+    def test_table_hint
+      sql = "SELECT  `singers`.* FROM `singers`@{FORCE_INDEX=idx_singers_full_name} WHERE `singers`.`id` = @p1 LIMIT @p2"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      Singer.optimizer_hints("table_hint: singers@{FORCE_INDEX=idx_singers_full_name}").find_by(id: 1)
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+    end
+
+    def test_multiple_table_hints
+      sql = "SELECT  `singers`.* FROM `singers`@{FORCE_INDEX=idx_singers_full_name} INNER JOIN `albums`@{FORCE_INDEX=_BASE_TABLE} ON `albums`.`singer_id` = `singers`.`id` WHERE (albums.title='test') ORDER BY `singers`.`id` ASC LIMIT @p1"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      Singer.optimizer_hints("table_hint: singers@{FORCE_INDEX=idx_singers_full_name}")
+            .optimizer_hints("table_hint: albums@{FORCE_INDEX=_BASE_TABLE}")
+            .joins(:albums)
+            .where("albums.title='test'")
+            .first
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+    end
+
+    def test_multiple_table_and_statement_hints
+      sql = " @{USE_ADDITIONAL_PARALLELISM=true}SELECT  `singers`.* FROM `singers`@{FORCE_INDEX=idx_singers_full_name} INNER JOIN `albums`@{FORCE_INDEX=_BASE_TABLE} ON `albums`.`singer_id` = `singers`.`id` WHERE (albums.title='test') ORDER BY `singers`.`id` ASC LIMIT @p1"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      Singer.optimizer_hints("table_hint: singers@{FORCE_INDEX=idx_singers_full_name}")
+            .optimizer_hints("table_hint: albums@{FORCE_INDEX=_BASE_TABLE}")
+            .optimizer_hints("statement_hint: @{USE_ADDITIONAL_PARALLELISM=true}")
+            .optimizer_hints("min_read_timestamp: 2021-09-07T14:33:30.1123Z")
+            .joins(:albums)
+            .where("albums.title='test'")
+            .first
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+      single_use = execute_sql_request.transaction.single_use
+      assert single_use
+      assert single_use.read_only.return_read_timestamp
+      assert single_use.read_only.min_read_timestamp
+      time = Google::Cloud::Spanner::Convert.time_to_timestamp Time.xmlschema("2021-09-07T14:33:30.1123Z")
+      assert_equal time, single_use.read_only.min_read_timestamp
+    end
+
+    def test_join_hint
+      sql = "SELECT `singers`.* FROM `singers` INNER JOIN @{JOIN_METHOD=HASH_JOIN, FORCE_JOIN_ORDER=TRUE} albums ON albums.singer_id=singers.id WHERE (albums.title='test') ORDER BY `singers`.`id` ASC LIMIT @p1"
+      @mock.put_statement_result sql, MockServerTests::create_random_singers_result(1)
+
+      # Joins can be customized by specifying them as strings, so we don't have to use any custom optimizer hints.
+      Singer.joins("INNER JOIN @{JOIN_METHOD=HASH_JOIN, FORCE_JOIN_ORDER=TRUE} albums ON albums.singer_id=singers.id")
+            .where("albums.title='test'")
+            .first
+
+      execute_sql_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == sql }
+      assert_equal sql, execute_sql_request.sql
+    end
+
     private
 
     def create_list_value values


### PR DESCRIPTION
Adds support for statement-, table- and join hints. Also includes a sample for how these can be used.

Fixes #131