### PR TITLE
deps: require Ruby 3.1 or higher

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -18,14 +18,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0"]
-        # Exclude combinations that are not supported.
-        exclude:
-          - ruby: "2.7"
-            ar: "~> 7.2.0"
-          - ruby: "3.0"
-            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,14 +10,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0"]
-        # Exclude combinations that are not supported.
-        exclude:
-          - ruby: "2.7"
-            ar: "~> 7.2.0"
-          - ruby: "3.0"
-            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -18,14 +18,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0"]
-        # Exclude combinations that are not supported.
-        exclude:
-          - ruby: "2.7"
-            ar: "~> 7.2.0"
-          - ruby: "3.0"
-            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -11,14 +11,8 @@ jobs:
       max-parallel: 4
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
         ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0"]
-        # Exclude combinations that are not supported.
-        exclude:
-          - ruby: "2.7"
-            ar: "~> 7.2.0"
-          - ruby: "3.0"
-            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: setup ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.3'
     - name: cache gems
       uses: actions/cache@v4
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
 
 Documentation:
   Enabled: false
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -24,7 +24,7 @@ Metrics/ModuleLength:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Style/EmptyMethod:
   Enabled: false

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename f }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.18"
   # Pin gRPC to 1.64.3, as 1.65 and 1.66 cause test runs to hang randomly.
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "google-style", "~> 1.24.0"
+  spec.add_development_dependency "google-style", "~> 1.30.1"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.1"

--- a/benchmarks/application.rb
+++ b/benchmarks/application.rb
@@ -63,7 +63,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 
   def self.execute_individual_benchmarks singer, client
@@ -120,9 +120,7 @@ class Application
       sql = "SELECT * FROM Singers WHERE id=@id"
       params = { id: singer[:id] }
       param_types = { id: :INT64 }
-      client.execute(sql, params: params, types: param_types).rows.each do |row|
-        return row
-      end
+      client.execute(sql, params: params, types: param_types).rows.first(1)
     else
       Singer.find singer.id
     end
@@ -134,9 +132,7 @@ class Application
       sql = "SELECT * FROM Singers WHERE id=@id"
       params = { id: singer[:id] }
       param_types = { id: :INT64 }
-      client.execute(sql, params: params, types: param_types).rows.each do |row|
-        return row
-      end
+      client.execute(sql, params: params, types: param_types).rows.first(1)
     else
       singer.reload
     end

--- a/examples/snippets/array-data-type/application.rb
+++ b/examples/snippets/array-data-type/application.rb
@@ -38,7 +38,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/bit-reversed-sequence/application.rb
+++ b/examples/snippets/bit-reversed-sequence/application.rb
@@ -25,7 +25,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 
   def self.find_album singerid, albumid

--- a/examples/snippets/bit-reversed-sequence/db/seeds.rb
+++ b/examples/snippets/bit-reversed-sequence/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 
@@ -14,7 +14,7 @@ last_names = %w[Wendelson Allison Peterson Johnson Henderson Ericsson Aronson Te
 adjectives = %w[daily happy blue generous cooked bad open]
 nouns = %w[windows potatoes bank street tree glass bottle]
 
-# Note: We do not use mutations to insert these rows, because letting the database generate the primary key means that
+# NOTE: We do not use mutations to insert these rows, because letting the database generate the primary key means that
 # we rely on a `THEN RETURN id` clause in the insert statement. This is only supported for DML statements, and not for
 # mutations.
 ActiveRecord::Base.transaction do

--- a/examples/snippets/bulk-insert/application.rb
+++ b/examples/snippets/bulk-insert/application.rb
@@ -46,7 +46,7 @@ class Application
       ]
     end
     puts ""
-    puts "Created a batch of #{singers.length} singers and #{albums.length} "\
+    puts "Created a batch of #{singers.length} singers and #{albums.length} " \
          "albums using a transaction with buffered mutations:"
     singers.each do |s|
       puts "  Created singer #{s.first_name} #{s.last_name} with id #{s.id}"
