### PR TITLE
feat: allows passing of type parameter when creating parent_key column

### DIFF
--- a/lib/active_record/connection_adapters/spanner/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_definitions.rb
@@ -15,8 +15,8 @@ module ActiveRecord
           @on_delete = on_delete
         end
 
-        def parent_key name
-          column name, :parent_key, null: false
+        def parent_key name, type: nil
+          column name, :parent_key, null: false, passed_type: type
         end
 
         def interleave_in?

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -389,7 +389,7 @@ module ActiveRecord
 
         # rubocop:disable Lint/UnusedMethodArgument
         def type_to_sql type, limit: nil, precision: nil, scale: nil, **opts
-          type = type.to_sym if type
+          type = opts[:passed_type] || type&.to_sym
           native = native_database_types[type]
 
           return type.to_s unless native

--- a/test/migrations_with_mock_server/db/migrate/10_create_parent_and_child_with_uuid_pk.rb
+++ b/test/migrations_with_mock_server/db/migrate/10_create_parent_and_child_with_uuid_pk.rb
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "composite_primary_keys"
+
+class CreateParentAndChildWithUuidPk < ActiveRecord::Migration[6.0]
+  def change
+    # Execute the entire migration as one DDL batch.
+    connection.ddl_batch do
+      create_table :parent_with_uuid_pk, id: false do |t|
+        t.primary_key :parentid, :string, limit: 36
+        t.string :first_name
+        t.string :last_name
+      end
+
+      create_table :child_with_uuid_pk, id: false do |t|
+        t.interleave_in :parent_with_uuid_pk
+        t.parent_key :parentid, type: 'STRING(36)'
+        t.primary_key :childid
+        t.string :title
+      end
+    end
+  end
+end
+

--- a/test/migrations_with_mock_server/models/child_with_uuid_pk.rb
+++ b/test/migrations_with_mock_server/models/child_with_uuid_pk.rb
@@ -1,0 +1,14 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "composite_primary_keys"
+
+module TestMigrationsWithMockServer
+  class ChildWithUuidPk < ActiveRecord::Base
+    # Register both primary key columns with composite_primary_keys
+    self.primary_keys = :parentid, :childid
+  end
+end

--- a/test/migrations_with_mock_server/models/parent_with_uuid_pk.rb
+++ b/test/migrations_with_mock_server/models/parent_with_uuid_pk.rb
@@ -1,0 +1,14 @@
+# Copyright 2022 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "composite_primary_keys"
+
+module TestMigrationsWithMockServer
+  class ParentWithUuidPk < ActiveRecord::Base
+    self.primary_keys = :parentid
+  end
+end
+


### PR DESCRIPTION
Our schema uses string UUIDs as primary keys. We want to create composite keys with these UUIDs to utilize interleaving. This is not currently possible with `parent_key` assuming we want an INT64 column.