### PR TITLE
docs: update bit-reversed sequence sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ __NOTE__: You do need to have [Docker](https://docs.docker.com/get-docker/) inst
 Some noteworthy examples in the snippets directory:
 - [quickstart](examples/snippets/quickstart): A simple application that shows how to create and query a simple database containing two tables.
 - [migrations](examples/snippets/migrations): Shows a best-practice for executing migrations on Cloud Spanner.
+- [bit-reversed-sequences](examples/snippets/bit-reversed-sequence): Shows how to use bit-reversed sequences for primary keys.
 - [read-write-transactions](examples/snippets/read-write-transactions): Shows how to execute transactions on Cloud Spanner.
 - [read-only-transactions](examples/snippets/read-only-transactions): Shows how to execute read-only transactions on Cloud Spanner.
 - [bulk-insert](examples/snippets/bulk-insert): Shows the best way to insert a large number of new records.

--- a/examples/snippets/bit-reversed-sequence/README.md
+++ b/examples/snippets/bit-reversed-sequence/README.md
@@ -5,6 +5,12 @@ This example shows how to use a bit-reversed sequence to generate the primary ke
 See https://cloud.google.com/spanner/docs/primary-key-default-value#bit-reversed-sequence for more information
 about bit-reversed sequences in Cloud Spanner.
 
+## Requirements
+Using bit-reversed sequences for generating primary key values in ActiveRecord has the following requirements:
+1. You must use __ActiveRecord version 7.1 or higher__.
+2. Your models must include a sequence name like this: `self.sequence_name = :singer_sequence`
+3. You must create the bit-reversed sequence using a SQL statement in your migrations.
+
 ## Creating Tables with Bit-Reversed Sequences in ActiveRecord
 You can create bit-reversed sequences using migrations in ActiveRecord by executing a SQL statement using the underlying
 connection.

--- a/examples/snippets/bit-reversed-sequence/db/migrate/01_create_tables.rb
+++ b/examples/snippets/bit-reversed-sequence/db/migrate/01_create_tables.rb
@@ -8,15 +8,12 @@ class CreateTables < ActiveRecord::Migration[7.1]
   def change
     # Execute the entire migration as one DDL batch.
     connection.ddl_batch do
-      # TODO: Uncomment when bit-reversed sequences are supported in the emulator.
-      # connection.execute "create sequence singer_sequence OPTIONS (sequence_kind = 'bit_reversed_positive')"
+      connection.execute "create sequence singer_sequence OPTIONS (sequence_kind = 'bit_reversed_positive')"
 
       # Explicitly define the primary key.
       create_table :singers, id: false, primary_key: :singerid do |t|
-        # TODO: Uncomment when bit-reversed sequences are supported in the emulator.
-        # t.integer :singerid, primary_key: true, null: false,
-        #           default: -> { "GET_NEXT_SEQUENCE_VALUE(SEQUENCE singer_sequence)" }
-        t.integer :singerid, primary_key: true, null: false, default: -> { "FARM_FINGERPRINT(GENERATE_UUID())" }
+        t.integer :singerid, primary_key: true, null: false,
+                  default: -> { "GET_NEXT_SEQUENCE_VALUE(SEQUENCE singer_sequence)" }
         t.string :first_name
         t.string :last_name
       end

--- a/examples/snippets/bit-reversed-sequence/db/schema.rb
+++ b/examples/snippets/bit-reversed-sequence/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "title"
   end
 
-  create_table "singers", primary_key: "singerid", default: -> { "FARM_FINGERPRINT(GENERATE_UUID())" }, force: :cascade do |t|
+  create_table "singers", primary_key: "singerid", default: -> { "GET_NEXT_SEQUENCE_VALUE(SEQUENCE singer_sequence)" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
   end


### PR DESCRIPTION
Update the bit-reversed sequence sample to actually use a bit-reversed sequence, and more clearly call out the requirement that a sequence name must be specified, and that ActiveRecord 7.1 must be used.