### PR TITLE
perf: inline BeginTransaction with first statement in the transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Table without Primary Key| Cloud Spanner support does not support tables without
 Table names CANNOT have spaces within them whether back-ticked or not|Cloud Spanner DOES NOT support tables with spaces in them for example `Entity ID`|Ensure that your table names don't contain spaces.
 Table names CANNOT have punctuation marks and MUST contain valid UTF-8|Cloud Spanner DOES NOT support punctuation marks e.g. periods ".", question marks "?" in table names|Ensure that your table names don't contain punctuation marks.
 Index with fields length [add_index](https://apidock.com/rails/v5.2.3/ActiveRecord/ConnectionAdapters/SchemaStatements/add_index)|Cloud Spanner does not support index with fields length | Ensure that your database definition does not include index definitions with field lengths.
+Interleaved tables have composite primary keys| ActiveRecord uses single-column primary keys. Interleaved tables in Cloud Spanner always have multiple columns in the primary key, as a child table always includes the primary key columns of the parent table. You can use interleaved tables with the Spanner ActiveRecord provider. The provider will however only use the child column of the primary key to access individual records, which can cause full table scans.| Define a unique secondary index on the child primary key column.
 
 ## Contributing
 

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -69,6 +69,10 @@ module ActiveRecordSpannerAdapter
       end
     end
 
+    def retry_begin_read_write
+      @grpc_transaction = @connection.session.create_transaction
+    end
+
     def next_sequence_number
       @sequence_number += 1 if @committable
     end

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -95,6 +95,10 @@ module Google
         end
       end
 
+      class Results
+        attr_reader :metadata
+      end
+
       class Transaction
         attr_accessor :seqno, :commit
       end

--- a/test/activerecord_spanner_mock_server/inline_begin_transaction_test.rb
+++ b/test/activerecord_spanner_mock_server/inline_begin_transaction_test.rb
@@ -124,6 +124,152 @@ module MockServerTests
       assert_empty rollback_requests
     end
 
+    def test_unhandled_error_on_first_statement_retries_transaction_and_fails
+      insert_sql = register_insert_singer_result
+      # Push the same error twice, so the same error will be returned both during the initial
+      # attempt and during the retry.
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(
+          GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+          "A row with the given identifier already exists")
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+        "A row with the given identifier already exists")
+
+      # The entire transaction should be retried if the first statement in a transaction
+      # causes an error with a different error code than Aborted, and the retried transaction
+      # should use an explicit BeginTransaction RPC. This is necessary in order to include
+      # the statement that caused the error in the transaction, as the error could be an
+      # indication of the state of the database during the transaction. A unique key constraint
+      # violation for example indicates that a record with a specific key value exists.
+      err = assert_raises ActiveRecord::StatementInvalid do
+        ActiveRecord::Base.transaction do
+          Singer.create(first_name: "Dave", last_name: "Allison")
+        end
+      end
+      assert err.cause.is_a?(Google::Cloud::FailedPreconditionError)
+
+      # There should be one explicit BeginTransaction request.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 2, sql_requests.length
+      assert sql_requests[0].transaction&.begin&.read_write
+      assert sql_requests[1].transaction&.id
+
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_empty commit_requests
+    end
+
+    def test_handled_error_on_first_statement_retries_transaction_and_succeeds
+      insert_sql = register_insert_singer_result
+      # Push the same error twice, so the same error will be returned both during the initial
+      # attempt and during the retry.
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+        "A row with the given identifier already exists")
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+        "A row with the given identifier already exists")
+
+      attempts = 0
+      ActiveRecord::Base.transaction do
+        begin
+          Singer.create(first_name: "Dave", last_name: "Allison")
+        rescue ActiveRecord::StatementInvalid
+          raise if (attempts += 1) > 1
+          # Ignore the error and retry the statement.
+          retry
+        end
+      end
+
+      # There should be one explicit BeginTransaction request.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      # There should be 3 ExecuteSqlRequests:
+      # 1. The initial attempt that includes a BeginTransaction. This statement will fail and be
+      #    retried after an explicit BeginTransaction request.
+      # 2. The retried attempt after the BeginTransaction RPC. This statement will also fail, as
+      #    the error has been added twice.
+      # 3. The error handler in the transaction block will retry the statement once more. This time
+      #    the statement will succeed, as the error has only been pushed twice.
+      assert_equal 3, sql_requests.length
+      assert sql_requests[0].transaction&.begin&.read_write
+      assert sql_requests[1].transaction&.id
+      assert_equal sql_requests[1].transaction&.id, sql_requests[2].transaction&.id
+
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal sql_requests[1].transaction&.id, commit_requests[0].transaction_id
+    end
+
+    def test_transient_error_on_first_statement_retries_transaction_and_succeeds
+      insert_sql = register_insert_singer_result
+      # Push the same error only once, so the retried statement will succeed.
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(
+        GRPC::Core::StatusCodes::RESOURCE_EXHAUSTED,
+        "Too many requests")
+
+      ActiveRecord::Base.transaction do
+        # This statement will fail once, and then be retried internally after an explicit
+        # BeginTransaction RPC. The second attempt will succeed as the error was only pushed once.
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      # There should be one explicit BeginTransaction request.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 2, sql_requests.length
+      assert sql_requests[0].transaction&.begin&.read_write
+      assert sql_requests[1].transaction&.id
+
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_equal 1, commit_requests.length
+      assert_equal sql_requests[1].transaction&.id, commit_requests[0].transaction_id
+    end
+
+    def test_error_on_first_statement_and_on_begin_transaction
+      insert_sql = register_insert_singer_result
+      @mock.push_error \
+        insert_sql, \
+        GRPC::BadStatus.new(GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+                            "A row with the given identifier already exists")
+      @mock.push_error \
+        "begin_transaction", \
+        GRPC::BadStatus.new(GRPC::Core::StatusCodes::PERMISSION_DENIED, "Not permitted")
+
+      err = assert_raises ActiveRecord::StatementInvalid do
+        ActiveRecord::Base.transaction do
+          # This statement will fail and cause an internal retry with an explicit BeginTransaction
+          # RPC. That RPC invocation will fail, but the original error from the SQL statement
+          # will be the error that is returned.
+          Singer.create(first_name: "Dave", last_name: "Allison")
+        end
+      end
+      assert err.cause.is_a?(Google::Cloud::FailedPreconditionError)
+
+      # There should be one explicit BeginTransaction request.
+      begin_transaction_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
+      assert_equal 1, begin_transaction_requests.length
+      sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      assert_equal 1, sql_requests.length
+      assert sql_requests[0].transaction&.begin&.read_write
+
+      commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
+      assert_empty commit_requests
+    end
+
     def register_insert_singer_result
       sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@p1, @p2, @p3)"
       @mock.put_statement_result sql, StatementResult.new(1)

