### PR TITLE
fix: ignore binds on unprepared statements

### DIFF
--- a/acceptance/cases/models/query_test.rb
+++ b/acceptance/cases/models/query_test.rb
@@ -166,6 +166,11 @@ module ActiveRecord
         assert_nil post.id
         assert_equal "Title - 1", post.title
       end
+
+      def test_to_sql
+        assert_equal "SELECT `comments`.* FROM `comments` WHERE `comments`.`comment` = 'Comment - 2'",
+                     Comment.where(comment: 'Comment - 2').to_sql
+      end
     end
   end
 end

--- a/lib/arel/visitors/spanner.rb
+++ b/lib/arel/visitors/spanner.rb
@@ -30,10 +30,16 @@ module Arel # :nodoc: all
         collector.hints = {}
         collector.table_hints = {}
         collector.join_hints = {}
+
         sql, binds = accept(node, collector).value
         sql = collector.hints[:statement_hint].value + sql if collector.hints[:statement_hint]
-        binds << collector.hints[:staleness] if collector.hints[:staleness]
-        [sql, binds]
+
+        if binds
+          binds << collector.hints[:staleness] if collector.hints[:staleness]
+          [sql, binds]
+        else
+          sql
+        end
       end
 
       private


### PR DESCRIPTION
`Relation#to_sql` disables prepared statements so the resulting SQL string has the binds interpolated into the statement. Keep the return value of the collector since the collector is context dependent.