### PR TITLE
test: add tests for after_save

### DIFF
--- a/test/activerecord_spanner_mock_server/models/singer.rb
+++ b/test/activerecord_spanner_mock_server/models/singer.rb
@@ -7,5 +7,15 @@
 module MockServerTests
   class Singer < ActiveRecord::Base
     has_many :albums
+    attr_reader :full_name
+
+    def initialize(attributes = nil)
+      super attributes
+      @full_name = ""
+    end
+
+    after_save do
+      @full_name = first_name + ' ' + last_name
+    end
   end
 end

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -145,6 +145,31 @@ module MockServerTests
       end
     end
 
+    def test_after_save
+      singer = Singer.create(first_name: "Dave", last_name: "Allison")
+
+      assert_equal "Dave Allison", singer.full_name
+    end
+
+    def test_after_save_buffered_mutations
+      singer = Singer.transaction isolation: :buffered_mutations do
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      assert_equal "Dave Allison", singer.full_name
+    end
+
+    def test_after_save_transaction
+      insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `id`) VALUES (@p1, @p2, @p3)"
+      @mock.put_statement_result insert_sql, StatementResult.new(1)
+
+      singer = Singer.transaction do
+        Singer.create(first_name: "Dave", last_name: "Allison")
+      end
+
+      assert_equal "Dave Allison", singer.full_name
+    end
+
     def test_create_singer_with_last_performance_as_time
       insert_sql = "INSERT INTO `singers` (`first_name`, `last_name`, `last_performance`, `id`) VALUES (@p1, @p2, @p3, @p4)"
       @mock.put_statement_result insert_sql, StatementResult.new(1)


### PR DESCRIPTION
Adds a couple of tests to verify that `after_save` can be used both with transactions and buffered mutations.