--- a/test/activerecord_spanner_mock_server/session_not_found_test.rb
+++ b/test/activerecord_spanner_mock_server/session_not_found_test.rb
@@ -79,14 +79,14 @@ module MockServerTests
       end
 
       begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-      assert_equal 2, begin_requests.length
-      refute_equal begin_requests[0].session, begin_requests[1].session
+      assert_empty begin_requests
       sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
       assert_equal 2, sql_requests.length
       refute_equal sql_requests[0].session, sql_requests[1].session
+      sql_requests.each { |req| assert req.transaction&.begin&.read_write }
       commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
       assert_equal 1, commit_requests.length
-      assert_equal begin_requests[1].session, commit_requests[0].session
+      assert_equal sql_requests[1].session, commit_requests[0].session
     end
 
     def test_session_not_found_on_select_in_transaction
@@ -99,14 +99,14 @@ module MockServerTests
       end
 
       begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-      assert_equal 2, begin_requests.length
-      refute_equal begin_requests[0].session, begin_requests[1].session
+      assert_empty begin_requests
       sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == select_sql }
       assert_equal 2, sql_requests.length
       refute_equal sql_requests[0].session, sql_requests[1].session
+      sql_requests.each { |req| assert req.transaction&.begin&.read_write }
       commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
       assert_equal 1, commit_requests.length
