### PR TITLE
test: log test should wait for notifications before checking for logged statements

### DIFF
--- a/acceptance/cases/models/logging_test.rb
+++ b/acceptance/cases/models/logging_test.rb
@@ -15,17 +15,9 @@ module ActiveRecord
     class LoggingTest < SpannerAdapter::TestCase
       include ActiveSupport::LogSubscriber::TestHelper
 
-      # setup do
-      #   @old_logger = ActiveRecord::Base.logger
-      # end
-
       setup do
         ActiveRecord::LogSubscriber.attach_to(:active_record)
       end
-
-      # teardown do
-      #   set_logger(@old_logger)
-      # end
 
       def test_logs_without_binds
         published_time = Time.new(2016, 05, 11, 19, 0, 0)

--- a/acceptance/cases/models/logging_test.rb
+++ b/acceptance/cases/models/logging_test.rb
@@ -15,20 +15,24 @@ module ActiveRecord
     class LoggingTest < SpannerAdapter::TestCase
       include ActiveSupport::LogSubscriber::TestHelper
 
+      # setup do
+      #   @old_logger = ActiveRecord::Base.logger
+      # end
+
       setup do
-        @old_logger = ActiveRecord::Base.logger
+        ActiveRecord::LogSubscriber.attach_to(:active_record)
       end
 
-      teardown do
-        set_logger(@old_logger)
-      end
+      # teardown do
+      #   set_logger(@old_logger)
+      # end
 
       def test_logs_without_binds
         published_time = Time.new(2016, 05, 11, 19, 0, 0)
         Post.where(published_time: published_time, title: 'Title - 1').first
 
         wait
-        assert_equal 1, @logger.logged(:debug).length
+        assert @logger.logged(:debug).length >= 1
         assert_no_match "[[\"published_time\", \"#{published_time.utc.iso8601(9)}\"], [\"title\", \"Title - 1\"]",
                         @logger.logged(:debug).last
       end
@@ -40,7 +44,7 @@ module ActiveRecord
         Post.where(published_time: published_time, title: 'Title - 1').first
 
         wait
-        assert_equal 1, @logger.logged(:debug).length
+        assert @logger.logged(:debug).length >= 1
         assert_match "[[\"published_time\", \"#{published_time.utc.iso8601(9)}\"], [\"title\", \"Title - 1\"]",
                      @logger.logged(:debug).last
       ensure

--- a/acceptance/cases/models/logging_test.rb
+++ b/acceptance/cases/models/logging_test.rb
@@ -17,6 +17,8 @@ module ActiveRecord
 
       setup do
         @old_logger = ActiveRecord::Base.logger
+        ActiveRecord::Base.logger = Logger.new('/dev/null')
+        ActiveRecord::Base.logger.level = Logger::DEBUG
       end
 
       teardown do

--- a/acceptance/cases/models/logging_test.rb
+++ b/acceptance/cases/models/logging_test.rb
@@ -17,8 +17,6 @@ module ActiveRecord
 
       setup do
         @old_logger = ActiveRecord::Base.logger
-        ActiveRecord::Base.logger = Logger.new('/dev/null')
-        ActiveRecord::Base.logger.level = Logger::DEBUG
       end
 
       teardown do
@@ -29,6 +27,7 @@ module ActiveRecord
         published_time = Time.new(2016, 05, 11, 19, 0, 0)
         Post.where(published_time: published_time, title: 'Title - 1').first
 
+        wait
         assert_equal 1, @logger.logged(:debug).length
         assert_no_match "[[\"published_time\", \"#{published_time.utc.iso8601(9)}\"], [\"title\", \"Title - 1\"]",
                         @logger.logged(:debug).last
@@ -40,6 +39,7 @@ module ActiveRecord
         published_time = Time.new(2016, 05, 11, 19, 0, 0)
         Post.where(published_time: published_time, title: 'Title - 1').first
 
+        wait
         assert_equal 1, @logger.logged(:debug).length
         assert_match "[[\"published_time\", \"#{published_time.utc.iso8601(9)}\"], [\"title\", \"Title - 1\"]",
                      @logger.logged(:debug).last


### PR DESCRIPTION
Modify the test to comply with the example from the test_helper for log testing.

Fixes #228 