### PR TITLE
build: pin emulator version because of errors with DEFAULT values

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.4.9
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.4.9
         ports:
           - 9010:9010
           - 9020:9020


### PR DESCRIPTION
There seems to be a problem with DEFAULT columns in v1.5.x versions of the emulator. The tests are therefore pinned to using v1.4.9 for now.