### PR TITLE
docs: add unique index to interleaved table sample

### DIFF
--- a/examples/snippets/interleaved-tables/db/migrate/01_create_tables.rb
+++ b/examples/snippets/interleaved-tables/db/migrate/01_create_tables.rb
@@ -26,6 +26,9 @@ class CreateTables < ActiveRecord::Migration[6.0]
         t.string :title
       end
 
+      # Add a unique index to the albumid column to prevent full table scans when a single album record is queried.
+      add_index :albums, [:albumid], unique: true
+
       create_table :tracks, id: false do |t|
         # Interleave the `tracks` table in the parent table `albums` and cascade delete all tracks that belong to an
         # album when an album is deleted.
@@ -39,6 +42,9 @@ class CreateTables < ActiveRecord::Migration[6.0]
         t.string :title
         t.numeric :duration
       end
+
+      # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.
+      add_index :tracks, [:trackid], unique: true
     end
   end
 end

--- a/examples/snippets/interleaved-tables/db/schema.rb
+++ b/examples/snippets/interleaved-tables/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,21 +12,23 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", primary_key: "albumid", force: :cascade do |t|
+  create_table "albums", primary_key: "albumid", id: { limit: 8 }, force: :cascade do |t|
     t.integer "singerid", limit: 8, null: false
     t.string "title"
+    t.index ["albumid"], name: "index_albums_on_albumid", unique: true, order: { albumid: :asc }
   end
 
-  create_table "singers", primary_key: "singerid", force: :cascade do |t|
+  create_table "singers", primary_key: "singerid", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end
 
-  create_table "tracks", primary_key: "trackid", force: :cascade do |t|
+  create_table "tracks", primary_key: "trackid", id: { limit: 8 }, force: :cascade do |t|
     t.integer "singerid", limit: 8, null: false
     t.integer "albumid", limit: 8, null: false
     t.string "title"
     t.decimal "duration"
+    t.index ["trackid"], name: "index_tracks_on_trackid", unique: true, order: { trackid: :asc }
   end
 
 end

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -32,6 +32,9 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.string :title
       end
 
+      # Add a unique index to the albumid column to prevent full table scans when a single album record is queried.
+      add_index :albums, [:albumid], unique: true
+
       # This table will be interleaved in a table that itself is already an interleaved table. We need to include the
       # primary key columns of all the parent tables in the hierarchy.
       create_table :tracks do |t|
@@ -41,6 +44,9 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.string :title
         t.numeric :duration
       end
+
+      # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.
+      add_index :tracks, [:trackid], unique: true
 
       # Execute the change as one DDL batch.
       connection.run_batch


### PR DESCRIPTION
Interleaved child tables should have a unique index on the child id column to prevent full
table scans when a single child record is fetched by ActiveRecord. ActiveRecord will only
use the child id column when fetching a record, and this query will not use the primary key
of the table, as that primary key starts with the parent id column(s).