### PR TITLE
feat: add check constraint support to migrations

### DIFF
--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -26,6 +26,12 @@ module ActiveRecord
             end
           end
 
+          if ActiveRecord::VERSION::MAJOR >= 7
+            statements.concat(o.check_constraints.map { |chk| accept chk })
+          else
+            statements.concat(o.check_constraints.map { |expression, options| check_constraint_in_create(o.name, expression, options) })
+          end
+
           create_sql << "(#{statements.join ', '}) " if statements.any?
 
           primary_keys = if o.primary_keys

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -376,6 +376,12 @@ module ActiveRecord
         end
         alias add_belongs_to add_reference
 
+        # Check Contraints
+
+        def check_constraints table_name
+          information_schema { |i| i.check_constraints table_name }
+        end
+
         def quoted_scope name = nil, type: nil
           scope = { schema: quote("") }
           scope[:name] = quote name if name

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -170,6 +170,10 @@ module ActiveRecord
         true
       end
 
+      def supports_check_constraints?
+        true
+      end
+
       # Generate next sequence number for primary key
       def next_sequence_value _sequence_name
         SecureRandom.uuid.gsub("-", "").hex & 0x7FFFFFFFFFFFFFFF

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -252,11 +252,11 @@ module ActiveRecordSpannerAdapter
           AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%%' AND cc.CHECK_CLAUSE LIKE '%%IS NOT NULL')
       SQL
 
-      rows = execute_query(sql, table_name: table_name)
+      rows = execute_query sql, table_name: table_name
 
       rows.map do |row|
         ActiveRecord::ConnectionAdapters::CheckConstraintDefinition.new(
-          table_name, row['CHECK_CLAUSE'], name: row['CONSTRAINT_NAME']
+          table_name, row["CHECK_CLAUSE"], name: row["CONSTRAINT_NAME"]
         )
       end
     end

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -249,7 +249,7 @@ module ActiveRecordSpannerAdapter
         INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
         WHERE tc.TABLE_NAME = %<table_name>s
           AND tc.CONSTRAINT_TYPE = 'CHECK'
-          AND tc.CONSTRAINT_NAME LIKE 'chk_rails_%%'
+          AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%%' AND cc.CHECK_CLAUSE LIKE '%%IS NOT NULL')
       SQL
 
       rows = execute_query(sql, table_name: table_name)

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -240,6 +240,27 @@ module ActiveRecordSpannerAdapter
       end
     end
 
+    def check_constraints table_name
+      sql = <<~SQL.squish
+        SELECT tc.TABLE_NAME,
+               tc.CONSTRAINT_NAME,
+               cc.CHECK_CLAUSE
+        FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+        INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+        WHERE tc.TABLE_NAME = %<table_name>s
+          AND tc.CONSTRAINT_TYPE = 'CHECK'
+          AND tc.CONSTRAINT_NAME LIKE 'chk_rails_%%'
+      SQL
+
+      rows = execute_query(sql, table_name: table_name)
+
+      rows.map do |row|
+        ActiveRecord::ConnectionAdapters::CheckConstraintDefinition.new(
+          table_name, row['CHECK_CLAUSE'], name: row['CONSTRAINT_NAME']
+        )
+      end
+    end
+
     def parse_type_and_limit value
       matched = /^([A-Z]*)\((.*)\)/.match value
       return [value] unless matched

--- a/test/activerecord_spanner_adapter/information_schema_test.rb
+++ b/test/activerecord_spanner_adapter/information_schema_test.rb
@@ -81,7 +81,7 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     @check_constraints_result = [
       {
         "TABLE_NAME" => "accounts",
-        "CONSTRAINT_NAME" => "chk_rails_accounts_name",
+        "CONSTRAINT_NAME" => "chk_accounts_name",
         "CHECK_CLAUSE" => "name IN ('bob')"
       }
     ]
@@ -346,14 +346,14 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal results.length, 1
 
     assert_sql_equal(
-      "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_TYPE = 'CHECK' AND tc.CONSTRAINT_NAME LIKE 'chk_rails_%'",
+      "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_TYPE = 'CHECK' AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%' AND cc.CHECK_CLAUSE LIKE '%IS NOT NULL')",
       last_executed_sql
     )
 
     cc = results.first
     assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
     assert_equal cc.table_name, "accounts"
-    assert_equal cc.name, "chk_rails_accounts_name"
+    assert_equal cc.name, "chk_accounts_name"
     assert_equal cc.expression, "name IN ('bob')"
   end
 end

--- a/test/activerecord_spanner_adapter/information_schema_test.rb
+++ b/test/activerecord_spanner_adapter/information_schema_test.rb
@@ -334,26 +334,28 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     assert_equal index.columns.any?{ |c| c.name == "user_id"}, true
   end
 
-  def test_empty_check_contraints
-    set_mocked_result []
-    results = info_schema.check_constraints "accounts"
-    assert_empty results
-  end
+  if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
+    def test_empty_check_contraints
+      set_mocked_result []
+      results = info_schema.check_constraints "accounts"
+      assert_empty results
+    end
 
-  def test_check_constraints
-    set_mocked_result check_constraints_result
-    results = info_schema.check_constraints "accounts"
-    assert_equal results.length, 1
+    def test_check_constraints
+      set_mocked_result check_constraints_result
+      results = info_schema.check_constraints "accounts"
+      assert_equal results.length, 1
 
