### PR TITLE
fix: more permissive arg passthrough for insert_all and upsert_all

### DIFF
--- a/acceptance/cases/models/insert_all_test.rb
+++ b/acceptance/cases/models/insert_all_test.rb
@@ -33,6 +33,12 @@ module ActiveRecord
         assert_raise(NotImplementedError) { Author.insert_all(values) }
       end
 
+      def test_insert
+        value = { id: Author.next_sequence_value, name: "Alice" }
+
+        assert_raise(NotImplementedError) { Author.insert(value) }
+      end
+
       def test_insert_all!
         values = [
           { id: Author.next_sequence_value, name: "Alice" },
@@ -83,6 +89,22 @@ module ActiveRecord
         assert_equal "Alice", authors[0].name
         assert_equal "Bob", authors[1].name
         assert_equal "Carol", authors[2].name
+      end
+
+      def test_upsert
+        Author.create id: 1, name: "David"
+        authors = Author.all.order(:name)
+        assert_equal 1, authors.length
+        assert_equal "David", authors[0].name
+
+        value = { id: 1, name: "Alice" }
+
+        Author.upsert(value)
+
+        authors = Author.all.order(:name)
+
+        assert_equal 1, authors.length
+        assert_equal "Alice", authors[0].name
       end
 
       def test_upsert_all

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -67,11 +67,11 @@ module ActiveRecord
       _buffer_record values, :insert_or_update
     end
 
-    def self.insert_all _attributes, _returning: nil, _unique_by: nil
-      raise NotImplementedError, "Cloud Spanner does not support skip_duplicates."
+    def self.insert_all _attributes, **_kwargs
+      raise NotImplementedError, "Cloud Spanner does not support skip_duplicates. Use insert! or upsert instead."
     end
 
-    def self.insert_all! attributes, returning: nil
+    def self.insert_all! attributes, **_kwargs
       return super unless spanner_adapter?
       return super if active_transaction? && !buffered_mutations?
 
@@ -90,7 +90,7 @@ module ActiveRecord
       end
     end
 
-    def self.upsert_all attributes, returning: nil, unique_by: nil
+    def self.upsert_all attributes, **_kwargs
       return super unless spanner_adapter?
       if active_transaction? && !buffered_mutations?
         raise NotImplementedError, "Cloud Spanner does not support upsert using DML. " \

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -9,7 +9,63 @@
 require_relative "./base_spanner_mock_server_test"
 
 module MockServerTests
+  CommitRequest = Google::Cloud::Spanner::V1::CommitRequest
+
   class SpannerActiveRecordMockServerTest < BaseSpannerMockServerTest
+
+    def test_insert
+      singer = { first_name: "Alice", last_name: "Ecila" }
+
+      assert_raises(NotImplementedError) { Singer.insert(singer) }
+    end
+
+    def test_insert!
+      singer = { first_name: "Alice", last_name: "Ecila" }
+      singer = Singer.insert! singer
+
+      commit_requests = @mock.requests.select { |req| req.is_a?(CommitRequest) }
+      assert_equal 1, commit_requests.length
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :insert, mutation.operation
+      assert_equal "singers", mutation.insert.table
+
+      assert_equal 1, mutation.insert.values.length
+      assert_equal 3, mutation.insert.values[0].length
+      assert_equal "Alice", mutation.insert.values[0][0]
+      assert_equal "Ecila", mutation.insert.values[0][1]
+      assert_equal singer[0]["id"], mutation.insert.values[0][2].to_i
+
+      assert_equal 3, mutation.insert.columns.length
+      assert_equal "first_name", mutation.insert.columns[0]
+      assert_equal "last_name", mutation.insert.columns[1]
+      assert_equal "id", mutation.insert.columns[2]
+    end
+
+    def test_upsert
+      singer = { first_name: "Alice", last_name: "Ecila" }
+      singer = Singer.upsert singer
+
+      commit_requests = @mock.requests.select { |req| req.is_a?(CommitRequest) }
+      assert_equal 1, commit_requests.length
+      mutations = commit_requests[0].mutations
+      assert_equal 1, mutations.length
+      mutation = mutations[0]
+      assert_equal :insert_or_update, mutation.operation
+      assert_equal "singers", mutation.insert_or_update.table
+
+      assert_equal 1, mutation.insert_or_update.values.length
+      assert_equal 3, mutation.insert_or_update.values[0].length
+      assert_equal "Alice", mutation.insert_or_update.values[0][0]
+      assert_equal "Ecila", mutation.insert_or_update.values[0][1]
+      assert_equal singer[0]["id"], mutation.insert_or_update.values[0][2].to_i
+
+      assert_equal 3, mutation.insert_or_update.columns.length
+      assert_equal "first_name", mutation.insert_or_update.columns[0]
+      assert_equal "last_name", mutation.insert_or_update.columns[1]
+      assert_equal "id", mutation.insert_or_update.columns[2]
+    end
 
     def test_selects_all_singers_without_transaction
       sql = "SELECT `singers`.* FROM `singers`"

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -22,6 +22,8 @@ module MockServerTests
     def test_insert!
       singer = { first_name: "Alice", last_name: "Ecila" }
       singer = Singer.insert! singer
+      id = singer[0]["id"]
+      id = id.value if id.respond_to?(:value)
 
       commit_requests = @mock.requests.select { |req| req.is_a?(CommitRequest) }
       assert_equal 1, commit_requests.length
@@ -35,7 +37,7 @@ module MockServerTests
       assert_equal 3, mutation.insert.values[0].length
       assert_equal "Alice", mutation.insert.values[0][0]
       assert_equal "Ecila", mutation.insert.values[0][1]
-      assert_equal singer[0]["id"], mutation.insert.values[0][2].to_i
+      assert_equal id, mutation.insert.values[0][2].to_i
 
       assert_equal 3, mutation.insert.columns.length
       assert_equal "first_name", mutation.insert.columns[0]
@@ -46,6 +48,8 @@ module MockServerTests
     def test_upsert
       singer = { first_name: "Alice", last_name: "Ecila" }
       singer = Singer.upsert singer
+      id = singer[0]["id"]
+      id = id.value if id.respond_to?(:value)
 
       commit_requests = @mock.requests.select { |req| req.is_a?(CommitRequest) }
       assert_equal 1, commit_requests.length
@@ -59,7 +63,7 @@ module MockServerTests
       assert_equal 3, mutation.insert_or_update.values[0].length
       assert_equal "Alice", mutation.insert_or_update.values[0][0]
       assert_equal "Ecila", mutation.insert_or_update.values[0][1]
-      assert_equal singer[0]["id"], mutation.insert_or_update.values[0][2].to_i
+      assert_equal id, mutation.insert_or_update.values[0][2].to_i
 
       assert_equal 3, mutation.insert_or_update.columns.length
       assert_equal "first_name", mutation.insert_or_update.columns[0]


### PR DESCRIPTION
Credits to @abachman for creating #275. This PR is created separately to work around issues with the CLA check in the original PR.

Fixes #274