@@ -57,7 +57,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/commit-timestamp/application.rb
+++ b/examples/snippets/commit-timestamp/application.rb
@@ -46,7 +46,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/create-records/application.rb
+++ b/examples/snippets/create-records/application.rb
@@ -35,7 +35,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/date-data-type/application.rb
+++ b/examples/snippets/date-data-type/application.rb
@@ -28,7 +28,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/date-data-type/db/seeds.rb
+++ b/examples/snippets/date-data-type/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 #
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 
 first_names = %w[Nelson Todd William Alex Dominique Adenoid Steve Nathan Beverly Annie Amy Norma Diana Regan Phyllis]

--- a/examples/snippets/generated-column/application.rb
+++ b/examples/snippets/generated-column/application.rb
@@ -30,7 +30,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/generated-column/db/seeds.rb
+++ b/examples/snippets/generated-column/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 
 first_names = %w[Pete Alice John Ethel Trudy Naomi Wendy Ruben Thomas Elly]

--- a/examples/snippets/hints/application.rb
+++ b/examples/snippets/hints/application.rb
@@ -40,7 +40,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/hints/db/seeds.rb
+++ b/examples/snippets/hints/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/interleaved-tables-before-7.1/application.rb
+++ b/examples/snippets/interleaved-tables-before-7.1/application.rb
@@ -31,7 +31,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 
   def self.find_singer

--- a/examples/snippets/interleaved-tables-before-7.1/db/seeds.rb
+++ b/examples/snippets/interleaved-tables-before-7.1/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 require_relative "../models/track"

--- a/examples/snippets/interleaved-tables/application.rb
+++ b/examples/snippets/interleaved-tables/application.rb
@@ -31,7 +31,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 
   def self.find_singer

--- a/examples/snippets/interleaved-tables/db/seeds.rb
+++ b/examples/snippets/interleaved-tables/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 require_relative "../models/track"

--- a/examples/snippets/migrations/application.rb
+++ b/examples/snippets/migrations/application.rb
@@ -19,7 +19,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/mutations/application.rb
+++ b/examples/snippets/mutations/application.rb
@@ -22,7 +22,7 @@ class Application
       to_album = Album.where.not(id: from_album.id).sample
 
       puts ""
-      puts "Transferring 10,000 marketing budget from #{from_album.title} (#{from_album.marketing_budget}) "\
+      puts "Transferring 10,000 marketing budget from #{from_album.title} (#{from_album.marketing_budget}) " \
            "to #{to_album.title} (#{to_album.marketing_budget})"
       from_album.update marketing_budget: from_album.marketing_budget - 10000
       to_album.update marketing_budget: to_album.marketing_budget + 10000
@@ -40,7 +40,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/mutations/db/seeds.rb
+++ b/examples/snippets/mutations/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/optimistic-locking/application.rb
+++ b/examples/snippets/optimistic-locking/application.rb
@@ -41,7 +41,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/optimistic-locking/db/seeds.rb
+++ b/examples/snippets/optimistic-locking/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/partitioned-dml/application.rb
+++ b/examples/snippets/partitioned-dml/application.rb
@@ -41,7 +41,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/partitioned-dml/db/seeds.rb
+++ b/examples/snippets/partitioned-dml/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/query-logs/application.rb
+++ b/examples/snippets/query-logs/application.rb
@@ -20,7 +20,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 
   def self.enable_query_logs
@@ -31,16 +31,9 @@ class Application
     # Query log comments *MUST* be prepended to be included as a request tag.
     ActiveRecord::QueryLogs.prepend_comment = true
 
-    # This block manually enables Query Logs without a full Rails application.
+    # Enable query logs in a non-Rails application.
     # This should normally not be needed in your application.
