### PR TITLE
test: use new call syntax for ActiveRecord 7.0.5 and higher

### DIFF
--- a/acceptance/cases/migration/change_table_test.rb
+++ b/acceptance/cases/migration/change_table_test.rb
@@ -86,15 +86,25 @@ module ActiveRecord
 
       def test_index_exists
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar]
-          t.index_exists?(:bar)
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3") && ActiveRecord::gem_version <= Gem::Version.create('7.0.4')
+            @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
+            t.index_exists?(:bar, {})
+          else
+            @connection.expect :index_exists?, nil, [:delete_me, :bar]
+            t.index_exists?(:bar)
+          end
         end
       end
 
       def test_index_exists_with_options
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar], unique: true
-          t.index_exists?(:bar, unique: true)
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3") && ActiveRecord::gem_version <= Gem::Version.create('7.0.4')
+            @connection.expect :index_exists?, nil, [:delete_me, :bar, {unique: true}]
+            t.index_exists?(:bar, {unique: true})
+          else
+            @connection.expect :index_exists?, nil, [:delete_me, :bar], unique: true
+            t.index_exists?(:bar, unique: true)
+          end
         end
       end
 

--- a/acceptance/cases/migration/change_table_test.rb
+++ b/acceptance/cases/migration/change_table_test.rb
@@ -86,25 +86,15 @@ module ActiveRecord
 
       def test_index_exists
         with_change_table do |t|
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
-            @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
-            t.index_exists?(:bar, {})
-          else
-            @connection.expect :index_exists?, nil, [:delete_me, :bar]
-            t.index_exists?(:bar)
-          end
+          @connection.expect :index_exists?, nil, [:delete_me, :bar]
+          t.index_exists?(:bar)
         end
       end
 
       def test_index_exists_with_options
         with_change_table do |t|
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
-            @connection.expect :index_exists?, nil, [:delete_me, :bar, {unique: true}]
-            t.index_exists?(:bar, {unique: true})
-          else
-            @connection.expect :index_exists?, nil, [:delete_me, :bar], unique: true
-            t.index_exists?(:bar, unique: true)
-          end
+          @connection.expect :index_exists?, nil, [:delete_me, :bar], unique: true
+          t.index_exists?(:bar, unique: true)
         end
       end
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/47293 fixed an issue that required us to call the index_exists? method in two different ways in our tests, depending on the Ruby version that was being used. This is no longer needed for versions 7.0.5 and higher.

Fixes #255