### PR TITLE
fix: build error for ruby 2.5

### DIFF
--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -221,7 +221,7 @@ module ActiveRecord
             ]
           end.to_h
           params = binds.enum_for(:each_with_index).map do |bind, i|
-            type = bind.respond_to?(:type) ? bind.type : :INT64
+            type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
             bind_value = bind.respond_to?(:value) ? bind.value : bind
             value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
                     .serialize_with_transaction_isolation_level(type, bind_value, :dml)

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -221,7 +221,7 @@ module ActiveRecord
             ]
           end.to_h
           params = binds.enum_for(:each_with_index).map do |bind, i|
-            type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
+            type = bind.respond_to?(:type) ? bind.type : :INT64
             bind_value = bind.respond_to?(:value) ? bind.value : bind
             value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
                     .serialize_with_transaction_isolation_level(type, bind_value, :dml)

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -222,8 +222,9 @@ module ActiveRecord
           end.to_h
           params = binds.enum_for(:each_with_index).map do |bind, i|
             type = bind.respond_to?(:type) ? bind.type : ActiveModel::Type::Integer
+            bind_value = bind.respond_to?(:value) ? bind.value : bind
             value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                    .serialize_with_transaction_isolation_level(type, bind.value, :dml)
+                    .serialize_with_transaction_isolation_level(type, bind_value, :dml)
 
             ["p#{i + 1}", value]
           end.to_h

--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -13,8 +13,10 @@ module ActiveRecord
         def self.serialize_with_transaction_isolation_level type, value, isolation_level
           if type.respond_to? :serialize_with_isolation_level
             type.serialize_with_isolation_level value, isolation_level
-          else
+          elsif type.respond_to?(:serialize)
             type.serialize value
+          else
+            value
           end
         end
 

--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         def self.serialize_with_transaction_isolation_level type, value, isolation_level
           if type.respond_to? :serialize_with_isolation_level
             type.serialize_with_isolation_level value, isolation_level
-          elsif type.respond_to?(:serialize)
+          elsif type.respond_to? :serialize
             type.serialize value
           else
             value


### PR DESCRIPTION
Fixes a test failure for Ruby 2.5. See https://github.com/googleapis/ruby-spanner-activerecord/actions/runs/3665608106