### PR TITLE
feat: schema_dumper should use DDL batch

### DIFF
--- a/acceptance/cases/migration/schema_dumper_test.rb
+++ b/acceptance/cases/migration/schema_dumper_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActiveRecord
+  class Migration
+    class IndexTest < SpannerAdapter::TestCase
+      include SpannerAdapter::Migration::TestHelper
+
+      def test_dump_schema_contains_start_batch_ddl
+        connection = ActiveRecord::Base.connection
+        schema = StringIO.new
+        ActiveRecord::SchemaDumper.dump connection, schema
+        assert schema.string.include?("connection.start_batch_ddl")
+      end
+
+      def test_dump_schema_contains_run_batch
+        connection = ActiveRecord::Base.connection
+        schema = StringIO.new
+        ActiveRecord::SchemaDumper.dump connection, schema
+        assert schema.string.include?("  connection.run_batch\n"\
+                                      "rescue\n"\
+                                      "  abort_batch\n"\
+                                      "  raise")
+      end
+    end
+  end
+end

--- a/examples/snippets/array-data-type/db/schema.rb
+++ b/examples/snippets/array-data-type/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "entity_with_array_types", force: :cascade do |t|
     t.string "col_array_string"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.time "col_array_timestamp"
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/bulk-insert/db/schema.rb
+++ b/examples/snippets/bulk-insert/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/commit-timestamp/db/schema.rb
+++ b/examples/snippets/commit-timestamp/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -26,4 +27,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/create-records/db/schema.rb
+++ b/examples/snippets/create-records/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/date-data-type/db/schema.rb
+++ b/examples/snippets/date-data-type/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "singers", force: :cascade do |t|
     t.string "first_name"
@@ -18,4 +19,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.date "birth_date"
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/generated-column/db/schema.rb
+++ b/examples/snippets/generated-column/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "singers", id: { limit: 8 }, force: :cascade do |t|
     t.string "first_name", limit: 100
@@ -18,4 +19,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.string "full_name", limit: 300, null: false
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/hints/db/schema.rb
+++ b/examples/snippets/hints/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
@@ -25,4 +26,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/interleaved-tables/db/schema.rb
+++ b/examples/snippets/interleaved-tables/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", primary_key: "albumid", id: { limit: 8 }, force: :cascade do |t|
     t.integer "singerid", limit: 8, null: false
@@ -29,4 +30,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.decimal "duration"
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/migrations/db/schema.rb
+++ b/examples/snippets/migrations/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -30,4 +31,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.index ["albums_id"], name: "index_tracks_on_albums_id", order: { albums_id: :asc }
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/mutations/db/schema.rb
+++ b/examples/snippets/mutations/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -24,4 +25,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/optimistic-locking/db/schema.rb
+++ b/examples/snippets/optimistic-locking/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -26,4 +27,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/partitioned-dml/db/schema.rb
+++ b/examples/snippets/partitioned-dml/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/quickstart/db/schema.rb
+++ b/examples/snippets/quickstart/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/read-only-transactions/db/schema.rb
+++ b/examples/snippets/read-only-transactions/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/read-write-transactions/db/schema.rb
+++ b/examples/snippets/read-write-transactions/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
@@ -24,4 +25,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/stale-reads/db/schema.rb
+++ b/examples/snippets/stale-reads/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "albums", id: { limit: 8 }, force: :cascade do |t|
     t.string "title"
@@ -23,4 +24,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   add_foreign_key "albums", "singers"
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/examples/snippets/timestamp-data-type/db/schema.rb
+++ b/examples/snippets/timestamp-data-type/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 1) do
+  connection.start_batch_ddl
 
   create_table "meetings", force: :cascade do |t|
     t.string "title"
@@ -18,4 +19,8 @@ ActiveRecord::Schema.define(version: 1) do
     t.string "meeting_timezone"
   end
 
+  connection.run_batch
+rescue
+  abort_batch
+  raise
 end

--- a/lib/active_record/connection_adapters/spanner/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_dumper.rb
@@ -13,6 +13,26 @@ module ActiveRecord
         def default_primary_key? column
           schema_type(column) == :integer
         end
+
+        def header(stream)
+          str = StringIO.new
+          super(str)
+          stream.puts <<HEADER
+#{str.string.rstrip}
+  connection.start_batch_ddl
+
+HEADER
+        end
+
+        def trailer(stream)
+          stream.puts <<TRAILER
+  connection.run_batch
+rescue
+  abort_batch
+  raise
+TRAILER
+          super
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/spanner/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_dumper.rb
@@ -14,23 +14,22 @@ module ActiveRecord
           schema_type(column) == :integer
         end
 
-        def header(stream)
+        def header stream
           str = StringIO.new
-          super(str)
-          stream.puts <<HEADER
-#{str.string.rstrip}
-  connection.start_batch_ddl
-
-HEADER
+          super str
+          stream.puts <<~HEADER
+            #{str.string.rstrip}
+            connection.start_batch_ddl
+          HEADER
         end
 
-        def trailer(stream)
-          stream.puts <<TRAILER
-  connection.run_batch
-rescue
-  abort_batch
-  raise
-TRAILER
+        def trailer stream
+          stream.puts <<~TRAILER
+              connection.run_batch
+            rescue
+              abort_batch
+              raise
+          TRAILER
           super
         end
       end


### PR DESCRIPTION
To speed up the loading of the schema.rb (in `rails db:schema:load`), load the entire schema in a batch.