### PR TITLE
fix: ignore no database when recreating

### DIFF
--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -29,7 +29,12 @@ module ActiveRecord
       end
 
       def purge
-        drop
+        begin
+          drop
+        rescue ActiveRecord::NoDatabaseError
+          # ignored; create the database
+        end
+
         create
       end
 

--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       def purge
         begin
           drop
-        rescue ActiveRecord::NoDatabaseError
+        rescue ActiveRecord::NoDatabaseError # rubocop:disable Lint/HandleExceptions
           # ignored; create the database
         end
 

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -89,9 +89,7 @@ module ActiveRecordSpannerAdapter
       @database ||= begin
         database = spanner.database instance_id, database_id
         unless database
-          raise ActiveRecord::NoDatabaseError(
-            "#{spanner.project}/#{instance_id}/#{database_id}"
-          )
+          raise ActiveRecord::NoDatabaseError, "#{spanner.project}/#{instance_id}/#{database_id}"
         end
         database
       end


### PR DESCRIPTION
When recreating the database, ignore if it does not exist and continue to create the database as requested.
This mimics the rest of the AR adapters.

Fixes the `NoDatabaseError` that is raised if there is no database.