### PR TITLE
test: reorder expected sql script for prod and clear information_schema

### DIFF
--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -86,14 +86,18 @@ module ActiveRecord
         end
         ActiveRecord::Tasks::DatabaseTasks.dump_schema db_config, :sql
         sql = File.read(filename)
-        assert_equal expected_schema_sql, sql
+        if ENV["SPANNER_EMULATOR_HOST"]
+          assert_equal expected_schema_sql_on_emulator, sql, msg = sql
+        else
+          assert_equal expected_schema_sql_on_emulator, sql, msg = sql
+        end
         drop_database
         create_database
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort
       end
 
-      def expected_schema_sql
+      def expected_schema_sql_on_emulator
         "CREATE TABLE all_types (
   id INT64 NOT NULL,
   col_string STRING(MAX),

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -93,7 +93,6 @@ module ActiveRecord
         end
         drop_database
         create_database
-        ActiveRecord::Base.connection.reset!
         # ActiveRecord::Tasks::DatabaseTasks.reset!
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       end
 
       def drop_database
-        ActiveRecord::Base.connection_pool.disconnect!
+        ActiveRecord::Base.connection_handler.clear_all_connections!
         spanner_instance.database(@database_id)&.drop
       end
 

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -89,7 +89,7 @@ module ActiveRecord
         if ENV["SPANNER_EMULATOR_HOST"]
           assert_equal expected_schema_sql_on_emulator, sql, msg = sql
         else
-          assert_equal expected_schema_sql_on_emulator, sql, msg = sql
+          assert_equal expected_schema_sql_on_production, sql, msg = sql
         end
         drop_database
         create_database
@@ -243,6 +243,158 @@ CREATE TABLE ar_internal_metadata (
   created_at TIMESTAMP NOT NULL,
   updated_at TIMESTAMP NOT NULL,
 ) PRIMARY KEY(key);