-    ActiveRecord::QueryLogs.taggings.merge!(
-      application:  "example-app",
-      action:       "run-test-application",
-      pid:          -> { Process.pid.to_s },
-      socket:       ->(context) { context[:connection].pool.db_config.socket },
-      db_host:      ->(context) { context[:connection].pool.db_config.host },
-      database:     ->(context) { context[:connection].pool.db_config.database }
-    )
+    enable_query_logs_without_rails
 
     ActiveRecord::QueryLogs.tags = [
       # The first tag *MUST* be the fixed value 'request_tag:true'.
@@ -57,6 +50,19 @@ class Application
       :db_host,
       :database
     ]
+  end
+
+  def self.enable_query_logs_without_rails
+    # This block manually enables Query Logs without a full Rails application.
+    # This should normally not be needed in your application.
+    ActiveRecord::QueryLogs.taggings.merge!(
+      application:  "example-app",
+      action:       "run-test-application",
+      pid:          -> { Process.pid.to_s },
+      socket:       ->(context) { context[:connection].pool.db_config.socket },
+      db_host:      ->(context) { context[:connection].pool.db_config.host },
+      database:     ->(context) { context[:connection].pool.db_config.database }
+    )
   end
 end
 

--- a/examples/snippets/query-logs/db/seeds.rb
+++ b/examples/snippets/query-logs/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/quickstart/application.rb
+++ b/examples/snippets/quickstart/application.rb
@@ -44,7 +44,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/quickstart/db/seeds.rb
+++ b/examples/snippets/quickstart/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/read-only-transactions/application.rb
+++ b/examples/snippets/read-only-transactions/application.rb
@@ -70,7 +70,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/read-only-transactions/db/seeds.rb
+++ b/examples/snippets/read-only-transactions/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/read-write-transactions/application.rb
+++ b/examples/snippets/read-write-transactions/application.rb
@@ -20,7 +20,7 @@ class Application
       to_album = Album.where.not(id: from_album.id).sample
 
       puts ""
-      puts "Transferring 10,000 marketing budget from #{from_album.title} (#{from_album.marketing_budget}) "\
+      puts "Transferring 10,000 marketing budget from #{from_album.title} (#{from_album.marketing_budget}) " \
            "to #{to_album.title} (#{to_album.marketing_budget})"
       from_album.update marketing_budget: from_album.marketing_budget - 10000
       to_album.update marketing_budget: to_album.marketing_budget + 10000
@@ -32,7 +32,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/read-write-transactions/db/seeds.rb
+++ b/examples/snippets/read-write-transactions/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/stale-reads/application.rb
+++ b/examples/snippets/stale-reads/application.rb
@@ -56,7 +56,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/stale-reads/db/seeds.rb
+++ b/examples/snippets/stale-reads/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/tags/application.rb
+++ b/examples/snippets/tags/application.rb
@@ -25,7 +25,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/examples/snippets/tags/db/seeds.rb
+++ b/examples/snippets/tags/db/seeds.rb
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-require_relative "../../config/environment.rb"
+require_relative "../../config/environment"
 require_relative "../models/singer"
 require_relative "../models/album"
 

--- a/examples/snippets/timestamp-data-type/application.rb
+++ b/examples/snippets/timestamp-data-type/application.rb
@@ -35,7 +35,7 @@ class Application
 
     puts ""
     puts "Press any key to end the application"
-    STDIN.getch
+    $stdin.getch
   end
 end
 

--- a/lib/active_record/connection_adapters/spanner/column.rb
+++ b/lib/active_record/connection_adapters/spanner/column.rb
@@ -10,16 +10,16 @@ module ActiveRecord
   module ConnectionAdapters
     module Spanner
       class Column < ConnectionAdapters::Column
-        # rubocop:disable Style/MethodDefParentheses
+        # rubocop:disable Style/OptionalBooleanParameter
         def initialize(name, default, sql_type_metadata = nil, null = true,
                        default_function = nil, collation: nil, comment: nil,
                        primary_key: false, **)
-          # rubocop:enable Style/MethodDefParentheses
+          # rubocop:enable Style/OptionalBooleanParameter
           super
           @primary_key = primary_key
         end
 
