### PR TITLE
docs: update limitation on interleaved tables and default column values

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Some noteworthy examples in the snippets directory:
   for inserting, updating and deleting data in a Cloud Spanner database. Mutations can have a significant performance
   advantage compared to DML statements, but do not allow read-your-writes semantics during a transaction.
 - [array-data-type](examples/snippets/array-data-type): Shows how to work with `ARRAY` data types.
+- [interleaved-tables](examples/snippets/interleaved-tables): Shows how to work with [Interleaved Tables](https://cloud.google.com/spanner/docs/schema-and-data-model#create-interleaved-tables).
 
 ## Limitations
 
 Limitation|Comment|Resolution
 ---|---|---
-Interleaved tables are not supported|Cloud Spanner requires to use composite primary keys for interleaved tables, but Active Record does not support composite primary keys. More details: [#160](https://github.com/googleapis/ruby-spanner-activerecord/issues/160) |Use non-interleaved tables.
-Lack of DEFAULT for columns [change_column_default](https://apidock.com/rails/v5.2.3/ActiveRecord/ConnectionAdapters/SchemaStatements/change_column_default)|Cloud Spanner does not support DEFAULT values for columns. The use of default must be enforced in your controller logic| Always set a value in your model or controller logic.
+Interleaved tables require composite primary keys| Cloud Spanner requires composite primary keys for interleaved tables. See [this example](examples/snippets/interleaved-tables/README.md) for an example on how to use interleaved tables with ActiveRecord |Use composite primary keys.
 Lack of sequential and auto-assigned IDs|Cloud Spanner doesn't autogenerate IDs and this integration instead creates UUID4 to avoid [hotspotting](https://cloud.google.com/spanner/docs/schema-design#uuid_primary_key) so you SHOULD NOT rely on IDs being sorted| UUID4s are automatically generated for primary keys.
 Table without Primary Key| Cloud Spanner support does not support tables without a primary key.| Always define a primary key for your table.
 Table names CANNOT have spaces within them whether back-ticked or not|Cloud Spanner DOES NOT support tables with spaces in them for example `Entity ID`|Ensure that your table names don't contain spaces.


### PR DESCRIPTION
Cleanup the limitations section a little, so that:
1. Support for interleaved tables is correctly documented
2. The lack of default column values is removed, as it is now supported