### PR TITLE
feat: INSERT OR [IGNORE|UPDATE]

### DIFF
--- a/acceptance/cases/models/insert_all_test.rb
+++ b/acceptance/cases/models/insert_all_test.rb
@@ -30,13 +30,24 @@ module ActiveRecord
           { id: Author.next_sequence_value, name: "Carol" },
         ]
 
-        assert_raise(NotImplementedError) { Author.insert_all(values) }
+        Author.insert_all(values)
+
+        authors = Author.all.order(:name)
+
+        assert_equal "Alice", authors[0].name
+        assert_equal "Bob", authors[1].name
+        assert_equal "Carol", authors[2].name
       end
 
       def test_insert
         value = { id: Author.next_sequence_value, name: "Alice" }
 
-        assert_raise(NotImplementedError) { Author.insert(value) }
+        Author.insert(value)
+
+        authors = Author.all.order(:name)
+
+        assert_equal 1, authors.length
+        assert_equal "Alice", authors[0].name
       end
 
       def test_insert_all!
@@ -136,12 +147,16 @@ module ActiveRecord
           { id: Author.next_sequence_value, name: "Carol" },
         ]
 
-        err = assert_raise(NotImplementedError) do
-          ActiveRecord::Base.transaction do
-            Author.upsert_all(values)
-          end
+        ActiveRecord::Base.transaction do
+          Author.upsert_all(values)
         end
-        assert_match "Use upsert outside a transaction block", err.message
+
+        authors = Author.all.order(:name)
+
+        assert_equal 3, authors.length
+        assert_equal "Alice", authors[0].name
+        assert_equal "Bob", authors[1].name
+        assert_equal "Carol", authors[2].name
       end
 
       def test_upsert_all_with_buffered_mutation_transaction

--- a/acceptance/cases/sessions/session_not_found_test.rb
+++ b/acceptance/cases/sessions/session_not_found_test.rb
@@ -51,6 +51,8 @@ module ActiveRecord
         sessions.each do |session|
           client.delete_session Google::Cloud::Spanner::V1::DeleteSessionRequest.new name: session.name
         end
+        # Wait a bit to ensure that the sessions are really deleted.
+        sleep 5 unless ENV["SPANNER_EMULATOR_HOST"]
       end
 
       def test_single_read

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -209,12 +209,14 @@ module ActiveRecord
           raise "ActiveRecordSpannerAdapter does not support insert_sql with buffered_mutations transaction."
         end
 
-        if insert.skip_duplicates? || insert.update_duplicates?
-          raise NotImplementedError, "CloudSpanner does not support skip_duplicates and update_duplicates."
-        end
-
         values_list, = insert.values_list
-        "INSERT #{insert.into} #{values_list}"
+        prefix = "INSERT"
+        if insert.update_duplicates?
+          prefix += " OR UPDATE"
+        elsif insert.skip_duplicates?
+          prefix += " OR IGNORE"
+        end
+        "#{prefix} #{insert.into} #{values_list}"
       end
 
       module TypeMapBuilder

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -125,7 +125,7 @@ module ActiveRecord
     def self.insert_all attributes, returning: nil, **_kwargs
       if active_transaction? && buffered_mutations?
         raise NotImplementedError,
-              "Spanner does not support skip_duplicates for mutations. " +
+              "Spanner does not support skip_duplicates for mutations. " \
               "Use a transaction that uses DML, or use insert! or upsert instead."
       end
       super

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -122,8 +122,13 @@ module ActiveRecord
       _buffer_record values, :insert_or_update, returning
     end
 
-    def self.insert_all _attributes, **_kwargs
-      raise NotImplementedError, "Cloud Spanner does not support skip_duplicates. Use insert! or upsert instead."
+    def self.insert_all attributes, returning: nil, **_kwargs
+      if active_transaction? && buffered_mutations?
+        raise NotImplementedError,
+              "Spanner does not support skip_duplicates for mutations. " +
+              "Use a transaction that uses DML, or use insert! or upsert instead."
+      end
+      super
     end
 
     def self.insert_all! attributes, returning: nil, **_kwargs
@@ -147,11 +152,7 @@ module ActiveRecord
 
     def self.upsert_all attributes, returning: nil, unique_by: nil, **_kwargs
       return super unless spanner_adapter?
-      if active_transaction? && !buffered_mutations?
-        raise NotImplementedError, "Cloud Spanner does not support upsert using DML. " \
-                                   "Use upsert outside a transaction block or in a transaction " \
-                                   "block with isolation: :buffered_mutations"
-      end
+      return super if active_transaction? && !buffered_mutations?
 
       # This might seem inefficient, but is actually not, as it is only buffering a mutation locally.
       # The mutations will be sent as one batch when the transaction is committed.


### PR DESCRIPTION
Add support for `INSERT OR [IGNORE|UPDATE]` DML statements.