### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/rails/devcontainer/images/ruby:3.3.5
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    network_mode: service:spanner-emulator
+
+  spanner-emulator:
+    image: gcr.io/cloud-spanner-emulator/emulator:latest
+
+volumes:
+  spanner-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Ruby",
+	"dockerComposeFile": "compose.yml",
+	"service": "app",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"features": {
+		"github-cli": "latest"
+	},
+	"postCreateCommand": "bundle install",
+	"containerEnv": {
+		"SPANNER_EMULATOR_HOST": "localhost:9010",
+		"SPANNER_TEST_PROJECT": "test-project",
+		"SPANNER_TEST_INSTANCE": "test-instance"
+	}
+}

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -28,6 +28,8 @@ jobs:
             ar: "~> 6.0.6"
           - ruby: "3.2"
             ar: "~> 6.0.6"
+          - ruby: "3.3"
+            ar: "~> 6.0.6"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         ar: ["~> 6.0.6", "~> 6.1.7", "~> 7.0.4", "~> 7.1.0"]
         # Exclude combinations that are not supported.
         exclude:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         ar: ["~> 6.0.6", "~> 6.1.7", "~> 7.0.4", "~> 7.1.0"]
         # Exclude combinations that are not supported.
         exclude:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -53,6 +53,14 @@ jobs:
             ar: 6.0.3.7
           - ruby: 3.2
             ar: 6.0.4
+          - ruby: 3.3
+            ar: 6.0.0
+          - ruby: 3.3
+            ar: 6.0.1
+          - ruby: 3.3
+            ar: 6.0.2.2
+          - ruby: 3.3
+            ar: 6.0.3.7
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1, 7.0.4, 7.0.5, 7.0.6, 7.0.7, 7.1.0, 7.1.1, 7.1.2]
         # Exclude combinations that are not supported.
         exclude:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       matrix:
         # Run unit tests all supported combinations of Ruby and ActiveRecord.
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
         ar: [6.0.0, 6.0.1, 6.0.2.2, 6.0.3.7, 6.0.4, 6.1.3.2, 6.1.4.7, 6.1.5.1, 6.1.6.1, 7.0.2.4, 7.0.3.1, 7.0.4, 7.0.5, 7.1.0, 7.1.1, 7.1.2]
         # Exclude combinations that are not supported.
         exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "activerecord", ENV.fetch("AR_VERSION", "~> 6.1.6.1")
+gem "ostruct"
 gem "minitest", "~> 5.25.0"
 gem "minitest-rg", "~> 5.3.0"
 gem "pry", "~> 0.13.0"

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -15,6 +15,7 @@ require "active_support/testing/stream"
 require "activerecord-spanner-adapter"
 require "active_record/connection_adapters/spanner_adapter"
 require "securerandom"
+require "ostruct"
 require "composite_primary_keys" if ActiveRecord::gem_version < Gem::Version.create('7.1.0')
 
 # rubocop:disable Style/GlobalVars

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require "minitest/rg"
 require "google/cloud/spanner"
 require "active_record"
 require "activerecord-spanner-adapter"
+require "ostruct"
 require "active_record/connection_adapters/spanner_adapter"
 
 module SqlStatmentAssertions


### PR DESCRIPTION
Add devcontainer configuration to allow easy to use development environment for this gem. It automatically configures a Spanner emulator so we can use to run tests.