### PR TITLE
fix: improve type commit_timestamp conversion detection

### DIFF
--- a/acceptance/cases/migration/schema_dumper_test.rb
+++ b/acceptance/cases/migration/schema_dumper_test.rb
@@ -43,6 +43,13 @@ module ActiveRecord
         ActiveRecord::SchemaDumper.dump connection, schema
         assert schema.string.include?("t.index [\"singerid\", \"albumid\", \"title\"], name: \"index_tracks_on_singerid_and_albumid_and_title\", order: { singerid: :asc, albumid: :asc, title: :asc }, null_filtered: true, interleave_in: \"albums\""), schema.string
       end
+
+      def test_dump_schema_contains_commit_timestamp
+        connection = ActiveRecord::Base.connection
+        schema = StringIO.new
+        ActiveRecord::SchemaDumper.dump connection, schema
+        assert schema.string.include?("t.time \"last_updated\", allow_commit_timestamp: true"), schema.string
+      end
     end
   end
 end

--- a/examples/snippets/commit-timestamp/db/schema.rb
+++ b/examples/snippets/commit-timestamp/db/schema.rb
@@ -16,13 +16,13 @@ ActiveRecord::Schema.define(version: 1) do
     t.string "title"
     t.decimal "marketing_budget"
     t.integer "singer_id", limit: 8
-    t.time "last_updated"
+    t.time "last_updated", allow_commit_timestamp: true
   end
 
   create_table "singers", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
-    t.time "last_updated"
+    t.time "last_updated", allow_commit_timestamp: true
   end
 
   add_foreign_key "albums", "singers"

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -220,7 +220,7 @@ module ActiveRecord
           params = binds.enum_for(:each_with_index).map do |bind, i|
             type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
             value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-              .serialize_with_transaction_isolation_level(type, bind.value, :mutation)
+                    .serialize_with_transaction_isolation_level(type, bind.value, :mutation)
 
             ["p#{i + 1}", value]
           end.to_h

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -220,7 +220,7 @@ module ActiveRecord
           params = binds.enum_for(:each_with_index).map do |bind, i|
             type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
             value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                    .serialize_with_transaction_isolation_level(type, bind.value, :mutation)
+                    .serialize_with_transaction_isolation_level(type, bind.value, :dml)
 
             ["p#{i + 1}", value]
           end.to_h

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -219,9 +219,8 @@ module ActiveRecord
           end.to_h
           params = binds.enum_for(:each_with_index).map do |bind, i|
             type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
-            value = bind
-            value = type.serialize bind.value, :dml if type.respond_to?(:serialize) && type.method(:serialize).arity < 0
-            value = type.serialize bind.value if type.respond_to?(:serialize) && type.method(:serialize).arity >= 0
+            value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+              .serialize_with_transaction_isolation_level(type, bind.value, :mutation)
 
             ["p#{i + 1}", value]
           end.to_h

--- a/lib/active_record/connection_adapters/spanner/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_dumper.rb
@@ -13,6 +13,14 @@ module ActiveRecord
         def default_primary_key? column
           schema_type(column) == :integer
         end
+
+        def prepare_column_options(column)
+          super.tap do |spec|
+            unless column.sql_type_metadata.allow_commit_timestamp.nil?
+              spec[:allow_commit_timestamp] = column.sql_type_metadata.allow_commit_timestamp
+            end
+          end
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/spanner/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_dumper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           schema_type(column) == :integer
         end
 
-        def prepare_column_options(column)
+        def prepare_column_options column
           super.tap do |spec|
             unless column.sql_type_metadata.allow_commit_timestamp.nil?
               spec[:allow_commit_timestamp] = column.sql_type_metadata.allow_commit_timestamp

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -111,13 +111,13 @@ module ActiveRecord
           ConnectionAdapters::Column.new \
             field.name,
             field.default,
-            fetch_type_metadata(field.spanner_type, field.ordinal_position),
+            fetch_type_metadata(field.spanner_type, field.ordinal_position, field.allow_commit_timestamp),
             field.nullable
         end
 