-        def has_default? # rubocop:disable Naming/PredicateName
+        def has_default?
           super && !virtual?
         end
 

--- a/lib/active_record/connection_adapters/spanner/quoting.rb
+++ b/lib/active_record/connection_adapters/spanner/quoting.rb
@@ -45,6 +45,7 @@ module ActiveRecord
         end
       end
     end
+
     module Spanner
       module Quoting
         def quote_column_name name
@@ -55,7 +56,7 @@ module ActiveRecord
           QUOTED_TABLE_NAMES[name] ||= "`#{name.to_s.gsub '.', '`.`'}`".freeze
         end
 
-        STR_ESCAPE_REGX = /[\n\r'\\]/.freeze
+        STR_ESCAPE_REGX = /[\n\r'\\]/
         STR_ESCAPE_VALUES = {
           "\n" => "\\n", "\r" => "\\r", "'" => "\\'", "\\" => "\\\\"
         }.freeze

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -44,10 +44,7 @@ module ActiveRecord
                                      else
                                        [o.options[:primary_key]]
                                      end
-                           pk_names = []
-                           columns.each do |c|
-                             pk_names.append c.to_s
-                           end
+                           pk_names = columns.map(&:to_s)
                            PrimaryKeyDefinition.new pk_names
                          else
                            pk_names = o.columns.each_with_object [] do |c, r|
@@ -93,8 +90,8 @@ module ActiveRecord
         end
 
         def visit_DropColumnDefinition o
-          "ALTER TABLE #{quote_table_name o.table_name} DROP" \
-           " COLUMN #{quote_column_name o.name}"
+          "ALTER TABLE #{quote_table_name o.table_name} DROP " \
+            "COLUMN #{quote_column_name o.name}"
         end
 
         def visit_ChangeColumnDefinition o
@@ -143,7 +140,7 @@ module ActiveRecord
 
           if !options[:allow_commit_timestamp].nil? &&
              options[:column].sql_type == "TIMESTAMP"
-            sql << " OPTIONS (allow_commit_timestamp = "\
+            sql << " OPTIONS (allow_commit_timestamp = " \
                    "#{options[:allow_commit_timestamp]})"
           end
 
@@ -153,8 +150,9 @@ module ActiveRecord
             sql << " STORED" if options[:stored]
             unless options[:stored]
               raise ArgumentError, "" \
-                "Cloud Spanner currently does not support generated columns without the STORED option." \
-                "Specify 'stored: true' option for `#{options[:column].name}`"
+                                   "Cloud Spanner currently does not support generated columns" \
+                                   "without the STORED option." \
+                                   "Specify 'stored: true' option for `#{options[:column].name}`"
             end
           end
 

--- a/lib/active_record/connection_adapters/spanner/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_definitions.rb
@@ -5,7 +5,7 @@
 # https://opensource.org/licenses/MIT.
 
 module ActiveRecord
-  module ConnectionAdapters #:nodoc:
+  module ConnectionAdapters # :nodoc:
     module Spanner
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         attr_reader :interleave_in_parent
@@ -62,6 +62,9 @@ module ActiveRecord
       DropIndexDefinition = Struct.new :name
 
       class ReferenceDefinition < ActiveRecord::ConnectionAdapters::ReferenceDefinition
+        # This constructor intentionally does not call super to prevent ActiveRecord
+        # from creating an additional secondary index for the foreign key.
+        # rubocop:disable Lint/MissingSuper
         def initialize \
             name,
             polymorphic: false,
@@ -81,6 +84,7 @@ module ActiveRecord
           return unless polymorphic && foreign_key
           raise ArgumentError, "Cannot add a foreign key to a polymorphic relation"
         end
+        # rubocop:enable Lint/MissingSuper
 
         private
 
@@ -96,8 +100,13 @@ module ActiveRecord
       end
 
       class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
-        attr_reader :null_filtered, :interleave_in, :storing, :orders
+        attr_reader :null_filtered
+        attr_reader :interleave_in
+        attr_reader :storing
+        attr_reader :orders
 
+        # This constructor intentionally does not call super.
+        # rubocop:disable Lint/MissingSuper
         def initialize \
             table_name,
             name,
@@ -123,6 +132,7 @@ module ActiveRecord
 
           @orders = @orders.symbolize_keys
         end
+        # rubocop:enable Lint/MissingSuper
 
         def columns_with_order
           columns.each_with_object({}) do |c, result|

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -180,8 +180,8 @@ module ActiveRecord
 
         def _remove_columns table_name, *column_names
           if column_names.empty?
-            raise ArgumentError, "You must specify at least one column name. "\
-              "Example: remove_columns(:people, :first_name)"
+            raise ArgumentError, "You must specify at least one column name. " \
+                                 "Example: remove_columns(:people, :first_name)"
           end
 
           statements = []
@@ -508,8 +508,8 @@ module ActiveRecord
           type ||= column.type
           options[:null] = column.null unless options.key? :null
 
-          if ["STRING", "BYTES"].include? type
-            options[:limit] = column.limit unless options.key? :limit
+          if ["STRING", "BYTES"].include?(type) && !options.key?(:limit)
+            options[:limit] = column.limit
           end
 
           # Only timestamp type can set commit timestamp

--- a/lib/active_record/connection_adapters/spanner/type_metadata.rb
+++ b/lib/active_record/connection_adapters/spanner/type_metadata.rb
@@ -14,7 +14,9 @@ module ActiveRecord
 
         include Deduplicable if defined?(Deduplicable)
 
-        attr_reader :ordinal_position, :allow_commit_timestamp, :generated
+        attr_reader :ordinal_position
+        attr_reader :allow_commit_timestamp
+        attr_reader :generated
 
         def initialize type_metadata, ordinal_position: nil, allow_commit_timestamp: nil, generated: nil
           super type_metadata
@@ -33,11 +35,7 @@ module ActiveRecord
         alias eql? ==
 
         def hash
-          TypeMetadata.hash ^
-            __getobj__.hash ^
-            ordinal_position.hash ^
-            allow_commit_timestamp.hash ^
-            generated.hash
+          [TypeMetadata.name, __getobj__, ordinal_position, allow_commit_timestamp, generated].hash
         end
 
         private

--- a/lib/active_record/tasks/spanner_database_tasks.rb
+++ b/lib/active_record/tasks/spanner_database_tasks.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       def purge
         begin
           drop
-        rescue ActiveRecord::NoDatabaseError # rubocop:disable Lint/HandleExceptions
+        rescue ActiveRecord::NoDatabaseError
           # ignored; create the database
         end
 
@@ -51,8 +51,8 @@ module ActiveRecord
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
 
         if ignore_tables.any?
-          index_regx = /^CREATE(.*)INDEX(.*)ON (#{ignore_tables.join "|"})\(/
-          table_regx = /^CREATE TABLE (#{ignore_tables.join "|"})/
+          index_regx = /^CREATE(.*)INDEX(.*)ON (#{ignore_tables.join '|'})\(/
+          table_regx = /^CREATE TABLE (#{ignore_tables.join '|'})/
         end
 
         @connection.database.ddl(force: true).each do |statement|
@@ -66,7 +66,7 @@ module ActiveRecord
       end
 
       def structure_load filename, _extra_flags
-        statements = File.read(filename).split(/;/).map(&:strip).reject(&:empty?)
+        statements = File.read(filename).split(";").map(&:strip).reject(&:empty?)
         ddls = statements.select { |s| s =~ /^(CREATE|ALTER|DROP|GRANT|REVOKE|ANALYZE)/ }
         @connection.execute_ddl ddls
 

--- a/lib/active_record/type/spanner/array.rb
+++ b/lib/active_record/type/spanner/array.rb
@@ -9,11 +9,15 @@ module ActiveRecord
     module Spanner
       class Array < Type::Value
         attr_reader :element_type
+
         delegate :type, :user_input_in_time_zone, :limit, :precision, :scale, to: :element_type
 
+        # This constructor intentionally does not call super.
+        # rubocop:disable Lint/MissingSuper
         def initialize element_type
           @element_type = element_type
         end
+        # rubocop:enable Lint/MissingSuper
 
         def cast value
           return super if value.nil?

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -10,7 +10,9 @@ require "activerecord_spanner_adapter/information_schema"
 
 module ActiveRecordSpannerAdapter
   class Connection
-    attr_reader :instance_id, :database_id, :spanner
+    attr_reader :instance_id
+    attr_reader :database_id
+    attr_reader :spanner
     attr_accessor :current_transaction
 
     def initialize config
@@ -217,6 +219,7 @@ module ActiveRecordSpannerAdapter
       execute_sql_request sql, converted_params, types, selector, request_options
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def execute_sql_request sql, converted_params, types, selector, request_options = nil
       res = session.execute_query \
         sql,
@@ -224,7 +227,7 @@ module ActiveRecordSpannerAdapter
         types: types,
         transaction: selector,
         request_options: request_options,
-        seqno: (current_transaction&.next_sequence_number)
+        seqno: current_transaction&.next_sequence_number
       current_transaction.grpc_transaction = res.metadata.transaction \
           if current_transaction && res&.metadata&.transaction
       res
@@ -252,6 +255,7 @@ module ActiveRecordSpannerAdapter
       # It was not the first statement, so propagate the error.
       raise
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Creates a transaction using a BeginTransaction RPC. This is used if the first statement of a
     # transaction fails, as that also means that no transaction id was returned.
@@ -283,7 +287,7 @@ module ActiveRecordSpannerAdapter
     end
 
     def transaction_selector
-      return current_transaction&.transaction_selector if current_transaction&.active?
+      current_transaction&.transaction_selector if current_transaction&.active?
     end
 
     def truncate table_name

--- a/lib/activerecord_spanner_adapter/foreign_key.rb
+++ b/lib/activerecord_spanner_adapter/foreign_key.rb
@@ -6,8 +6,15 @@
 
 module ActiveRecordSpannerAdapter
   class ForeignKey
-    attr_accessor :table_schema, :table_name, :name, :columns, :ref_schema, :ref_table, :ref_columns,
-                  :on_delete, :on_update
+    attr_accessor :table_schema
+    attr_accessor :table_name
+    attr_accessor :name
+    attr_accessor :columns
+    attr_accessor :ref_schema
+    attr_accessor :ref_table
+    attr_accessor :ref_columns
+    attr_accessor :on_delete
+    attr_accessor :on_update
 
     def initialize \
         table_name,

--- a/lib/activerecord_spanner_adapter/index.rb
+++ b/lib/activerecord_spanner_adapter/index.rb
@@ -8,8 +8,16 @@ require "activerecord_spanner_adapter/index/column"
 
 module ActiveRecordSpannerAdapter
   class Index
-    attr_accessor :schema, :table, :name, :columns, :type, :unique, :null_filtered,
-                  :interleave_in, :storing, :state
+    attr_accessor :schema
+    attr_accessor :table
+    attr_accessor :name
+    attr_accessor :columns
+    attr_accessor :type
+    attr_accessor :unique
+    attr_accessor :null_filtered
+    attr_accessor :interleave_in
+    attr_accessor :storing
+    attr_accessor :state
 
     def initialize \
         table,

--- a/lib/activerecord_spanner_adapter/index/column.rb
+++ b/lib/activerecord_spanner_adapter/index/column.rb
@@ -7,7 +7,12 @@
 module ActiveRecordSpannerAdapter
   class Index
     class Column
-      attr_accessor :table_name, :schema_name, :index_name, :name, :order, :ordinal_position
+      attr_accessor :table_name
+      attr_accessor :schema_name
+      attr_accessor :index_name
+      attr_accessor :name
+      attr_accessor :order
+      attr_accessor :ordinal_position
 
       def initialize \
           table_name,

--- a/lib/activerecord_spanner_adapter/information_schema.rb
+++ b/lib/activerecord_spanner_adapter/information_schema.rb
@@ -32,7 +32,7 @@ module ActiveRecordSpannerAdapter
 
       rows = execute_query(
         sql,
-        schema_name: (schema_name || ""), table_name: table_name
+        schema_name: schema_name || "", table_name: table_name
       )
 
       rows.map do |row|

--- a/lib/activerecord_spanner_adapter/primary_key.rb
+++ b/lib/activerecord_spanner_adapter/primary_key.rb
@@ -18,8 +18,8 @@ module ActiveRecord
         end
 
         def fetch_primary_and_parent_key
-          return connection.spanner_schema_cache.primary_and_parent_keys table_name \
-            if ActiveRecord::Base != self && table_exists?
+          connection.spanner_schema_cache.primary_and_parent_keys table_name \
+            if self != ActiveRecord::Base && table_exists?
         end
 
         def primary_and_parent_key= value

--- a/lib/activerecord_spanner_adapter/table.rb
+++ b/lib/activerecord_spanner_adapter/table.rb
@@ -30,8 +30,14 @@ require "activerecord_spanner_adapter/table/column"
 
 module ActiveRecordSpannerAdapter
   class Table
-    attr_accessor :name, :on_delete, :parent_table, :schema_name, :catalog,
-                  :indexes, :columns, :foreign_keys
+    attr_accessor :name
+    attr_accessor :on_delete
+    attr_accessor :parent_table
+    attr_accessor :schema_name
+    attr_accessor :catalog
+    attr_accessor :indexes
+    attr_accessor :columns
+    attr_accessor :foreign_keys
 
     # parent_table == interleave_in
     def initialize \

--- a/lib/activerecord_spanner_adapter/table/column.rb
+++ b/lib/activerecord_spanner_adapter/table/column.rb
@@ -7,9 +7,18 @@
 module ActiveRecordSpannerAdapter
   class Table
     class Column
-      attr_accessor :schema_name, :table_name, :name, :type, :limit, :ordinal_position,
-                    :allow_commit_timestamp, :default, :default_function, :generated,
-                    :primary_key, :nullable
+      attr_accessor :schema_name
+      attr_accessor :table_name
+      attr_accessor :name
+      attr_accessor :type
+      attr_accessor :limit
+      attr_accessor :ordinal_position
+      attr_accessor :allow_commit_timestamp
+      attr_accessor :default
+      attr_accessor :default_function
+      attr_accessor :generated
+      attr_accessor :primary_key
+      attr_accessor :nullable
 
       def initialize \
           table_name,

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -123,7 +123,7 @@ module ActiveRecordSpannerAdapter
 
     def shoot_and_forget_rollback
       @connection.session.rollback @grpc_transaction.transaction_id if @committable
-    rescue StandardError # rubocop:disable Lint/HandleExceptions
+    rescue StandardError
       # Ignored
     end
 

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -66,8 +66,8 @@ module Google
           ensure_service!
 
           snp_grpc = service.create_snapshot \
-            path, timestamp: (timestamp || read_timestamp),
-            staleness: (staleness || exact_staleness)
+            path, timestamp: timestamp || read_timestamp,
+            staleness: staleness || exact_staleness
           num_args = Snapshot.method(:from_grpc).arity
           if num_args == 3
             Snapshot.from_grpc snp_grpc, self, nil
@@ -105,7 +105,8 @@ module Google
       end
 
       class Transaction
-        attr_accessor :seqno, :commit
+        attr_accessor :seqno
+        attr_accessor :commit
       end
     end
   end


### PR DESCRIPTION
Removes unsupported Ruby versions from the test runs and updates the
minimum required Ruby version to 3.1. Updates google-style and the
corresponding rubocop version.