### PR TITLE
Revert "chore: upgrade minitest from 5.15 to 5.16"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "activerecord", ENV.fetch("AR_VERSION", "~> 6.1.6.1")
-gem "minitest", "~> 5.16.3"
+gem "minitest", "~> 5.15.0"
 gem "pry", "~> 0.13.0"
 gem "pry-byebug", "~> 3.9.0"
 

--- a/acceptance/cases/migration/change_table_test.rb
+++ b/acceptance/cases/migration/change_table_test.rb
@@ -30,87 +30,77 @@ module ActiveRecord
 
       def test_remove_references_column_type_with_polymorphic_removes_type
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true
+          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true]
           t.remove_references :taggable, polymorphic: true
         end
       end
 
       def test_references_column_type_with_polymorphic_and_options_null_is_false_adds_table_flag
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable], polymorphic: true, null: false
+          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true, null: false]
           t.references :taggable, polymorphic: true, null: false
         end
       end
 
       def test_remove_references_column_type_with_polymorphic_and_options_null_is_false_removes_table_flag
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true, null: false
+          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true, null: false]
           t.remove_references :taggable, polymorphic: true, null: false
         end
       end
 
       def test_references_column_type_with_polymorphic_and_type
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable], polymorphic: true, type: :string
+          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true, type: :string]
           t.references :taggable, polymorphic: true, type: :string
         end
       end
 
       def test_remove_references_column_type_with_polymorphic_and_type
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true, type: :string
+          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true, type: :string]
           t.remove_references :taggable, polymorphic: true, type: :string
         end
       end
 
       def test_timestamps_creates_updated_at_and_created_at
         with_change_table do |t|
-          @connection.expect :add_timestamps, nil, [:delete_me], null: true
+          @connection.expect :add_timestamps, nil, [:delete_me, null: true]
           t.timestamps null: true
         end
       end
 
       def test_remove_timestamps_creates_updated_at_and_created_at
         with_change_table do |t|
-          @connection.expect :remove_timestamps, nil, [:delete_me], null: true
+          @connection.expect :remove_timestamps, nil, [:delete_me, { null: true }]
           t.remove_timestamps(null: true)
         end
       end
 
       def test_primary_key_creates_primary_key_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :id, :primary_key], primary_key: true, first: true
+          @connection.expect :add_column, nil, [:delete_me, :id, :primary_key, primary_key: true, first: true]
           t.primary_key :id, first: true
         end
       end
 
       def test_index_exists
         with_change_table do |t|
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
-            @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
-            t.index_exists?(:bar, {})
-          else
-            @connection.expect :index_exists?, nil, [:delete_me, :bar]
-            t.index_exists?(:bar)
-          end
+          @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
+          t.index_exists?(:bar)
         end
       end
 
       def test_index_exists_with_options
         with_change_table do |t|
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
-            @connection.expect :index_exists?, nil, [:delete_me, :bar, {unique: true}]
-            t.index_exists?(:bar, {unique: true})
-          else
-            @connection.expect :index_exists?, nil, [:delete_me, :bar], unique: true
-            t.index_exists?(:bar, unique: true)
-          end
+          @connection.expect :index_exists?, nil, [:delete_me, :bar, { unique: true }]
+          t.index_exists?(:bar, unique: true)
         end
       end
 
       def test_remove_drops_multiple_columns_when_column_options_are_given
         with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz], type: :string, null: false
+          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz, type: :string, null: false]
           t.remove :bar, :baz, type: :string, null: false
         end
       end


### PR DESCRIPTION
This needs to be reverted as minitest 5.16 dropped support for Ruby 2.5. We can add this again when we drop support for Ruby 2.5.

Reverts googleapis/ruby-spanner-activerecord#217