### PR TITLE
test: enable JSON tests on emulator

### DIFF
--- a/acceptance/cases/type/all_types_test.rb
+++ b/acceptance/cases/type/all_types_test.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         AllTypes.create col_string: "string", col_int64: 100, col_float64: 3.14, col_numeric: 6.626, col_bool: true,
           col_bytes: StringIO.new("bytes"), col_date: ::Date.new(2021, 6, 23),
           col_timestamp: ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"),
-          col_json: ENV["SPANNER_EMULATOR_HOST"] ? "" : { kind: "user_renamed", change: %w[jack john]},
+          col_json: { kind: "user_renamed", change: %w[jack john]},
           col_array_string: ["string1", nil, "string2"],
           col_array_int64: [100, nil, 200, "300"],
           col_array_float64: [3.14, nil, 2.0/3.0, "3.14"],
@@ -40,8 +40,7 @@ module ActiveRecord
           col_array_date: [::Date.new(2021, 6, 23), nil, ::Date.new(2021, 6, 24), "2021-06-25"],
           col_array_timestamp: [::Time.new(2021, 6, 23, 17, 8, 21, "+02:00"), nil, \
                                 ::Time.new(2021, 6, 24, 17, 8, 21, "+02:00"), "2021-06-25 17:08:21 +02:00"],
-          col_array_json: ENV["SPANNER_EMULATOR_HOST"] ? [""] : \
-                            [{ kind: "user_renamed", change: %w[jack john]}, nil, \
+          col_array_json: [{ kind: "user_renamed", change: %w[jack john]}, nil, \
                              { kind: "user_renamed", change: %w[alice meredith]},
                              "{\"kind\":\"user_renamed\",\"change\":[\"bob\",\"carol\"]}"]
       end
@@ -67,7 +66,7 @@ module ActiveRecord
           assert_equal ::Date.new(2021, 6, 23), record.col_date
           assert_equal ::Time.new(2021, 6, 23, 17, 8, 21, "+02:00").utc, record.col_timestamp.utc
           assert_equal ({"kind" => "user_renamed", "change" => %w[jack john]}),
-                       record.col_json unless ENV["SPANNER_EMULATOR_HOST"]
+                       record.col_json
 
           assert_equal ["string1", nil, "string2"], record.col_array_string
           assert_equal [100, nil, 200, 300], record.col_array_int64
@@ -83,9 +82,9 @@ module ActiveRecord
                        record.col_array_timestamp.map { |timestamp| timestamp&.utc}
           assert_equal [{"kind" => "user_renamed", "change" => %w[jack john]}, \
                         nil, \
-                        {"kind" => "user_renamed", "change" => %w[alice meredith]},
-                        {"kind" => "user_renamed", "change" => %w[bob carol]}],
-                       record.col_array_json unless ENV["SPANNER_EMULATOR_HOST"]
+                        {"kind" => "user_renamed", "change" => %w[alice meredith]}, \
+                        "{\"kind\":\"user_renamed\",\"change\":[\"bob\",\"carol\"]}"],
+                       record.col_array_json
         end
       end
 
@@ -100,7 +99,7 @@ module ActiveRecord
                           col_bool: false, col_bytes: StringIO.new("new bytes"),
                           col_date: ::Date.new(2021, 6, 28),
                           col_timestamp: ::Time.new(2021, 6, 28, 11, 22, 21, "+02:00"),
-                          col_json: ENV["SPANNER_EMULATOR_HOST"] ? "" : { kind: "user_created", change: %w[jack alice]},
+                          col_json: { kind: "user_created", change: %w[jack alice]},
                           col_array_string: ["new string 1", "new string 2"],
                           col_array_int64: [300, 200, 100],
                           col_array_float64: [1.1, 2.2, 3.3],
@@ -109,9 +108,7 @@ module ActiveRecord
                           col_array_bytes: [StringIO.new("new bytes 1"), StringIO.new("new bytes 2")],
                           col_array_date: [::Date.new(2021, 6, 28)],
                           col_array_timestamp: [::Time.utc(2020, 12, 31, 0, 0, 0)],
-                          col_array_json: ENV["SPANNER_EMULATOR_HOST"] ?
-                                            [""] : \
-                                            [{ kind: "user_created", change: %w[jack alice]}]
+                          col_array_json: [{ kind: "user_created", change: %w[jack alice]}]
           end
 
           # Verify that the record was updated.
@@ -125,7 +122,7 @@ module ActiveRecord
           assert_equal ::Date.new(2021, 6, 28), record.col_date
           assert_equal ::Time.new(2021, 6, 28, 11, 22, 21, "+02:00").utc, record.col_timestamp.utc
           assert_equal ({"kind" => "user_created", "change" => %w[jack alice]}),
-                       record.col_json unless ENV["SPANNER_EMULATOR_HOST"]
+                     record.col_json
 
           assert_equal ["new string 1", "new string 2"], record.col_array_string
           assert_equal [300, 200, 100], record.col_array_int64
@@ -137,7 +134,7 @@ module ActiveRecord
           assert_equal [::Date.new(2021, 6, 28)], record.col_array_date
           assert_equal [::Time.utc(2020, 12, 31, 0, 0, 0)], record.col_array_timestamp.map(&:utc)
           assert_equal [{"kind" => "user_created", "change" => %w[jack alice]}],
-                       record.col_array_json unless ENV["SPANNER_EMULATOR_HOST"]
+                       record.col_array_json
         end
       end
 

--- a/acceptance/cases/type/json_test.rb
+++ b/acceptance/cases/type/json_test.rb
@@ -18,8 +18,6 @@ module ActiveRecord
       end
 
       def test_set_json
-        return if ENV["SPANNER_EMULATOR_HOST"]
-
         expected_hash = {"key"=>"value", "array_key"=>%w[value1 value2]}
         record = TestTypeModel.new details: {key: "value", array_key: %w[value1 value2]}
 

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -17,8 +17,7 @@ ActiveRecord::Schema.define do
       t.column :col_bytes, :binary
       t.column :col_date, :date
       t.column :col_timestamp, :datetime
-      t.column :col_json, :json unless ENV["SPANNER_EMULATOR_HOST"]
-      t.column :col_json, :string if ENV["SPANNER_EMULATOR_HOST"]
+      t.column :col_json, :json
 
       t.column :col_array_string, :string, array: true
       t.column :col_array_int64, :bigint, array: true
@@ -28,8 +27,7 @@ ActiveRecord::Schema.define do
       t.column :col_array_bytes, :binary, array: true
       t.column :col_array_date, :date, array: true
       t.column :col_array_timestamp, :datetime, array: true
-      t.column :col_array_json, :json, array: true unless ENV["SPANNER_EMULATOR_HOST"]
-      t.column :col_array_json, :string, array: true if ENV["SPANNER_EMULATOR_HOST"]
+      t.column :col_array_json, :json, array: true
     end
 
     create_table :firms do |t|

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -208,7 +208,7 @@ module SpannerAdapter
           t.date :start_date
           t.datetime :start_datetime
           t.time :start_time
-          t.json :details unless ENV["SPANNER_EMULATOR_HOST"]
+          t.json :details
         end
       end
 


### PR DESCRIPTION
Enable JSON tests on the emulator now that the emulator also supports JSON columns.