### PR TITLE
Revert "chore: Change env var names used in tests"

### DIFF
--- a/acceptance/cases/sessions/session_not_found_test.rb
+++ b/acceptance/cases/sessions/session_not_found_test.rb
@@ -37,7 +37,7 @@ module ActiveRecord
         @client ||= Google::Cloud::Spanner::V1::Spanner::Client.new do |config|
           config.credentials = ENV["SPANNER_EMULATOR_HOST"] \
             ? :this_channel_is_insecure \
-            : ENV["SPANNER_KEYFILE_JSON"]
+            : ENV["SPANNER_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
           config.endpoint = ENV["SPANNER_EMULATOR_HOST"] if ENV["SPANNER_EMULATOR_HOST"]
         end
       end
@@ -45,7 +45,7 @@ module ActiveRecord
       def delete_all_sessions
         sessions = client.list_sessions(
           Google::Cloud::Spanner::V1::ListSessionsRequest.new(
-            database: "projects/#{ENV["SPANNER_PROJECT"]}/instances/#{ENV["SPANNER_TEST_INSTANCE"]}/databases/#{$spanner_test_database}"
+            database: "projects/#{ENV["SPANNER_TEST_PROJECT"]}/instances/#{ENV["SPANNER_TEST_INSTANCE"]}/databases/#{$spanner_test_database}"
           )
         )
         sessions.each do |session|

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -24,17 +24,17 @@ def connector_config
   {
     "adapter" => "spanner",
     "emulator_host" => ENV["SPANNER_EMULATOR_HOST"],
-    "project" => ENV["SPANNER_PROJECT"],
+    "project" => ENV["SPANNER_TEST_PROJECT"],
     "instance" => ENV["SPANNER_TEST_INSTANCE"],
-    "credentials" => ENV["SPANNER_KEYFILE_JSON"],
+    "credentials" => ENV["SPANNER_TEST_KEYFILE"],
     "database" => $spanner_test_database
   }
 end
 
 def spanner
   $spanner ||= Google::Cloud::Spanner.new(
-    project_id: ENV["SPANNER_PROJECT"],
-    credentials: ENV["SPANNER_KEYFILE_JSON"]
+    project_id: ENV["SPANNER_TEST_PROJECT"],
+    credentials: ENV["SPANNER_TEST_KEYFILE"]
   )
 end
 


### PR DESCRIPTION
Reverts googleapis/ruby-spanner-activerecord#211