+INSERT INTO `schema_migrations` (version) VALUES
+('1');
+
+"
+      end
+
+      def expected_schema_sql_on_production
+        "CREATE TABLE accounts (
+  id INT64 NOT NULL,
+  customer_id INT64,
+  firm_id INT64,
+  name STRING(MAX),
+  credit_limit INT64,
+  transactions_count INT64,
+) PRIMARY KEY(id);
+CREATE TABLE addresses (
+  id INT64 NOT NULL,
+  line1 STRING(MAX),
+  postal_code STRING(MAX),
+  city STRING(MAX),
+  author_id INT64,
+) PRIMARY KEY(id);
+CREATE TABLE all_types (
+  id INT64 NOT NULL,
+  col_string STRING(MAX),
+  col_int64 INT64,
+  col_float64 FLOAT64,
+  col_numeric NUMERIC,
+  col_bool BOOL,
+  col_bytes BYTES(MAX),
+  col_date DATE,
+  col_timestamp TIMESTAMP,
+  col_json JSON,
+  col_array_string ARRAY<STRING(MAX)>,
+  col_array_int64 ARRAY<INT64>,
+  col_array_float64 ARRAY<FLOAT64>,
+  col_array_numeric ARRAY<NUMERIC>,
+  col_array_bool ARRAY<BOOL>,
+  col_array_bytes ARRAY<BYTES(MAX)>,
+  col_array_date ARRAY<DATE>,
+  col_array_timestamp ARRAY<TIMESTAMP>,
+  col_array_json ARRAY<JSON>,
+) PRIMARY KEY(id);
+CREATE TABLE ar_internal_metadata (
+  key STRING(MAX) NOT NULL,
+  value STRING(MAX),
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+) PRIMARY KEY(key);
+CREATE TABLE authors (
+  id INT64 NOT NULL,
+  name STRING(MAX) NOT NULL,
+  registered_date DATE,
+  organization_id INT64,
+) PRIMARY KEY(id);
+CREATE TABLE clubs (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+) PRIMARY KEY(id);
+CREATE TABLE comments (
+  id INT64 NOT NULL,
+  comment STRING(MAX),
+  post_id INT64,
+) PRIMARY KEY(id);
+CREATE TABLE customers (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+) PRIMARY KEY(id);
+CREATE TABLE departments (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+  resource_type STRING(255),
+  resource_id INT64,
+) PRIMARY KEY(id);
+CREATE INDEX index_departments_on_resource ON departments(resource_type, resource_id);
+CREATE TABLE firms (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+  rating INT64,
+  description STRING(MAX),
+  account_id INT64,
+) PRIMARY KEY(id);
+CREATE INDEX index_firms_on_account_id ON firms(account_id);
+CREATE TABLE member_types (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+) PRIMARY KEY(id);
+CREATE TABLE members (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+  member_type_id INT64,
+  admittable_type STRING(255),
+  admittable_id INT64,
+) PRIMARY KEY(id);
+CREATE TABLE memberships (
+  id INT64 NOT NULL,
+  joined_on TIMESTAMP,
+  club_id INT64,
+  member_id INT64,
+  favourite BOOL,
+) PRIMARY KEY(id);
+CREATE TABLE organizations (
+  id INT64 NOT NULL,
+  name STRING(MAX),
+  last_updated TIMESTAMP OPTIONS (
+    allow_commit_timestamp = true
+  ),
+) PRIMARY KEY(id);
+CREATE TABLE posts (
+  id INT64 NOT NULL,
+  title STRING(MAX),
+  content STRING(MAX),
+  author_id INT64,
+  comments_count INT64,
+  post_date DATE,
+  published_time TIMESTAMP,
+) PRIMARY KEY(id);
+ALTER TABLE comments ADD CONSTRAINT fk_rails_2fd19c0db7 FOREIGN KEY(post_id) REFERENCES posts(id);
+CREATE INDEX index_posts_on_author_id ON posts(author_id);
+CREATE TABLE schema_migrations (
+  version STRING(MAX) NOT NULL,
+) PRIMARY KEY(version);
+CREATE TABLE singers (
+  singerid INT64 NOT NULL,
+  first_name STRING(200),
+  last_name STRING(MAX),
+  tracks_count INT64,
+  lock_version INT64,
+  full_name STRING(MAX) AS (COALESCE(first_name || ' ', '') || last_name) STORED,
+) PRIMARY KEY(singerid);
+CREATE TABLE albums (
+  albumid INT64 NOT NULL,
+  singerid INT64 NOT NULL,
+  title STRING(MAX),
+  lock_version INT64,
+) PRIMARY KEY(singerid, albumid),
+  INTERLEAVE IN PARENT singers ON DELETE NO ACTION;
+CREATE TABLE tracks (
+  trackid INT64 NOT NULL,
+  singerid INT64 NOT NULL,
+  albumid INT64 NOT NULL,
+  title STRING(MAX),
+  duration NUMERIC,
+  lock_version INT64,
+) PRIMARY KEY(singerid, albumid, trackid),
+  INTERLEAVE IN PARENT albums ON DELETE CASCADE;
+CREATE NULL_FILTERED INDEX index_tracks_on_singerid_and_albumid_and_title ON tracks(singerid, albumid, title), INTERLEAVE IN albums;
+CREATE TABLE transactions (
+  id INT64 NOT NULL,
+  amount FLOAT64,
+  account_id INT64,
+) PRIMARY KEY(id);
 INSERT INTO `schema_migrations` (version) VALUES
 ('1');
 

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -60,6 +60,7 @@ module ActiveRecord
 
       def drop_database
         ActiveRecord::Base.connection_handler.clear_all_connections!
+        ActiveRecord::Base.connection_pool.disconnect!
         spanner_instance.database(@database_id)&.drop
       end
 
@@ -93,6 +94,8 @@ module ActiveRecord
         end
         drop_database
         create_database
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+        ActiveRecord::Base.connection_pool.disconnect!
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort
       end

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
 
       def drop_database
         ActiveRecord::Base.connection_pool.disconnect!
-        ActiveRecordSpannerAdapter::Connection.reset_information_schema!
+        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
         spanner_instance.database(@database_id)&.drop
       end
 

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -60,6 +60,7 @@ module ActiveRecord
 
       def drop_database
         ActiveRecord::Base.connection_pool.disconnect!
+        ActiveRecordSpannerAdapter::Connection.reset_information_schema!
         spanner_instance.database(@database_id)&.drop
       end
 
