### PR TITLE
chore(main): Added artifacts definition in release job

### DIFF
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -31,3 +31,12 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
 }
+
+# Store the packages uploaded to rubygems.org, which
+# we can later use to generate SBOMs and attestations.
+action {
+ define_artifacts {
+   regex: "github/ruby-spanner-activerecord/pkg/*.gem"
+   strip_prefix: "github"
+ }
+}


### PR DESCRIPTION
Updating the Kokoro release job for storing the artifacts released on rubygems.org in placer.