### PR TITLE
deps: update supported versions

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -19,13 +19,15 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: [2.6, 2.7, 3.0]
-        ar: [6.0.4, 6.1.4, 7.0.2.4]
+        ar: [6.0.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: 3.0
-            ar: 6.0.4
+            ar: 6.0.5.1
           - ruby: 2.6
             ar: 7.0.2.4
+          - ruby: 2.6
+            ar: 7.0.3.1
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -2,6 +2,8 @@ on:
   schedule:
     # 06:00 UTC
     - cron:  '0 6 * * *'
+  workflow_dispatch:
+  pull_request:
 name: nightly acceptance tests on emulator
 jobs:
   test:
@@ -19,7 +21,7 @@ jobs:
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
         ruby: [2.5, 2.6, 2.7, 3.0]
-        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4, 7.0.2.4]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: 3.0
@@ -36,6 +38,10 @@ jobs:
             ar: 7.0.2.4
           - ruby: 2.6
             ar: 7.0.2.4
+          - ruby: 2.5
+            ar: 7.0.3.1
+          - ruby: 2.6
+            ar: 7.0.3.1
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -3,7 +3,6 @@ on:
     # 06:00 UTC
     - cron:  '0 6 * * *'
   workflow_dispatch:
-  pull_request:
 name: nightly acceptance tests on emulator
 jobs:
   test:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -3,7 +3,6 @@ on:
     # 05:30 UTC
     - cron:  '30 5 * * *'
   workflow_dispatch:
-  pull_request:
 name: nightly-unit-tests
 jobs:
   test:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -2,6 +2,8 @@ on:
   schedule:
     # 05:30 UTC
     - cron:  '30 5 * * *'
+  workflow_dispatch:
+  pull_request:
 name: nightly-unit-tests
 jobs:
   test:
@@ -11,7 +13,7 @@ jobs:
       matrix:
         # Run unit tests all supported combinations of Ruby and ActiveRecord.
         ruby: [2.5, 2.6, 2.7, 3.0]
-        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.0, 6.1.1, 6.1.2.1, 6.1.3.2, 6.1.4, 7.0.2.4]
+        ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: 3.0
@@ -28,6 +30,10 @@ jobs:
             ar: 7.0.2.4
           - ruby: 2.6
             ar: 7.0.2.4
+          - ruby: 2.5
+            ar: 7.0.3.1
+          - ruby: 2.6
+            ar: 7.0.3.1
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in activerecord-spanner.gemspec
 gemspec
 
-gem "activerecord", ENV.fetch("AR_VERSION", "~> 6.1.4")
+gem "activerecord", ENV.fetch("AR_VERSION", "~> 6.1.6.1")
 gem "minitest", "~> 5.15.0"
 gem "pry", "~> 0.13.0"
 gem "pry-byebug", "~> 3.9.0"

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -846,7 +846,9 @@ module MockServerTests
     end
 
     def test_insert_all_bang_dml
+      insert_sql_2_5 = "INSERT INTO `singers`(`id`,`first_name`,`last_name`) VALUES (1, 'Dave', 'Allison'), (2, 'Alice', 'Davidson'), (3, 'Rene', 'Henderson')"
       insert_sql = "INSERT INTO `singers` (`id`,`first_name`,`last_name`) VALUES (1, 'Dave', 'Allison'), (2, 'Alice', 'Davidson'), (3, 'Rene', 'Henderson')"
+      @mock.put_statement_result insert_sql_2_5, StatementResult.new(3)
       @mock.put_statement_result insert_sql, StatementResult.new(3)
 
       values = [
@@ -861,7 +863,7 @@ module MockServerTests
       commit_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::CommitRequest) }
       assert_equal 1, commit_requests.length
       assert_equal 0, commit_requests[0].mutations.length
-      execute_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == insert_sql }
+      execute_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && (req.sql == insert_sql || req.sql == insert_sql_2_5) }
       assert_equal 1, execute_requests.length
     end
 


### PR DESCRIPTION
The composite_primary_key gem does not work with ActiveRecord 6.1.0, 6.1.1 and 6.1.2 due to an API change in 6.1.3. That has caused build errors for the nightly builds in the past couple of weeks. This change updates the tested and supported versions of ActiveRecord and Ruby, and also adds the newest versions of ActiveRecord.

I've run all the nightly tests as part of this PR as well. See:
* Nightly acceptance tests: https://github.com/googleapis/ruby-spanner-activerecord/actions/workflows/nightly-acceptance-tests-on-emulator.yaml
* Nightly unit tests: https://github.com/googleapis/ruby-spanner-activerecord/actions/workflows/nightly-unit-tests.yaml