### PR TITLE
fix: schema with integer primary keys

### DIFF
--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -8,7 +8,7 @@
 
 ActiveRecord::Schema.define do
   ActiveRecord::Base.connection.ddl_batch do
-    create_table :all_types do |t|
+    create_table :all_types, id: { limit: 8 } do |t|
       t.column :col_string, :string
       t.column :col_int64, :bigint
       t.column :col_float64, :float

--- a/examples/snippets/array-data-type/db/schema.rb
+++ b/examples/snippets/array-data-type/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "entity_with_array_types", force: :cascade do |t|
+  create_table "entity_with_array_types", id: { limit: 8 }, force: :cascade do |t|
     t.string "col_array_string"
     t.integer "col_array_int64", limit: 8
     t.float "col_array_float64"

--- a/examples/snippets/bulk-insert/db/schema.rb
+++ b/examples/snippets/bulk-insert/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,12 +12,12 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/examples/snippets/commit-timestamp/db/schema.rb
+++ b/examples/snippets/commit-timestamp/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,14 +12,14 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.decimal "marketing_budget"
     t.integer "singer_id", limit: 8
     t.time "last_updated"
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.time "last_updated"

--- a/examples/snippets/create-records/db/schema.rb
+++ b/examples/snippets/create-records/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,12 +12,12 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/examples/snippets/date-data-type/db/schema.rb
+++ b/examples/snippets/date-data-type/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.date "birth_date"

--- a/examples/snippets/migrations/db/schema.rb
+++ b/examples/snippets/migrations/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,18 +12,18 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.integer "singers_id", limit: 8
     t.index ["singers_id"], name: "index_albums_on_singers_id", order: { singers_id: :asc }
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end
 
-  create_table "tracks", force: :cascade do |t|
+  create_table "tracks", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.decimal "duration"
     t.integer "albums_id", limit: 8

--- a/examples/snippets/mutations/db/schema.rb
+++ b/examples/snippets/mutations/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,13 +12,13 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.decimal "marketing_budget"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/examples/snippets/optimistic-locking/db/schema.rb
+++ b/examples/snippets/optimistic-locking/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,14 +12,14 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.decimal "marketing_budget"
     t.integer "singer_id", limit: 8
     t.integer "lock_version", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.integer "lock_version", limit: 8

--- a/examples/snippets/quickstart/db/schema.rb
+++ b/examples/snippets/quickstart/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,12 +12,12 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/examples/snippets/read-write-transactions/db/schema.rb
+++ b/examples/snippets/read-write-transactions/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,13 +12,13 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "albums", force: :cascade do |t|
+  create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.decimal "marketing_budget"
     t.integer "singer_id", limit: 8
   end
 
-  create_table "singers", force: :cascade do |t|
+  create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end

--- a/examples/snippets/timestamp-data-type/db/schema.rb
+++ b/examples/snippets/timestamp-data-type/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 1) do
 
-  create_table "meetings", force: :cascade do |t|
+  create_table "meetings", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
     t.time "meeting_time"
     t.string "meeting_timezone"

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -39,18 +39,19 @@ module ActiveRecord
         end
         alias data_source_exists? table_exists?
 
-        def create_table table_name, **options
+        def create_table table_name, id: :primary_key, **options
           td = create_table_definition table_name, options
 
-          if options[:id] != false
+          if id
             pk = options.fetch :primary_key do
               Base.get_primary_key table_name.to_s.singularize
             end
+            id = id.fetch(:type, :primary_key) if id.is_a?(Hash)
 
             if pk.is_a? Array
               td.primary_keys pk
             else
-              td.primary_key pk, options.fetch(:id, :primary_key), **{}
+              td.primary_key pk, id, **{}
             end
           end
 

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -46,7 +46,7 @@ module ActiveRecord
             pk = options.fetch :primary_key do
               Base.get_primary_key table_name.to_s.singularize
             end
-            id = id.fetch(:type, :primary_key) if id.is_a?(Hash)
+            id = id.fetch :type, :primary_key if id.is_a? Hash
 
             if pk.is_a? Array
               td.primary_keys pk


### PR DESCRIPTION
`create_table` had outdated logic that needed to be updated to Rails 6.1+ to allow for a `id: { limit: 8 }` option on the primary key (even though not used by the driver). The `limit: 8` is added due to the type definition of the INT64 columns.