-    assert_sql_equal(
-      "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_TYPE = 'CHECK' AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%' AND cc.CHECK_CLAUSE LIKE '%IS NOT NULL')",
-      last_executed_sql
-    )
+      assert_sql_equal(
+        "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_TYPE = 'CHECK' AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%' AND cc.CHECK_CLAUSE LIKE '%IS NOT NULL')",
+        last_executed_sql
+      )
 
-    cc = results.first
-    assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
-    assert_equal cc.table_name, "accounts"
-    assert_equal cc.name, "chk_accounts_name"
-    assert_equal cc.expression, "name IN ('bob')"
+      cc = results.first
+      assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
+      assert_equal cc.table_name, "accounts"
+      assert_equal cc.name, "chk_accounts_name"
+      assert_equal cc.expression, "name IN ('bob')"
+    end
   end
 end

--- a/test/activerecord_spanner_adapter/information_schema_test.rb
+++ b/test/activerecord_spanner_adapter/information_schema_test.rb
@@ -9,7 +9,8 @@ require "test_helper"
 class InformationSchemaTest < TestHelper::MockActiveRecordTest
   attr_reader :info_schema, :tables_schema_result,
     :table_columns_result, :indexes_result,
-    :index_columns_result
+    :index_columns_result,
+    :check_constraints_result
 
   def setup
     super
@@ -75,6 +76,13 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
         "COLUMN_ORDERING" => "ASC",
         "IS_NULLABLE" => "YES",
         "SPANNER_TYPE" => "INT64"
+      }
+    ]
+    @check_constraints_result = [
+      {
+        "TABLE_NAME" => "accounts",
+        "CONSTRAINT_NAME" => "chk_rails_accounts_name",
+        "CHECK_CLAUSE" => "name IN ('bob')"
       }
     ]
   end
@@ -324,5 +332,28 @@ class InformationSchemaTest < TestHelper::MockActiveRecordTest
     index = result.first
     assert_equal index.name, "index_orders_on_user_id"
     assert_equal index.columns.any?{ |c| c.name == "user_id"}, true
+  end
+
+  def test_empty_check_contraints
+    set_mocked_result []
+    results = info_schema.check_constraints "accounts"
+    assert_empty results
+  end
+
+  def test_check_constraints
+    set_mocked_result check_constraints_result
+    results = info_schema.check_constraints "accounts"
+    assert_equal results.length, 1
+
+    assert_sql_equal(
+      "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_TYPE = 'CHECK' AND tc.CONSTRAINT_NAME LIKE 'chk_rails_%'",
+      last_executed_sql
+    )
+
+    cc = results.first
+    assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
+    assert_equal cc.table_name, "accounts"
+    assert_equal cc.name, "chk_rails_accounts_name"
+    assert_equal cc.expression, "name IN ('bob')"
   end
 end

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -44,7 +44,9 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.string :title
         t.numeric :duration
 
-        t.check_constraint 'duration > 0', name: :chk_tracks_duration
+        if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
+          t.check_constraint 'duration > 0', name: :chk_tracks_duration
+        end
       end
 
       # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -44,7 +44,7 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.string :title
         t.numeric :duration
 
-        t.check_constraint 'duration > 0', name: :chk_rails_tracks_duration
+        t.check_constraint 'duration > 0', name: :chk_tracks_duration
       end
 
       # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -43,6 +43,8 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.parent_key :albumid
         t.string :title
         t.numeric :duration
+
+        t.check_constraint 'duration > 0', name: :chk_rails_tracks_duration
       end
 
       # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -229,7 +229,7 @@ module TestMigrationsWithMockServer
 
       expectedDdl = "CREATE TABLE `tracks` "
       expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC,"
-      expectedDdl << " CONSTRAINT chk_rails_tracks_duration CHECK (duration > 0))"
+      expectedDdl << " CONSTRAINT chk_tracks_duration CHECK (duration > 0))"
       expectedDdl << " PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
       assert_equal expectedDdl, ddl_requests[2].statements[3]
 

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -228,7 +228,8 @@ module TestMigrationsWithMockServer
       assert_equal expectedDdl, ddl_requests[2].statements[2]
 
       expectedDdl = "CREATE TABLE `tracks` "
-      expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC)"
+      expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC,"
+      expectedDdl << " CONSTRAINT chk_rails_tracks_duration CHECK (duration > 0))"
       expectedDdl << " PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
       assert_equal expectedDdl, ddl_requests[2].statements[3]
 

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -228,9 +228,11 @@ module TestMigrationsWithMockServer
       assert_equal expectedDdl, ddl_requests[2].statements[2]
 
       expectedDdl = "CREATE TABLE `tracks` "
-      expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC,"
-      expectedDdl << " CONSTRAINT chk_tracks_duration CHECK (duration > 0))"
-      expectedDdl << " PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
+      expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC"
+      if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
+        expectedDdl << ", CONSTRAINT chk_tracks_duration CHECK (duration > 0)"
+      end
+      expectedDdl << ") PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
       assert_equal expectedDdl, ddl_requests[2].statements[3]
 
       expectedDdl = "CREATE UNIQUE INDEX `index_tracks_on_trackid` "


### PR DESCRIPTION
Support native rails check constraints in the Spanner adapter:

```
create_table :adults do |t|
  t.integer :age, null: false
  t.check_constraint 'age > 18', name: :chk_adults_age
end
```

Will generate the following constraint:

```
CONSTRAINT chk_adults_age CHECK(age > 18)
```