-        def fetch_type_metadata sql_type, ordinal_position = nil
+        def fetch_type_metadata sql_type, ordinal_position = nil, allow_commit_timestamp = nil
           Spanner::TypeMetadata.new \
-            super(sql_type), ordinal_position: ordinal_position
+            super(sql_type), ordinal_position: ordinal_position, allow_commit_timestamp: allow_commit_timestamp
         end
 
         def add_column table_name, column_name, type, **options

--- a/lib/active_record/connection_adapters/spanner/type_metadata.rb
+++ b/lib/active_record/connection_adapters/spanner/type_metadata.rb
@@ -39,8 +39,8 @@ module ActiveRecord
 
         private
 
-        def deduplcated
-          __setobj__ __getobj__.deduplcate
+        def deduplicated
+          __setobj__ __getobj__.deduplicate
           super
         end
       end

--- a/lib/active_record/connection_adapters/spanner/type_metadata.rb
+++ b/lib/active_record/connection_adapters/spanner/type_metadata.rb
@@ -12,24 +12,36 @@ module ActiveRecord
       class TypeMetadata < DelegateClass(SqlTypeMetadata)
         undef to_yaml if method_defined? :to_yaml
 
-        attr_reader :ordinal_position
+        include Deduplicable
 
-        def initialize type_metadata, ordinal_position: nil
+        attr_reader :ordinal_position, :allow_commit_timestamp
+
+        def initialize type_metadata, ordinal_position: nil, allow_commit_timestamp: nil
           super type_metadata
           @ordinal_position = ordinal_position
+          @allow_commit_timestamp = allow_commit_timestamp
         end
 
         def == other
           other.is_a?(TypeMetadata) &&
             __getobj__ == other.__getobj__ &&
-            ordinal_position == other.ordinal_position
+            ordinal_position == other.ordinal_position &&
+            allow_commit_timestamp == other.allow_commit_timestamp
         end
         alias eql? ==
 
         def hash
           TypeMetadata.hash ^
             __getobj__.hash ^
-            ordinal_position.hash
+            ordinal_position.hash ^
+            allow_commit_timestamp.hash
+        end
+
+        private
+
+        def deduplcated
+          __setobj__(__getobj__.deduplcate)
+          super
         end
       end
     end

--- a/lib/active_record/connection_adapters/spanner/type_metadata.rb
+++ b/lib/active_record/connection_adapters/spanner/type_metadata.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       class TypeMetadata < DelegateClass(SqlTypeMetadata)
         undef to_yaml if method_defined? :to_yaml
 
-        include Deduplicable
+        include Deduplicable if defined?(Deduplicable)
 
         attr_reader :ordinal_position, :allow_commit_timestamp
 
@@ -40,7 +40,7 @@ module ActiveRecord
         private
 
         def deduplcated
-          __setobj__(__getobj__.deduplcate)
+          __setobj__ __getobj__.deduplcate
           super
         end
       end

--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -10,6 +10,14 @@ module ActiveRecord
   module Type
     module Spanner
       class SpannerActiveRecordConverter
+        def self.serialize_with_transaction_isolation_level type, value, isolation_level
+          if type.respond_to?(:serialize_with_isolation_level)
+            type.serialize_with_isolation_level(value, isolation_level)
+          else
+            type.serialize(value)
+          end
+        end
+
         ##
         # Converts an ActiveModel::Type to a Spanner type code.
         def self.convert_active_model_type_to_spanner type # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -11,10 +11,10 @@ module ActiveRecord
     module Spanner
       class SpannerActiveRecordConverter
         def self.serialize_with_transaction_isolation_level type, value, isolation_level
-          if type.respond_to?(:serialize_with_isolation_level)
-            type.serialize_with_isolation_level(value, isolation_level)
+          if type.respond_to? :serialize_with_isolation_level
+            type.serialize_with_isolation_level value, isolation_level
           else
-            type.serialize(value)
+            type.serialize value
           end
         end
 

