### PR TITLE
docs: update README to reference PGAdapter for PG (#263)

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         ar: ["~> 6.0.6", "~> 6.1.7", "~> 7.0.4"]
         # Exclude combinations that are not supported.
         exclude:
@@ -28,8 +28,6 @@ jobs:
             ar: "~> 6.0.6"
           - ruby: "3.2"
             ar: "~> 6.0.6"
-          - ruby: "2.6"
-            ar: "~> 7.0.4"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         ar: ["~> 6.0.6", "~> 6.1.7", "~> 7.0.4"]
         # Exclude combinations that are not supported.
         exclude:
@@ -20,8 +20,6 @@ jobs:
             ar: "~> 6.0.6"
           - ruby: "3.2"
             ar: "~> 6.0.6"
-          - ruby: "2.6"
-            ar: "~> 7.0.4"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.6, 2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1, 7.0.4, 7.0.5, 7.0.6, 7.0.7]
         # Exclude combinations that are not supported.
         exclude:
@@ -53,18 +53,6 @@ jobs:
             ar: 6.0.3.7
           - ruby: 3.2
             ar: 6.0.4
-          - ruby: 2.6
-            ar: 7.0.2.4
-          - ruby: 2.6
-            ar: 7.0.3.1
-          - ruby: 2.6
-            ar: 7.0.4
-          - ruby: 2.6
-            ar: 7.0.5
-          - ruby: 2.6
-            ar: 7.0.6
-          - ruby: 2.6
-            ar: 7.0.7
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run unit tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.6, 2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1, 7.0.4, 7.0.5]
         # Exclude combinations that are not supported.
         exclude:
@@ -45,14 +45,6 @@ jobs:
             ar: 6.0.3.7
           - ruby: 3.2
             ar: 6.0.4
-          - ruby: 2.6
-            ar: 7.0.2.4
-          - ruby: 2.6
-            ar: 7.0.3.1
-          - ruby: 2.6
-            ar: 7.0.4
-          - ruby: 2.6
-            ar: 7.0.5
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ![rubocop](https://github.com/googleapis/ruby-spanner-activerecord/workflows/rubocop/badge.svg)
 
 __This adapter only supports GoogleSQL-dialect Cloud Spanner databases. PostgreSQL-dialect
-databases are not supported.__
+databases are not supported. You can use the standard PostgreSQL ActiveRecord adapter in
+[combination with PGAdapter](https://github.com/GoogleCloudPlatform/pgadapter/blob/-/samples/ruby/activerecord)
+for Cloud Spanner PostgreSQL-dialect databases.__
 
 This project provides a Cloud Spanner adapter for ActiveRecord. It supports the following versions:
 

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename f }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.10"
+  spec.add_dependency "google-cloud-spanner", "~> 2.18"
   spec.add_runtime_dependency "activerecord", [">= 6.0.0", "< 7.1"]
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"


### PR DESCRIPTION
The Google Cloud libraries have already dropped suppport for Ruby 2.6, and now the build is failing because the latest version of the google-protobuf libraries require 2.7 or higher.

See also https://github.com/googleapis/ruby-spanner-activerecord/actions/runs/6728914269/job/18288964465
