### PR TITLE
fix: support for changes in Rails 7.0.7

### DIFF
--- a/lib/active_record/connection_adapters/spanner/quoting.rb
+++ b/lib/active_record/connection_adapters/spanner/quoting.rb
@@ -32,12 +32,15 @@ module ActiveRecord
   module ConnectionAdapters
     module Spanner
       module Quoting
+        QUOTED_COLUMN_NAMES = Concurrent::Map.new # :nodoc:
+        QUOTED_TABLE_NAMES = Concurrent::Map.new # :nodoc:
+
         def quote_column_name name
-          self.class.quoted_column_names[name] ||= "`#{super.gsub '`', '``'}`".freeze
+          QUOTED_COLUMN_NAMES[name] ||= "`#{super.gsub '`', '``'}`".freeze
         end
 
         def quote_table_name name
-          self.class.quoted_table_names[name] ||= super.gsub(".", "`.`").freeze
+          QUOTED_TABLE_NAMES[name] ||= super.gsub(".", "`.`").freeze
         end
 
         STR_ESCAPE_REGX = /[\n\r'\\]/.freeze


### PR DESCRIPTION
Using Rails 7.0.7, the following error occurs when performing database migration.
This pull-req is a fix for this.

```bash
$ bundle exec rails db:migrate
rails aborted!
NoMethodError: undefined method `quoted_table_names' for ActiveRecord::ConnectionAdapters::SpannerAdapter:Class
```

see also: https://github.com/rails/rails/pull/48773/files