### PR TITLE
chore: Fix default branch in a bunch of workflow configs

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -2,7 +2,7 @@ rebaseMergeAllowed: true
 squashMergeAllowed: true
 mergeCommitAllowed: false
 branchProtectionRules:
-- pattern: master
+- pattern: main
   isAdminEnforced: true
   requiredStatusCheckContexts:
     - 'cla/google'

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 name: acceptance tests on emulator
 jobs:

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 name: acceptance tests on production
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 name: ci
 jobs:

--- a/.github/workflows/release-please-label.yml
+++ b/.github/workflows/release-please-label.yml
@@ -2,7 +2,7 @@ name: release-please-label
 on:
   pull_request_target:
     branches:
-      - master
+      - main
     types:
       - opened
 jobs:

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ $ cd ruby-spanner-activerecord
 $ bundle exec rubocop
 ```
 
-The rubocop settings depend on [googleapis/ruby-style](https://github.com/googleapis/ruby-style/), in addition to [.rubocop.yml](https://github.com/googleapis/ruby-spanner-activerecord/blob/master/.rubocop.yml).
+The rubocop settings depend on [googleapis/ruby-style](https://github.com/googleapis/ruby-style/), in addition to [.rubocop.yml](https://github.com/googleapis/ruby-spanner-activerecord/blob/main/.rubocop.yml).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Activerecord::Spanner project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/googleapis/ruby-spanner-activerecord/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Activerecord::Spanner project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/googleapis/ruby-spanner-activerecord/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Fix the branch name (`master` -> `main`) for several workflows. Also fix a few links referencing the old branch name. I set this PR as "chore" because github will forward links with the old branch name so we don't need to release a fixed gem. Rather, this will fix CI so we actually get proper continuous runs when PRs are merged.