-      assert_equal begin_requests[1].session, commit_requests[0].session
+      assert_equal sql_requests[1].session, commit_requests[0].session
     end
 
     def test_session_not_found_on_commit
@@ -119,14 +119,14 @@ module MockServerTests
       end
 
       begin_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::BeginTransactionRequest }
-      assert_equal 2, begin_requests.length
-      refute_equal begin_requests[0].session, begin_requests[1].session
+      assert_empty begin_requests
       sql_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
       assert_equal 2, sql_requests.length
       refute_equal sql_requests[0].session, sql_requests[1].session
+      sql_requests.each { |req| assert req.transaction&.begin&.read_write }
       commit_requests = @mock.requests.select { |req| req.is_a? Google::Cloud::Spanner::V1::CommitRequest }
       assert_equal 2, commit_requests.length
-      assert_equal begin_requests[1].session, commit_requests[1].session
+      assert_equal sql_requests[1].session, commit_requests[1].session
     end
 
     def register_insert_singer_result


### PR DESCRIPTION
Replaces the `BeginTransaction` RPC invocation at the beginning of a read/write transaction with an inlined `BeginTransaction` option on the first statement in the transaction. This reduces the number of roundtrips by one for read/write transactions that execute at least one SQL statement (DML or query).

Transactions that only execute one or more mutations still need to execute a `BeginTransaction` RPC before the `Commit`.

