### PR TITLE
chore: Release scripts use a safer common tool to install python dependencies

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -7,9 +7,7 @@ set -eo pipefail
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
-python3 -m pip install git+https://github.com/googleapis/releasetool
-python3 -m pip install gcp-docuploader
 gem install --no-document toys
-
+toys release install-python-tools -v
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 toys release perform -v --enable-docs < /dev/null

--- a/.toys/release.rb
+++ b/.toys/release.rb
@@ -14,5 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load_git remote: "https://github.com/googleapis/ruby-common-tools.git",
-         path: "toys/release"
+if ENV["RUBY_COMMON_TOOLS"]
+  common_tools_dir = File.expand_path ENV["RUBY_COMMON_TOOLS"]
+  load File.join(common_tools_dir, "toys", "release")
+else
+  load_git remote: "https://github.com/googleapis/ruby-common-tools.git",
+           path: "toys/release",
+           update: true
+end


### PR DESCRIPTION
`pip install` without a hash check is considered unsafe from a software supply chain perspective. Currently the release script does that to install python tools for the release process. The Ruby team has provided a safe install mechanism for the release-related python packages (`gcp-releasetool` and `gcp-docuploader`), and has implemented it centrally in the googleapis/ruby-common-tools repository. This PR updates the release script to call that install mechanism rather than invoking `pip install` directly.