### PR TITLE
build: remove bang from sub function in gem file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "pry", "~> 0.13.0"
 gem "pry-byebug", "~> 3.9.0"
 
 # Required for samples and testing.
-install_if -> { ENV.fetch("AR_VERSION", "~> 6.1.6.1").dup.to_s.sub!("~>", "").strip < "7.1.0" && !ENV["SKIP_COMPOSITE_PK"] } do
+install_if -> { ENV.fetch("AR_VERSION", "~> 6.1.6.1").dup.to_s.sub("~>", "").strip < "7.1.0" && !ENV["SKIP_COMPOSITE_PK"] } do
   gem "composite_primary_keys"
 end
 

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -68,7 +68,12 @@ module Google
           snp_grpc = service.create_snapshot \
             path, timestamp: (timestamp || read_timestamp),
             staleness: (staleness || exact_staleness)
-          Snapshot.from_grpc snp_grpc, self
+          num_args = Snapshot.method(:from_grpc).arity
+          if num_args == 3
+            Snapshot.from_grpc snp_grpc, self, nil
+          else
+            Snapshot.from_grpc snp_grpc, self
+          end
         end
 
         def create_pdml


### PR DESCRIPTION
Replace `sub!` with `sub`, as not all dependency version declarations contain the prefix.