### PR TITLE
fix: Corrected the namespace for the transaction selector class

### DIFF
--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -251,7 +251,7 @@ module ActiveRecordSpannerAdapter
     # transaction fails, as that also means that no transaction id was returned.
     def create_transaction_after_failed_first_statement original_error
       transaction = current_transaction.force_begin_read_write
-      Google::Spanner::V1::TransactionSelector.new id: transaction.transaction_id
+      Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction.transaction_id
     rescue Google::Cloud::Error
       # Raise the original error if the BeginTransaction RPC also fails.
       raise original_error

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -55,9 +55,9 @@ module ActiveRecordSpannerAdapter
         when :pdml
           @grpc_transaction = @connection.session.create_pdml
         else
-          @begin_transaction_selector = Google::Spanner::V1::TransactionSelector.new \
-            begin: Google::Spanner::V1::TransactionOptions.new(
-              read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new
+          @begin_transaction_selector = Google::Cloud::Spanner::V1::TransactionSelector.new \
+            begin: Google::Cloud::Spanner::V1::TransactionOptions.new(
+              read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new
             )
 
         end
@@ -143,7 +143,7 @@ module ActiveRecordSpannerAdapter
 
       # Use the transaction that has been started by a BeginTransaction RPC or returned by a
       # statement, if present.
-      return Google::Spanner::V1::TransactionSelector.new id: @grpc_transaction.transaction_id \
+      return Google::Cloud::Spanner::V1::TransactionSelector.new id: @grpc_transaction.transaction_id \
           if @grpc_transaction
 
       # Return a transaction selector that will instruct the statement to also start a transaction

--- a/lib/activerecord_spanner_adapter/version.rb
+++ b/lib/activerecord_spanner_adapter/version.rb
@@ -5,5 +5,5 @@
 # https://opensource.org/licenses/MIT.
 
 module ActiveRecordSpannerAdapter
-  VERSION = "1.2.0".freeze
+  VERSION = "1.2.1".freeze
 end

--- a/lib/activerecord_spanner_adapter/version.rb
+++ b/lib/activerecord_spanner_adapter/version.rb
@@ -5,5 +5,5 @@
 # https://opensource.org/licenses/MIT.
 
 module ActiveRecordSpannerAdapter
-  VERSION = "1.2.1".freeze
+  VERSION = "1.2.0".freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -204,7 +204,7 @@ module MockGoogleSpanner
     alias execute execute_query
 
     def create_transaction
-      grpc = Google::Spanner::V1::Transaction.new id: SecureRandom.base64
+      grpc = Google::Cloud::Spanner::V1::Transaction.new id: SecureRandom.base64
       Google::Cloud::Spanner::Transaction.from_grpc grpc, self
     end
 
@@ -248,7 +248,7 @@ module MockGoogleSpanner
 
     def create_snapshot session_name, strong: nil, timestamp: nil,
                         staleness: nil
-      Google::Spanner::V1::Transaction.new id: SecureRandom.base64
+      Google::Cloud::Spanner::V1::Transaction.new id: SecureRandom.base64
     end
 
     def update statements: nil, operation_id: nil


### PR DESCRIPTION
I was getting an error that `Google::Spanner` was uninitialized. This update fixed it for me.