### PR TITLE
fix: wrap default values in () as required

### DIFF
--- a/acceptance/cases/migration/change_schema_test.rb
+++ b/acceptance/cases/migration/change_schema_test.rb
@@ -120,6 +120,27 @@ module ActiveRecord
         end
       end
 
+      def test_create_table_with_column_default
+        testings_klass = Class.new ActiveRecord::Base
+        connection.ddl_batch do
+          connection.create_table :testings do |t|
+            t.string :name, null: false, default: "no name"
+            t.integer :age, null: false, default: 10
+          end
+          testings_klass.table_name = "testings"
+        end
+
+        testings_klass.reset_column_information
+        assert_equal false, testings_klass.columns_hash["name"].null
+        assert_equal false, testings_klass.columns_hash["age"].null
+
+        assert_nothing_raised {
+          testings_klass.connection.transaction {
+            testings_klass.connection.execute("insert into testings (id, name, age) values (#{generate_id}, DEFAULT, DEFAULT)")
+          }
+        }
+      end
+
       def test_create_table_with_limits
         connection.ddl_batch do
           connection.create_table :testings do |t|

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -129,7 +129,7 @@ module ActiveRecord
             sql << " NOT NULL"
           end
           if options.key? :default
-            sql << " DEFAULT #{quote_default_expression options[:default], column}"
+            sql << " DEFAULT (#{quote_default_expression options[:default], column})"
           end
 
           if !options[:allow_commit_timestamp].nil? &&

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -1025,7 +1025,7 @@ module TestMigrationsWithMockServer
       assert_equal 1, ddl_requests[2].statements.length
 
       expectedDdl = "CREATE TABLE `singers` "
-      expectedDdl << "(`id` INT64 NOT NULL, `name` STRING(MAX) NOT NULL DEFAULT 'no name', `age` INT64 NOT NULL DEFAULT 0) "
+      expectedDdl << "(`id` INT64 NOT NULL, `name` STRING(MAX) NOT NULL DEFAULT ('no name'), `age` INT64 NOT NULL DEFAULT (0)) "
       expectedDdl << "PRIMARY KEY (`id`)"
       assert_equal expectedDdl, ddl_requests[2].statements[0]
     end


### PR DESCRIPTION
Seems to have been an oversight in #196