### PR TITLE
fix: support Rails 7 default config in interleaved tables

### DIFF
--- a/acceptance/cases/models/interleave_test.rb
+++ b/acceptance/cases/models/interleave_test.rb
@@ -1,0 +1,36 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/singer"
+require "models/album_partial_disabled"
+
+module ActiveRecord
+  module Model
+    class InterleaveTest < SpannerAdapter::TestCase
+      include SpannerAdapter::Associations::TestHelper
+
+      attr_accessor :singer
+
+      def setup
+        super
+
+        @singer = Singer.create first_name: "FirstName", last_name: "LastName"
+      end
+
+      def teardown
+        Album.destroy_all
+        Singer.destroy_all
+      end
+
+      def test_with_partial_inserts_disabled
+        AlbumPartialDisabled.create! title: "Title3", singer: singer
+      end
+    end
+  end
+end

--- a/acceptance/models/album_partial_disabled.rb
+++ b/acceptance/models/album_partial_disabled.rb
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+# frozen_string_literal: true
+
+require "models/album"
+
+class AlbumPartialDisabled < Album
+  self.table_name = :albums
+
+  if ActiveRecord::VERSION::MAJOR >= 7
+    self.partial_inserts = false
+  end
+end

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -143,7 +143,7 @@ module ActiveRecord
       primary_key.each do |col|
         value = values[col]
 
-        if !value && prefetch_primary_key?
+        if (value.nil? || value.is_a?(ActiveModel::Attribute) && value.value.nil?) && prefetch_primary_key?
           value =
             if ActiveRecord::VERSION::MAJOR >= 7
               ActiveModel::Attribute.from_database col, next_sequence_value, ActiveModel::Type::BigInteger.new

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -141,29 +141,41 @@ module ActiveRecord
     def self._set_composite_primary_key_values primary_key, values
       primary_key_value = []
       primary_key.each do |col|
-        value = values[col]
-
-        if (value.nil? || value.is_a?(ActiveModel::Attribute) && value.value.nil?) && prefetch_primary_key?
-          value =
-            if ActiveRecord::VERSION::MAJOR >= 7
-              ActiveModel::Attribute.from_database col, next_sequence_value, ActiveModel::Type::BigInteger.new
-            else
-              next_sequence_value
-            end
-          values[col] = value
-        end
-        if value.is_a? ActiveModel::Attribute
-          value = value.value
-        end
-        primary_key_value.append value
+        primary_key_value.append _set_composite_primary_key_value col, values
       end
       primary_key_value
+    end
+
+    def self._set_composite_primary_key_value primary_key, values
+      value = values[primary_key]
+
+      if value.is_a? ActiveModel::Attribute
+        value = value.value
+      end
+
+      return value unless prefetch_primary_key?
+
+      if value.nil?
+        value = next_sequence_value
+      end
+
+      values[primary_key] =
+        if ActiveRecord::VERSION::MAJOR >= 7
+          ActiveModel::Attribute.from_database primary_key, value,
+                                               ActiveModel::Type::BigInteger.new
+        else
+          value
+        end
+
+      value
     end
 
     def self._set_single_primary_key_value primary_key, values
       primary_key_value = values[primary_key] || values[primary_key.to_sym]
 
-      if !primary_key_value && prefetch_primary_key?
+      return primary_key_value unless prefetch_primary_key?
+
+      if primary_key_value.nil?
         primary_key_value = next_sequence_value
         if ActiveRecord::VERSION::MAJOR >= 7
           values[primary_key] = ActiveModel::Attribute.from_database primary_key, primary_key_value,
@@ -172,6 +184,7 @@ module ActiveRecord
           values[primary_key] = primary_key_value
         end
       end
+
       primary_key_value
     end
 


### PR DESCRIPTION
Hi! I fixed an error on interleave.

[reproduction code](https://github.com/nownabe/bug-report-activerecord-spanner/tree/main/interleave)

With Rails 7 default config, creating a record into the interleaved child table causes an error like:

```
ActiveRecord::StatementInvalid: Google::Cloud::FailedPreconditionError: 9:Cannot specify a null value for column: albums.album_id in table: albums.
```

Rails 7 sets `partial_inserts` to `false` as default.
https://edgeguides.rubyonrails.org/configuring.html#config-active-record-partial-inserts

If a model's `partial_inserts` is set to `false`, each `value` has an instance of `ActiveModel::Attribute` even if the value is `nil`. Otherwise, nil values keep `nil` (`values` variable doesn't include nil values).

This difference comes from `ActiveRecord::AttributeMethods::Dirty.attribute_names_for_partial_inserts`, which is used at `ActiveRecord::AttributeMethods::Dirty._create_record`, and these `attribute_names` propagates to `_set_composite_primary_key_values`. https://github.com/rails/rails/blob/v7.0.4/activerecord/lib/active_record/attribute_methods/dirty.rb#L231



