### PR TITLE
feat: add extra index options to the schema.rb

### DIFF
--- a/lib/active_record/connection_adapters/spanner/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_dumper.rb
@@ -13,6 +13,14 @@ module ActiveRecord
         def default_primary_key? column
           schema_type(column) == :integer
         end
+
+        def index_parts(index)
+          index_parts = super
+          index_parts << "null_filtered: #{index.null_filtered.inspect}" if index.null_filtered
+          index_parts << "interleave_in: #{index.interleave_in.inspect}" if index.interleave_in
+          index_parts << "storing: #{format_index_parts(index.storing)}" if index.storing.present?
+          index_parts
+        end
       end
     end
   end


### PR DESCRIPTION
Adds `null_filtered`, `interleave_in`, `storing` index options to the schema.rb dump file.