### PR TITLE
build: drop Ruby 2.5 from nightly tests

### DIFF
--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1]
         # Exclude combinations that are not supported.
         exclude:
@@ -33,12 +33,8 @@ jobs:
             ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
-          - ruby: 2.5
-            ar: 7.0.2.4
           - ruby: 2.6
             ar: 7.0.2.4
-          - ruby: 2.5
-            ar: 7.0.3.1
           - ruby: 2.6
             ar: 7.0.3.1
     env:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run unit tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1]
         # Exclude combinations that are not supported.
         exclude:
@@ -25,12 +25,8 @@ jobs:
             ar: 6.0.3.7
           - ruby: 3.0
             ar: 6.0.4
-          - ruby: 2.5
-            ar: 7.0.2.4
           - ruby: 2.6
             ar: 7.0.2.4
-          - ruby: 2.5
-            ar: 7.0.3.1
           - ruby: 2.6
             ar: 7.0.3.1
     env:


### PR DESCRIPTION
Minitest 5.16.3 depends on Ruby 2.6 or higher. Also, Ruby 2.5. has been EOL since 31 Mar 2021.