--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -16,7 +16,7 @@ module ActiveRecord
             return "spanner.commit_timestamp()" if isolation_level == :mutation
           end
 
-          serialize(value)
+          serialize value
         end
 
         def serialize value

--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -10,9 +10,16 @@ module ActiveRecord
   module Type
     module Spanner
       class Time < ActiveRecord::Type::Time
-        def serialize value, *options
-          return "PENDING_COMMIT_TIMESTAMP()" if value == :commit_timestamp && options.length && options[0] == :dml
-          return "spanner.commit_timestamp()" if value == :commit_timestamp && options.length && options[0] == :mutation
+        def serialize_with_isolation_level value, isolation_level
+          if value == :commit_timestamp
+            return "PENDING_COMMIT_TIMESTAMP()" if isolation_level == :dml
+            return "spanner.commit_timestamp()" if isolation_level == :mutation
+          end
+
+          serialize(value)
+        end
+
+        def serialize value
           val = super value
           val.acts_like?(:time) ? val.utc.rfc3339(9) : val
         end

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -230,7 +230,9 @@ module ActiveRecord
       columns = []
       values.each_pair do |k, v|
         serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-          .serialize_with_transaction_isolation_level(metadata.type(k), unwrap_attribute(v), :mutation)
+                             .serialize_with_transaction_isolation_level(metadata.type(k),
+                                                                         unwrap_attribute(v),
+                                                                         :mutation)
         columns << metadata.arel_table[k].name
       end
       [columns, Google::Protobuf::Value.new(list_value:
@@ -280,7 +282,9 @@ module ActiveRecord
       all_values.each do |h|
         h.each_pair do |k, v|
           all_serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-            .serialize_with_transaction_isolation_level(metadata.type(k), self.class.unwrap_attribute(v), :mutation)
+                                   .serialize_with_transaction_isolation_level(metadata.type(k),
+                                                                               self.class.unwrap_attribute(v),
+                                                                               :mutation)
           all_columns << metadata.arel_table[k].name
         end
       end
@@ -326,7 +330,9 @@ module ActiveRecord
       serialized_values = []
       keys.each do |key|
         serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-          .serialize_with_transaction_isolation_level(metadata.type(key), attribute_in_database(key), :mutation)
+                             .serialize_with_transaction_isolation_level(metadata.type(key),
+                                                                         attribute_in_database(key),
+                                                                         :mutation)
       end
       serialized_values
     end

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -229,9 +229,8 @@ module ActiveRecord
       serialized_values = []
       columns = []
       values.each_pair do |k, v|
-        v = unwrap_attribute v
-        type = metadata.type k
-        serialized_values << (type.method(:serialize).arity < 0 ? type.serialize(v, :mutation) : type.serialize(v))
+        serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+          .serialize_with_transaction_isolation_level(metadata.type(k), unwrap_attribute(v), :mutation)
         columns << metadata.arel_table[k].name
       end
       [columns, Google::Protobuf::Value.new(list_value:
@@ -280,10 +279,8 @@ module ActiveRecord
       all_columns = []
       all_values.each do |h|
         h.each_pair do |k, v|
-          type = metadata.type k
-          v = self.class.unwrap_attribute v
-          has_serialize_options = type.method(:serialize).arity < 0
-          all_serialized_values << (has_serialize_options ? type.serialize(v, :mutation) : type.serialize(v))
+          all_serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+            .serialize_with_transaction_isolation_level(metadata.type(k), self.class.unwrap_attribute(v), :mutation)
           all_columns << metadata.arel_table[k].name
         end
       end
@@ -328,10 +325,8 @@ module ActiveRecord
     def serialize_keys metadata, keys
       serialized_values = []
       keys.each do |key|
-        type = metadata.type key
-        has_serialize_options = type.method(:serialize).arity < 0
-        serialized_values << type.serialize(attribute_in_database(key), :mutation) if has_serialize_options
-        serialized_values << type.serialize(attribute_in_database(key)) unless has_serialize_options
+        serialized_values << ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+          .serialize_with_transaction_isolation_level(metadata.type(key), attribute_in_database(key), :mutation)
       end
       serialized_values
     end

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -69,14 +69,14 @@ module ActiveRecordSpannerAdapter
       sql << " AND COLUMN_NAME=%<column_name>s" if column_name
       sql << " ORDER BY ORDINAL_POSITION ASC"
 
-      column_options = column_options(table_name, column_name)
+      column_options = column_options table_name, column_name
       execute_query(
         sql,
         table_name: table_name,
         column_name: column_name
       ).map do |row|
         type, limit = parse_type_and_limit row["SPANNER_TYPE"]
-        column_name = row['COLUMN_NAME']
+        column_name = row["COLUMN_NAME"]
         options = column_options[column_name]
 
         Table::Column.new \
@@ -84,7 +84,7 @@ module ActiveRecordSpannerAdapter
           column_name,
           type,
           limit: limit,
-          allow_commit_timestamp: options['allow_commit_timestamp'],
+          allow_commit_timestamp: options["allow_commit_timestamp"],
           ordinal_position: row["ORDINAL_POSITION"],
           nullable: row["IS_NULLABLE"] == "YES",
           default: row["COLUMN_DEFAULT"]
@@ -269,11 +269,11 @@ module ActiveRecordSpannerAdapter
         table_name: table_name,
         column_name: column_name
       ).each_with_object(column_options) do |row, options|
-        next unless row['OPTION_TYPE'] == 'BOOL'
+        next unless row["OPTION_TYPE"] == "BOOL"
 
-        col = row['COLUMN_NAME']
-        opt = row['OPTION_NAME']
-        value = row['OPTION_VALUE'] == 'TRUE'
+        col = row["COLUMN_NAME"]
+        opt = row["OPTION_NAME"]
+        value = row["OPTION_VALUE"] == "TRUE"
         options[col][opt] = value
       end
     end

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -69,17 +69,22 @@ module ActiveRecordSpannerAdapter
       sql << " AND COLUMN_NAME=%<column_name>s" if column_name
       sql << " ORDER BY ORDINAL_POSITION ASC"
 
+      column_options = column_options(table_name, column_name)
       execute_query(
         sql,
         table_name: table_name,
         column_name: column_name
       ).map do |row|
         type, limit = parse_type_and_limit row["SPANNER_TYPE"]
+        column_name = row['COLUMN_NAME']
+        options = column_options[column_name]
+
         Table::Column.new \
           table_name,
-          row["COLUMN_NAME"],
+          column_name,
           type,
           limit: limit,
+          allow_commit_timestamp: options['allow_commit_timestamp'],
           ordinal_position: row["ORDINAL_POSITION"],
           nullable: row["IS_NULLABLE"] == "YES",
           default: row["COLUMN_DEFAULT"]
@@ -251,6 +256,27 @@ module ActiveRecordSpannerAdapter
     end
 
     private
+
+    def column_options table_name, column_name
+      sql = +"SELECT COLUMN_NAME, OPTION_NAME, OPTION_TYPE, OPTION_VALUE"
+      sql << " FROM INFORMATION_SCHEMA.COLUMN_OPTIONS"
+      sql << " WHERE TABLE_NAME=%<table_name>s"
+      sql << " AND COLUMN_NAME=%<column_name>s" if column_name
+
+      column_options = Hash.new { |h, k| h[k] = {} }
+      execute_query(
+        sql,
+        table_name: table_name,
+        column_name: column_name
+      ).each_with_object(column_options) do |row, options|
+        next unless row['OPTION_TYPE'] == 'BOOL'
+
+        col = row['COLUMN_NAME']
+        opt = row['OPTION_NAME']
+        value = row['OPTION_VALUE'] == 'TRUE'
+        options[col][opt] = value
+      end
+    end
 
     def execute_query sql, params = {}
       params = params.transform_values { |v| quote v }

--- a/test/activerecord_spanner_interleaved_table/model_helper.rb
+++ b/test/activerecord_spanner_interleaved_table/model_helper.rb
@@ -137,6 +137,8 @@ module TestInterleavedTables
   end
 
   def self.register_singers_columns_result spanner_mock_server
+    MockServerTests::register_commit_timestamps_result spanner_mock_server, "singers"
+
     sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='singers' ORDER BY ORDINAL_POSITION ASC"
 
     column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -213,6 +215,8 @@ module TestInterleavedTables
   end
 
   def self.register_albums_columns_result spanner_mock_server
+    MockServerTests::register_commit_timestamps_result spanner_mock_server, "albums"
+
     sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='albums' ORDER BY ORDINAL_POSITION ASC"
 
     column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -299,6 +303,8 @@ module TestInterleavedTables
   end
 
   def self.register_tracks_columns_result spanner_mock_server
+    MockServerTests::register_commit_timestamps_result spanner_mock_server, "tracks"
+
     sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='tracks' ORDER BY ORDINAL_POSITION ASC"
 
     column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -1034,6 +1034,8 @@ module TestMigrationsWithMockServer
 
     def register_schema_migrations_columns_result
       # CREATE TABLE `schema_migrations` (`version` STRING(MAX) NOT NULL) PRIMARY KEY (`version`)
+      MockServerTests::register_commit_timestamps_result @mock, "schema_migrations"
+
       sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='schema_migrations' ORDER BY ORDINAL_POSITION ASC"
 
       column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -1066,6 +1068,8 @@ module TestMigrationsWithMockServer
 
     def register_ar_internal_metadata_columns_result
       # CREATE TABLE `ar_internal_metadata` (`key` STRING(MAX) NOT NULL, `value` STRING(MAX), `created_at` TIMESTAMP NOT NULL, `updated_at` TIMESTAMP NOT NULL) PRIMARY KEY (`key`)
+      MockServerTests::register_commit_timestamps_result @mock, "ar_internal_metadata"
+
       sql = "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='ar_internal_metadata' ORDER BY ORDINAL_POSITION ASC"
 
       column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -1186,6 +1190,7 @@ module TestMigrationsWithMockServer
     end
 
     def register_single_select_columns_result sql, column_name, spanner_type, is_nullable = true
+      MockServerTests::register_commit_timestamps_result @mock, "singers", column_name
       col_column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       col_spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       col_is_nullable = Google::Cloud::Spanner::V1::StructType::Field.new name: "IS_NULLABLE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
@@ -1269,6 +1274,7 @@ module TestMigrationsWithMockServer
     end
 
     def register_select_single_column_result sql, column_name, spanner_type, is_nullable = true
+      MockServerTests::register_commit_timestamps_result @mock, "singers", column_name
       # "SELECT COLUMN_NAME, SPANNER_TYPE, IS_NULLABLE, CAST(COLUMN_DEFAULT AS STRING) AS COLUMN_DEFAULT, ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='singers' AND COLUMN_NAME='age' ORDER BY ORDINAL_POSITION ASC"
       col_column_name = Google::Cloud::Spanner::V1::StructType::Field.new name: "COLUMN_NAME", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)
       col_spanner_type = Google::Cloud::Spanner::V1::StructType::Field.new name: "SPANNER_TYPE", type: Google::Cloud::Spanner::V1::Type.new(code: Google::Cloud::Spanner::V1::TypeCode::STRING)


### PR DESCRIPTION
Some type classes are defined as delegates of other types, so the arity
of the `serialize` method will be -1 as it delegates the implementation.
This causes errors for timestamp columns that are timezone aware. This
detail was added due to the conditional nature of the Spanner commit
timestamp value depending on the query type, dml or in a mutation.

This was causing `ArgumentError`s under certain conditions when 
typecasting timezone aware attributes.

To make it more clear, define a explicit interface for the adapter to
use that takes the isolation level.

This also includes a feature to add `allow_commit_timestamp` to the Ruby
schema.rb