### PR TITLE
fix: ActiveRecord::Type::Spanner::Array does not use element type

### DIFF
--- a/acceptance/cases/type/all_types_test.rb
+++ b/acceptance/cases/type/all_types_test.rb
@@ -32,17 +32,18 @@ module ActiveRecord
           col_timestamp: ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"),
           col_json: ENV["SPANNER_EMULATOR_HOST"] ? "" : { kind: "user_renamed", change: %w[jack john]},
           col_array_string: ["string1", nil, "string2"],
-          col_array_int64: [100, nil, 200],
-          col_array_float64: [3.14, nil, 2.0/3.0],
-          col_array_numeric: [6.626, nil, 3.20],
-          col_array_bool: [true, nil, false],
+          col_array_int64: [100, nil, 200, "300"],
+          col_array_float64: [3.14, nil, 2.0/3.0, "3.14"],
+          col_array_numeric: [6.626, nil, 3.20, "400"],
+          col_array_bool: [true, nil, false, "false"],
           col_array_bytes: [StringIO.new("bytes1"), nil, StringIO.new("bytes2")],
-          col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24)],
+          col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24), "2021-06-25"],
           col_array_timestamp: [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), nil, \
-                                ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")],
+                                ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00"), "2021-06-25 17:08:21 +02:00"],
           col_array_json: ENV["SPANNER_EMULATOR_HOST"] ? [""] : \
                             [{ kind: "user_renamed", change: %w[jack john]}, nil, \
-                             { kind: "user_renamed", change: %w[alice meredith]}]
+                             { kind: "user_renamed", change: %w[alice meredith]},
+                             "{\"kind\":\"user_renamed\",\"change\":[\"bob\",\"carol\"]}"]
       end
 
       def test_create_record
@@ -69,20 +70,21 @@ module ActiveRecord
                        record.col_json unless ENV["SPANNER_EMULATOR_HOST"]
 
           assert_equal ["string1", nil, "string2"], record.col_array_string
-          assert_equal [100, nil, 200], record.col_array_int64
-          assert_equal [3.14, nil, 2.0/3.0], record.col_array_float64
-          assert_equal [6.626, nil, 3.20], record.col_array_numeric
-          assert_equal [true, nil, false], record.col_array_bool
+          assert_equal [100, nil, 200, 300], record.col_array_int64
+          assert_equal [3.14, nil, 2.0/3.0, 3.14], record.col_array_float64
+          assert_equal [6.626, nil, 3.20, 400], record.col_array_numeric
+          assert_equal [true, nil, false, false], record.col_array_bool
           assert_equal [StringIO.new("bytes1"), nil, StringIO.new("bytes2")].map { |bytes| bytes&.read },
                        record.col_array_bytes.map { |bytes| bytes&.read }
-          assert_equal [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24)], record.col_array_date
+          assert_equal [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24), ::Date.new(2021, 06, 25)], record.col_array_date
           assert_equal [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), \
                             nil, \
-                            ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00")].map { |timestamp| timestamp&.utc },
+                            ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00"), ::Time.new(2021, 6, 25, 17, 8, 21, "+02:00")].map { |timestamp| timestamp&.utc },
                        record.col_array_timestamp.map { |timestamp| timestamp&.utc}
           assert_equal [{"kind" => "user_renamed", "change" => %w[jack john]}, \
                         nil, \
-                        {"kind" => "user_renamed", "change" => %w[alice meredith]}],
+                        {"kind" => "user_renamed", "change" => %w[alice meredith]},
+                        {"kind" => "user_renamed", "change" => %w[bob carol]}],
                        record.col_array_json unless ENV["SPANNER_EMULATOR_HOST"]
         end
       end

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -198,7 +198,7 @@ module ActiveRecord
 
       def register_array_types m
         m.register_type %r{^ARRAY<BOOL>}i, Type::Spanner::Array.new(Type::Boolean.new)
-        m.register_type %r{^ARRAY<BYTES\((MAX|d+)\)>}i, Type::Spanner::Array.new(Type::Binary.new)
+        m.register_type %r{^ARRAY<BYTES\((MAX|d+)\)>}i, Type::Spanner::Array.new(ActiveRecord::Type::Spanner::Bytes.new)
         m.register_type %r{^ARRAY<DATE>}i, Type::Spanner::Array.new(Type::Date.new)
         m.register_type %r{^ARRAY<FLOAT64>}i, Type::Spanner::Array.new(Type::Float.new)
         m.register_type %r{^ARRAY<NUMERIC>}i, Type::Spanner::Array.new(Type::Decimal.new)

--- a/lib/active_record/type/spanner/array.rb
+++ b/lib/active_record/type/spanner/array.rb
@@ -15,15 +15,29 @@ module ActiveRecord
           @element_type = element_type
         end
 
-        def serialize value
+        def cast value
           return super if value.nil?
-          return super unless @element_type.is_a? Type::Decimal
           return super unless value.respond_to? :map
 
-          # Convert a decimal (NUMERIC) array to a String array to prevent it from being encoded as a FLOAT64 array.
           value.map do |v|
-            next if v.nil?
-            v.to_s
+            @element_type.cast v
+          end
+        end
+
+        def serialize value
+          return super if value.nil?
+          return super unless value.respond_to? :map
+
+          if @element_type.is_a? ActiveRecord::Type::Decimal
+            # Convert a decimal (NUMERIC) array to a String array to prevent it from being encoded as a FLOAT64 array.
+            value.map do |v|
+              next if v.nil?
+              v.to_s
+            end
+          else
+            value.map do |v|
+              @element_type.serialize v
+            end
           end
         end
       end


### PR DESCRIPTION
Rails always assumes input of type `ActiveRecord::Type` to be cast/converted to the appropriate database type, but `ActiveRecord::Type::Spanner::Array` does not serialize and does not cast/convert values correctly from/to the database type in all cases.

This can cause exceptions if the array elements that are passed in are not of the expected database type (e.g. trying to use a string value in a float64 array).

Fixes #163
