### PR TITLE
docs: add sample for Partitioned DML

### DIFF
--- a/examples/snippets/partitioned-dml/README.md
+++ b/examples/snippets/partitioned-dml/README.md
@@ -1,0 +1,16 @@
+# Sample - Partitioned DML
+
+This example shows how to use Partitioned DML with the Spanner ActiveRecord adapter.
+
+See https://cloud.google.com/spanner/docs/dml-partitioned for more information on Partitioned DML.
+
+## Running the Sample
+
+The sample will automatically start a Spanner Emulator in a docker container and execute the sample
+against that emulator. The emulator will automatically be stopped when the application finishes.
+
+Run the application with the command
+
+```bash
+bundle exec rake run
+```

--- a/examples/snippets/partitioned-dml/Rakefile
+++ b/examples/snippets/partitioned-dml/Rakefile
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../config/environment"
+require "sinatra/activerecord/rake"
+
+desc "Sample showing how to work with Partitioned DML in ActiveRecord."
+task :run do
+  Dir.chdir("..") { sh "bundle exec rake run[partitioned-dml]" }
+end

--- a/examples/snippets/partitioned-dml/application.rb
+++ b/examples/snippets/partitioned-dml/application.rb
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "io/console"
+require_relative "../config/environment"
+require_relative "models/singer"
+require_relative "models/album"
+
+class Application
+  def self.run
+    singer_count = Singer.all.count
+    album_count = Album.all.count
+    puts ""
+    puts "Singers in the database: #{singer_count}"
+    puts "Albums in the database: #{album_count}"
+
+    puts ""
+    puts "Deleting all albums in the database using Partitioned DML"
+    # Note that a Partitioned DML transaction can contain ONLY ONE DML statement.
+    # If we want to delete all data in two different tables, we need to do so in two different PDML transactions.
+    Album.transaction isolation: :pdml do
+      count = Album.delete_all
+      puts "Deleted #{count} albums"
+    end
+
+    puts ""
+    puts "Deleting all singers in the database using Partitioned DML"
+    Singer.transaction isolation: :pdml do
+      count = Singer.delete_all
+      puts "Deleted #{count} singers"
+    end
+
+    singer_count = Singer.all.count
+    album_count = Album.all.count
+    puts ""
+    puts "Singers in the database: #{singer_count}"
+    puts "Albums in the database: #{album_count}"
+
+    puts ""
+    puts "Press any key to end the application"
+    STDIN.getch
+  end
+end
+
+Application.run

--- a/examples/snippets/partitioned-dml/config/database.yml
+++ b/examples/snippets/partitioned-dml/config/database.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  pool: 5
+  timeout: 5000

--- a/examples/snippets/partitioned-dml/db/migrate/01_create_tables.rb
+++ b/examples/snippets/partitioned-dml/db/migrate/01_create_tables.rb
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateTables < ActiveRecord::Migration[6.0]
+  def change
+    connection.ddl_batch do
+      create_table :singers do |t|
+        t.string :first_name, limit: 100
+        t.string :last_name, limit: 200, null: false
+      end
+
+      create_table :albums do |t|
+        t.string :title
+        t.references :singer, index: false, foreign_key: true
+      end
+    end
+  end
+end

--- a/examples/snippets/partitioned-dml/db/schema.rb
+++ b/examples/snippets/partitioned-dml/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 1) do
+
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
+    t.string "title"
+    t.integer "singer_id", limit: 8
+  end
+
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
+    t.string "first_name", limit: 100
+    t.string "last_name", limit: 200, null: false
+  end
+
+  add_foreign_key "albums", "singers"
+end

--- a/examples/snippets/partitioned-dml/db/seeds.rb
+++ b/examples/snippets/partitioned-dml/db/seeds.rb
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../../config/environment.rb"
+require_relative "../models/singer"
+require_relative "../models/album"
+
+first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy Ruben Thomas Elly]
+last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson Aronson Tennet Courtou]
+
+adjectives = %w[daily happy blue generous cooked bad open]
+nouns = %w[windows potatoes bank street tree glass bottle]
+
+# This ensures all the records are inserted using one read/write transaction that will use mutations instead of DML.
+ActiveRecord::Base.transaction isolation: :buffered_mutations do
+  singers = []
+  5.times do
+    singers << Singer.create(first_name: first_names.sample, last_name: last_names.sample)
+  end
+
+  albums = []
+  20.times do
+    singer = singers.sample
+    albums << Album.create(title: "#{adjectives.sample} #{nouns.sample}", singer: singer)
+  end
+end

--- a/examples/snippets/partitioned-dml/models/album.rb
+++ b/examples/snippets/partitioned-dml/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/examples/snippets/partitioned-dml/models/singer.rb
+++ b/examples/snippets/partitioned-dml/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end


### PR DESCRIPTION
Adds a sample for using Partitioned DML with the ActiveRecord Spanner adapter.