@@ -93,7 +94,6 @@ module ActiveRecord
         end
         drop_database
         create_database
-        # ActiveRecord::Tasks::DatabaseTasks.reset!
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort
       end

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -59,6 +59,7 @@ module ActiveRecord
       end
 
       def drop_database
+        ActiveRecord::Base.connection_pool.disconnect!
         spanner_instance.database(@database_id)&.drop
       end
 
@@ -93,6 +94,7 @@ module ActiveRecord
         drop_database
         create_database
         ActiveRecord::Base.connection.reset!
+        # ActiveRecord::Tasks::DatabaseTasks.reset!
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort
       end

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -59,8 +59,6 @@ module ActiveRecord
       end
 
       def drop_database
-        ActiveRecord::Base.connection_handler.clear_all_connections!
-        ActiveRecord::Base.connection_pool.disconnect!
         spanner_instance.database(@database_id)&.drop
       end
 
@@ -94,8 +92,7 @@ module ActiveRecord
         end
         drop_database
         create_database
-        ActiveRecord::Base.connection_handler.clear_all_connections!
-        ActiveRecord::Base.connection_pool.disconnect!
+        ActiveRecord::Base.connection.reset!
         ActiveRecord::Tasks::DatabaseTasks.load_schema db_config, :sql
         assert_equal tables, connection.tables.sort
       end

--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -38,10 +38,6 @@ module ActiveRecord
         create
       end
 
-      def reset!
-        @connection.reset!
-      end
-
       def charset
         nil
       end
@@ -70,7 +66,6 @@ module ActiveRecord
       end
 
       def structure_load filename, _extra_flags
-        reset!
         statements = File.read(filename).split(/;/).map(&:strip).reject(&:empty?)
         ddls = statements.select { |s| s =~ /^(CREATE|ALTER|DROP|GRANT|REVOKE|ANALYZE)/ }
         @connection.execute_ddl ddls

--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -38,6 +38,10 @@ module ActiveRecord
         create
       end
 
+      def reset!
+        @connection.reset!
+      end
+
       def charset
         nil
       end

--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -70,6 +70,7 @@ module ActiveRecord
       end
 
       def structure_load filename, _extra_flags
+        reset!
         statements = File.read(filename).split(/;/).map(&:strip).reject(&:empty?)
         ddls = statements.select { |s| s =~ /^(CREATE|ALTER|DROP|GRANT|REVOKE|ANALYZE)/ }
         @connection.execute_ddl ddls

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -36,6 +36,10 @@ module ActiveRecordSpannerAdapter
       end
     end
 
+    def self.reset_information_schema!
+      @information_schemas = {}
+    end
+
     def self.information_schema config
       @information_schemas ||= {}
       @information_schemas[database_path(config)] ||= \

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -72,6 +72,7 @@ module ActiveRecordSpannerAdapter
 
     def reset!
       disconnect!
+      @information_schemas = {}
       session
       true
     end

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -65,6 +65,7 @@ module ActiveRecordSpannerAdapter
 
     def disconnect!
       session.release!
+      @information_schemas = {}
       true
     ensure
       @session = nil

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -36,7 +36,10 @@ module ActiveRecordSpannerAdapter
       end
     end
 
-    def self.reset_information_schema!
+    # Clears the cached information about the underlying information schemas.
+    # Call this method if you drop and recreate a database with the same name
+    # to prevent the cached information to be used for the new database.
+    def self.reset_information_schemas!
       @information_schemas = {}
     end
 
@@ -69,7 +72,6 @@ module ActiveRecordSpannerAdapter
 
     def disconnect!
       session.release!
-      @information_schemas = {}
       true
     ensure
       @session = nil
@@ -77,7 +79,6 @@ module ActiveRecordSpannerAdapter
 
     def reset!
       disconnect!
-      @information_schemas = {}
       session
       true
     end


### PR DESCRIPTION
Reorders the expected SQL script to match the order that is returned by production when a schema is dumped, and clears the cached information_schema after dropping and recreating a database. The latter is required to prevent the existing information_schema information to be reused for the new database with the same name as the dropped database (specifically the session would be reused).