The [inline_begin_transaction_test.rb](https://github.com/googleapis/ruby-spanner-activerecord/blob/35df01ca87d72cdbbf3d1a3e63736c88462c48cc/test/activerecord_spanner_mock_server/inline_begin_transaction_test.rb) file is a good starting point for reviewing this PR, as it gives an overview of how the provider behaves for different scenarios.

## Benchmarks

```
Benchmarks for ActiveRecord
                                                                                  user     system      total        real
Select one row:                                                               0.005923   0.000108   0.006031 (  0.020545)
Save one row with fetch after:                                                0.004887   0.000050   0.004937 (  0.025885)
Select and update 1 row in transaction using mutation:                        0.005404   0.000000   0.005404 (  0.075397)
Select and update 1 row in transaction using DML:                             0.005592   0.000174   0.005766 (  0.043225)
Select and update 25 rows in transaction using mutation:                      0.034073   0.008113   0.042186 (  0.151752)
Select and update 25 rows in transaction using DML:                           0.057145   0.008064   0.065209 (  0.298057)
Create 100 albums using mutations:                                            0.049477   0.004085   0.053562 (  0.098786)
Create 100 albums using DML:                                                  0.176151   0.008699   0.184850 (  0.688414)
Select and iterate over 100 singers:                                          0.007212   0.000000   0.007212 (  0.028932)
Select and iterate over 100 singers in a read-only transaction:               0.008563   0.000222   0.008785 (  0.039447)
Select and iterate over 100 singers in a read/write transaction:              0.005572   0.003742   0.009314 (  0.030663)
                                                                                  user     system      total        real
Total execution time (1):                                                     0.058740   0.000000   0.058740 (  0.261739)
Total execution time (5):                                                     0.204751   0.007962   0.212713 (  0.345838)
Total execution time (10):                                                    0.447394   0.015949   0.463343 (  0.561728)
Total execution time (25):                                                    0.983090   0.095282   1.078372 (  1.255142)
Total execution time (50):                                                    2.211445   0.116437   2.327882 (  2.576518)
Total execution time (100):                                                   4.391837   0.316523   4.708360 (  5.131198)
Total execution time (200):                                                   9.795164   0.647298  10.442462 ( 11.102745)
Total execution time (400):                                                  17.320740   1.470954  18.791694 ( 30.548032)
Benchmarks for Spanner client
                                                                                  user     system      total        real
Select one row:                                                               0.003363   0.000000   0.003363 (  0.031631)
Save one row with fetch after:                                                0.002478   0.000139   0.002617 (  0.016598)
Select and update 1 row in transaction using mutation:                        0.002654   0.003920   0.006574 (  0.054519)
Select and update 1 row in transaction using DML:                             0.006363   0.000000   0.006363 (  0.046582)
Select and update 25 rows in transaction using mutation:                      0.029641   0.003963   0.033604 (  0.180197)
Select and update 25 rows in transaction using DML:                           0.054942   0.008510   0.063452 (  0.367085)
Create 100 albums using mutations:                                            0.010886   0.000207   0.011093 (  0.039520)
Create 100 albums using DML:                                                  0.031594   0.003975   0.035569 (  0.348762)
Select and iterate over 100 singers:                                          0.004819   0.000058   0.004877 (  0.027926)
Select and iterate over 100 singers in a read-only transaction:               0.005611   0.000000   0.005611 (  0.043016)
Select and iterate over 100 singers in a read/write transaction:              0.005407   0.000000   0.005407 (  0.041318)
                                                                                  user     system      total        real
Total execution time (1):                                                     0.061344   0.003226   0.064570 (  0.270657)
Total execution time (5):                                                     0.127943   0.003408   0.131351 (  0.295201)
Total execution time (10):                                                    0.224252   0.039778   0.264030 (  0.626101)
Total execution time (25):                                                    0.502620   0.080572   0.583192 (  0.689937)
Total execution time (50):                                                    1.009005   0.161462   1.170467 (  1.351502)
Total execution time (100):                                                   2.238698   0.343673   2.582371 (  2.858914)
Total execution time (200):                                                   5.099566   0.746336   5.845902 (  8.837476)
Total execution time (400):                                                   9.245205   1.741330  10.986535 ( 59.127166)
```

### Side-by-side
The table below contains the same results as above, but presented side-by-side for a direct comparison between the normal Spanner client and the ActiveRecord provider. The figures shown are the real execution times, i.e. including network time. The `ActiveRecord (original)` times are taken from the original benchmark run (before this change). The `ActiveRecord (new)` column contains the measurements after this change.

| Benchmark | ActiveRecord (original) | Spanner client | ActiveRecord (new) |
|------------|------------------------|----------------|---------------------|
| Select one row | 0.011054 | 0.031631 | 0.020545 |
| Save one row with fetch after | 0.030973 | 0.016598 | 0.025885 |
| Select and update 1 row in transaction using mutation | 0.178689 | 0.054519 | 0.075397 |
| Select and update 1 row in transaction using DML | 0.139983 | 0.046582 | 0.043225 |
| Select and update 25 rows in transaction using mutation | 0.304142 | 0.151752 | 0.151752 |
| Select and update 25 rows in transaction using DML | 0.649054 | 0.367085 | 0.298057 |
| Create 100 albums using mutations | 0.220688 | 0.039520 | 0.098786 |
| Create 100 albums using DML | 1.022725 | 0.348762 | 0.688414 |
| Select and iterate over 100 singers | 0.115998 | 0.027926 | 0.028932 |
| Select and iterate over 100 singers in a read-only transaction | 0.050298 | 0.043016 | 0.039447 |
| Select and iterate over 100 singers in a read/write transaction | 0.054801 | 0.041318 | 0.030663 |
| Total execution time (1) | 0.643255 | 0.270657 | 0.261739 |
| Total execution time (5) | 0.754162 | 0.295201 | 0.345838 |
| Total execution time (10) | 0.909938 | 0.626101 | 0.561728 |
| Total execution time (25) | 1.925742 | 0.689937 | 1.255142 |
| Total execution time (50) | 3.396065 | 1.351502 | 2.576518 |
| Total execution time (100) | 6.944054 | 2.858914 | 5.131198 |
| Total execution time (200) | 14.459822 | 8.837476 | 11.102745 |
| Total execution time (400) | 30.333424 | 59.127166 | 30.548032 |
