### PR TITLE
test: drop database after test

### DIFF
--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -48,6 +48,7 @@ module ActiveRecord
       end
 
       def teardown
+        drop_database
         ActiveRecord::Base.connection_pool.disconnect!
         FileUtils.rm_rf ActiveRecord::Tasks::DatabaseTasks.db_dir
         ActiveRecord::Tasks::DatabaseTasks.db_dir = @original_db_dir


### PR DESCRIPTION
The database tasks test did not drop the test database after running, which caused a slow build-up of test databases on the test instance.