### PR TITLE
fix: local emulator test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,8 +56,8 @@ task :acceptance, [:project, :keyfile, :instance, :tests] do |t, args|
   tests ||= "**"
 
   # always overwrite when running tests
-  ENV["SPANNER_PROJECT"] = project
-  ENV["SPANNER_KEYFILE_JSON"] = keyfile
+  ENV["SPANNER_TEST_PROJECT"] = project
+  ENV["SPANNER_TEST_KEYFILE_JSON"] = keyfile
   ENV["SPANNER_TEST_INSTANCE"] = instance
   ENV["SPANNER_EMULATOR_HOST"] = emulator_host
 


### PR DESCRIPTION
Hello,

I tried to run a local emulator test(command below) and found that it failed. It seemed to be due to the fact that the environment variable names were different from those used in the test, so I fixed it.

```shell
bundle exec rake "acceptance[dummy-project,,dummy-instance,]"
```