### PR TITLE
fix: Use more permissive argument passthrough for insert_all and upsert_all

### DIFF
--- a/acceptance/cases/models/insert_all_test.rb
+++ b/acceptance/cases/models/insert_all_test.rb
@@ -33,6 +33,12 @@ module ActiveRecord
         assert_raise(NotImplementedError) { Author.insert_all(values) }
       end
 
+      def test_insert
+        value = { id: Author.next_sequence_value, name: "Alice" }
+
+        assert_raise(NotImplementedError) { Author.insert(value) }
+      end
+
       def test_insert_all!
         values = [
           { id: Author.next_sequence_value, name: "Alice" },
@@ -83,6 +89,22 @@ module ActiveRecord
         assert_equal "Alice", authors[0].name
         assert_equal "Bob", authors[1].name
         assert_equal "Carol", authors[2].name
+      end
+
+      def test_upsert
+        Author.create id: 1, name: "David"
+        authors = Author.all.order(:name)
+        assert_equal 1, authors.length
+        assert_equal "David", authors[0].name
+
+        value = { id: 1, name: "Alice" }
+
+        Author.upsert(value)
+
+        authors = Author.all.order(:name)
+
+        assert_equal 1, authors.length
+        assert_equal "Alice", authors[0].name
       end
 
       def test_upsert_all

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -67,11 +67,11 @@ module ActiveRecord
       _buffer_record values, :insert_or_update
     end
 
-    def self.insert_all _attributes, _returning: nil, _unique_by: nil
+    def self.insert_all _attributes, **_kwargs
       raise NotImplementedError, "Cloud Spanner does not support skip_duplicates."
     end
 
-    def self.insert_all! attributes, returning: nil
+    def self.insert_all! attributes, **kwargs
       return super unless spanner_adapter?
       return super if active_transaction? && !buffered_mutations?
 
@@ -90,7 +90,7 @@ module ActiveRecord
       end
     end
 
-    def self.upsert_all attributes, returning: nil, unique_by: nil
+    def self.upsert_all attributes, **kwargs
       return super unless spanner_adapter?
       if active_transaction? && !buffered_mutations?
         raise NotImplementedError, "Cloud Spanner does not support upsert using DML. " \


### PR DESCRIPTION
fixes #274 

Rails 7.0 introduced new keyword arguments to `ActiveRecord::Base.upsert_all` and `ActiveRecord::Base.insert_all`. The same methods without `_all` call through to the `_all` versions of the methods, passing along the new keyword arguments. 

For example, [in Rails 7.0.8 activerecord/lib/active_record/persistence.rb we see](https://github.com/rails/rails/blob/v7.0.8/activerecord/lib/active_record/persistence.rb#L222-L224):

```ruby
def upsert(attributes, on_duplicate: :update, returning: nil, unique_by: nil, record_timestamps: nil)
  upsert_all([ attributes ], on_duplicate: on_duplicate, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
end
```

When this library's override of `upsert_all` is called with the `on_duplicate:` and `record_timestamps:` keyword arguments, an error is raised: 

```ruby
ArgumentError: unknown keywords: :on_duplicate, :record_timestamps
```

We can see this in the test suite by adding a test to `acceptance/cases/models/insert_all_test.rb` like: 

```ruby
def test_upsert
  Author.create id: 1, name: "David"
  authors = Author.all.order(:name)
  assert_equal 1, authors.length
  assert_equal "David", authors[0].name

  value = { id: 1, name: "Alice" }

  Author.upsert(value)

  authors = Author.all.order(:name)

  assert_equal 1, authors.length
  assert_equal "Alice", authors[0].name
end
```

and setting `AR_VERSION=7.0.8` in the environment before running the acceptance suite.

## Changes

This PR changes the method signatures for `insert_all!` and `upsert_all` to use keyword splats (`**kwargs`) instead of specific, individual keywords. 