### PR TITLE
Fix combination of composite primary keys and Rails 7.0

### DIFF
--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -49,7 +49,10 @@ module ActiveRecord
     end
 
     def self._insert_record values, returning = []
-      return super unless buffered_mutations? || (primary_key && values.is_a?(Hash))
+      unless buffered_mutations? || (primary_key && values.is_a?(Hash))
+        return super(values) if ActiveRecord.gem_version < VERSION_7_1
+        return super
+      end
 
       # Mutations cannot be used in combination with a sequence, as mutations do not support a THEN RETURN clause.
       if buffered_mutations? && sequence_name


### PR DESCRIPTION
This method changed to have 2 arguments in Rails 7.1, and changes in #278 to support that cause this to error on Rails 7.0. Call super with the appropriate arguments on older versions of Rails.