### PR TITLE
chore: Update ruby github team names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/yoshi-ruby @skuruppu @hengfengli @olavloite @xiangshen-dk
+*     @googleapis/ruby-team @skuruppu @hengfengli @olavloite @xiangshen-dk

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,7 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
 permissionRules:
-  - team: yoshi-ruby
+  - team: ruby-team
     permission: push
-  - team: yoshi-ruby-admins
+  - team: ruby-admins
     permission: admin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,14 +10,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: [2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.4, 7.0.2.4]
+        ruby: ["2.6", "2.7", "3.0"]
+        ar: ["6.0.4", "6.1.4", "7.0.2.4"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: 3.0
-            ar: 6.0.4
-          - ruby: 2.6
-            ar: 7.0.2.4
+          - ruby: "3.0"
+            ar: "6.0.4"
+          - ruby: "2.6"
+            ar: "7.0.2.4"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:


### PR DESCRIPTION
Switch to github ruby teams that are managed by teamsync.