### PR TITLE
feat!: drop support for Rails 6.1

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: ["3.1", "3.2", "3.3"]
-        ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
+        ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: "3.1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: ["3.1", "3.2", "3.3"]
-        ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
+        ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: "3.1"

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: ["3.1", "3.2", "3.3"]
-        ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
+        ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: "3.1"

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
         ruby: ["3.1", "3.2", "3.3"]
-        ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
+        ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: "3.1"

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         ruby: ["3.1", "3.2", "3.3"]
-        ar: ["~> 6.1.0", "~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
+        ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
           - ruby: "3.1"

--- a/acceptance/cases/migration/command_recorder_test.rb
+++ b/acceptance/cases/migration/command_recorder_test.rb
@@ -13,9 +13,6 @@ module ActiveRecord
     class CommandRecorderTest < SpannerAdapter::TestCase
       include SpannerAdapter::Migration::TestHelper
 
-      VERSION_6_1_0 = Gem::Version.create "6.1.0"
-      VERSION_6_0_3 = Gem::Version.create "6.0.3"
-
       def setup
         skip_test_table_create!
         super
@@ -203,20 +200,12 @@ module ActiveRecord
 
       def test_invert_add_index
         remove = @recorder.inverse_of :add_index, [:table, [:one, :two]]
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert_equal [:remove_index, [:table, { column: [:one, :two] }]], remove
-        else
-          assert_equal [:remove_index, [:table, [:one, :two]], nil], remove
-        end
+        assert_equal [:remove_index, [:table, [:one, :two]], nil], remove
       end
 
       def test_invert_add_index_with_name
         remove = @recorder.inverse_of :add_index, [:table, [:one, :two], name: "new_index"]
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert_equal [:remove_index, [:table, { name: "new_index" }]], remove
-        else
-          assert_equal [:remove_index, [:table, [:one, :two], {:name=>"new_index"}], nil], remove
-        end
+        assert_equal [:remove_index, [:table, [:one, :two], {:name=>"new_index"}], nil], remove
       end
 
       def test_invert_remove_index
@@ -226,11 +215,7 @@ module ActiveRecord
 
       def test_invert_remove_index_with_options
         add = @recorder.inverse_of :remove_index, [:table, { column: :one }]
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert_equal [:add_index, [:table, :one, {} ]], add
-        else
-          assert_equal [:add_index, [:table, :one ]], add
-        end
+        assert_equal [:add_index, [:table, :one ]], add
       end
 
       def test_invert_remove_index_with_positional_column
@@ -250,11 +235,7 @@ module ActiveRecord
 
       def test_invert_remove_index_with_no_special_options
         add = @recorder.inverse_of :remove_index, [:table, { column: [:one, :two] }]
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert_equal [:add_index, [:table, [:one, :two], {}]], add
-        else
-          assert_equal [:add_index, [:table, [:one, :two]]], add
-        end
+        assert_equal [:add_index, [:table, [:one, :two]]], add
       end
 
       def test_invert_remove_index_with_no_column
@@ -315,11 +296,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
-        if ActiveRecord.gem_version < VERSION_6_0_3
-          assert_equal [:remove_foreign_key, [:dogs, :people]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable
       end
 
       def test_invert_remove_foreign_key
@@ -329,11 +306,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id"]
-        if ActiveRecord.gem_version < VERSION_6_0_3
-          assert_equal [:remove_foreign_key, [:dogs, column: "owner_id"]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column
@@ -343,11 +316,7 @@ module ActiveRecord
 
       def test_invert_add_foreign_key_with_column_and_name
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
-        if ActiveRecord.gem_version < VERSION_6_0_3
-          assert_equal [:remove_foreign_key, [:dogs, { name: "fk" }]], enable
-        else
-          assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
-        end
+        assert_equal [:remove_foreign_key, [:dogs, :people, { column: "owner_id", name: "fk" }], nil], enable
       end
 
       def test_invert_remove_foreign_key_with_column_and_name

--- a/acceptance/cases/migration/references_index_test.rb
+++ b/acceptance/cases/migration/references_index_test.rb
@@ -76,12 +76,7 @@ module ActiveRecord
             t.references :foo, polymorphic: true, index: true
           end
         end
-
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
-        else
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
-        end
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
       end
 
       def test_creates_index_for_existing_table
@@ -124,11 +119,7 @@ module ActiveRecord
           end
         end
 
-        if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
-        else
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
-        end
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
       end
     end
   end

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -168,14 +168,8 @@ module ActiveRecord
           execute_schema_statements statements
         end
 
-        if ActiveRecord.gem_version < VERSION_6_1_0
-          def remove_columns table_name, *column_names
-            _remove_columns table_name, *column_names
-          end
-        else
-          def remove_columns table_name, *column_names, _type: nil, **_options
-            _remove_columns table_name, *column_names
-          end
+        def remove_columns table_name, *column_names, _type: nil, **_options
+          _remove_columns table_name, *column_names
         end
 
         def _remove_columns table_name, *column_names
@@ -193,14 +187,8 @@ module ActiveRecord
           execute_schema_statements statements
         end
 
-        if ActiveRecord.gem_version < VERSION_6_1_0
-          def change_column table_name, column_name, type, options = {}
-            _change_column table_name, column_name, type, **options
-          end
-        else
-          def change_column table_name, column_name, type, **options
-            _change_column table_name, column_name, type, **options
-          end
+        def change_column table_name, column_name, type, **options
+          _change_column table_name, column_name, type, **options
         end
 
         def change_column_null table_name, column_name, null, _default = nil
@@ -280,16 +268,9 @@ module ActiveRecord
           execute_schema_statements schema_creation.accept(id)
         end
 
-        if ActiveRecord.gem_version < VERSION_6_1_0
-          def remove_index table_name, options = {}
-            index_name = index_name_for_remove table_name, options
-            execute "DROP INDEX #{quote_table_name index_name}"
-          end
-        else
-          def remove_index table_name, column_name = nil, **options
-            index_name = index_name_for_remove table_name, column_name, options
-            execute "DROP INDEX #{quote_table_name index_name}"
-          end
+        def remove_index table_name, column_name = nil, **options
+          index_name = index_name_for_remove table_name, column_name, options
+          execute "DROP INDEX #{quote_table_name index_name}"
         end
 
         def rename_index table_name, old_name, new_name
@@ -358,14 +339,8 @@ module ActiveRecord
           end
         end
 
-        if ActiveRecord.gem_version < VERSION_6_0_3
-          def add_foreign_key from_table, to_table, options = {}
-            _add_foreign_key from_table, to_table, **options
-          end
-        else
-          def add_foreign_key from_table, to_table, **options
-            _add_foreign_key from_table, to_table, **options
-          end
+        def add_foreign_key from_table, to_table, **options
+          _add_foreign_key from_table, to_table, **options
         end
 
         def _add_foreign_key from_table, to_table, **options

--- a/test/activerecord_spanner_adapter/information_schema_test.rb
+++ b/test/activerecord_spanner_adapter/information_schema_test.rb
@@ -473,28 +473,26 @@ lines>],
     end
   end
 
-  if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
-    def test_empty_check_contraints
-      set_mocked_result []
-      results = info_schema.check_constraints "accounts"
-      assert_empty results
-    end
+  def test_empty_check_contraints
+    set_mocked_result []
+    results = info_schema.check_constraints "accounts"
+    assert_empty results
+  end
 
-    def test_check_constraints
-      set_mocked_result check_constraints_result
-      results = info_schema.check_constraints "accounts"
-      assert_equal results.length, 1
+  def test_check_constraints
+    set_mocked_result check_constraints_result
+    results = info_schema.check_constraints "accounts"
+    assert_equal results.length, 1
 
-      assert_sql_equal(
-        "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_CATALOG = cc.CONSTRAINT_CATALOG AND tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_SCHEMA = '' AND tc.CONSTRAINT_TYPE = 'CHECK' AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%' AND cc.CHECK_CLAUSE LIKE '%IS NOT NULL')",
-        last_executed_sql
-      )
+    assert_sql_equal(
+      "SELECT tc.TABLE_NAME, tc.CONSTRAINT_NAME, cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_CATALOG = cc.CONSTRAINT_CATALOG AND tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME WHERE tc.TABLE_NAME = 'accounts' AND tc.CONSTRAINT_SCHEMA = '' AND tc.CONSTRAINT_TYPE = 'CHECK' AND NOT (tc.CONSTRAINT_NAME LIKE 'CK_IS_NOT_NULL_%' AND cc.CHECK_CLAUSE LIKE '%IS NOT NULL')",
+      last_executed_sql
+    )
 
-      cc = results.first
-      assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
-      assert_equal cc.table_name, "accounts"
-      assert_equal cc.name, "chk_accounts_name"
-      assert_equal cc.expression, "name IN ('bob')"
-    end
+    cc = results.first
+    assert_instance_of ActiveRecord::ConnectionAdapters::CheckConstraintDefinition, cc
+    assert_equal cc.table_name, "accounts"
+    assert_equal cc.name, "chk_accounts_name"
+    assert_equal cc.expression, "name IN ('bob')"
   end
 end

--- a/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
+++ b/test/migrations_with_mock_server/db/migrate/04_create_singer_and_album_and_track_tables.rb
@@ -44,9 +44,7 @@ class CreateSingerAndAlbumAndTrackTables < ActiveRecord::Migration[6.0]
         t.string :title
         t.numeric :duration
 
-        if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
-          t.check_constraint 'duration > 0', name: :chk_tracks_duration
-        end
+        t.check_constraint 'duration > 0', name: :chk_tracks_duration
       end
 
       # Add a unique index to the trackid column to prevent full table scans when a single track record is queried.

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -248,9 +248,7 @@ module TestMigrationsWithMockServer
 
       expectedDdl = "CREATE TABLE `tracks` "
       expectedDdl << "(`trackid` INT64 NOT NULL, `singerid` INT64 NOT NULL, `albumid` INT64 NOT NULL, `title` STRING(MAX), `duration` NUMERIC"
-      if ActiveRecord.gem_version >= Gem::Version.create("6.1.0")
-        expectedDdl << ", CONSTRAINT chk_tracks_duration CHECK (duration > 0)"
-      end
+      expectedDdl << ", CONSTRAINT chk_tracks_duration CHECK (duration > 0)"
       expectedDdl << ") PRIMARY KEY (`singerid`, `albumid`, `trackid`), INTERLEAVE IN PARENT `albums` ON DELETE CASCADE"
       assert_equal expectedDdl, ddl_requests[2].statements[3]
 
@@ -638,9 +636,7 @@ module TestMigrationsWithMockServer
     end
 
     def test_references_column_with_polymorphic_adds_type
-      index_name = ActiveRecord::gem_version < VERSION_6_1_0 \
-                     ? "index_singers_on_person_type_and_person_id"
-                     : "index_singers_on_person"
+      index_name = "index_singers_on_person"
 
       select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
       register_single_select_tables_result select_table_sql, "albums"
@@ -943,8 +939,7 @@ module TestMigrationsWithMockServer
     end
 
     def test_creates_polymorphic_index_for_existing_table
-      index_name = "index_singers_on_foo" unless ActiveRecord::gem_version < Gem::Version.create('6.1.0')
-      index_name = "index_singers_on_foo_type_and_foo_id" if ActiveRecord::gem_version < Gem::Version.create('6.1.0')
+      index_name = "index_singers_on_foo"
 
       select_table_sql = "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME='singers'"
       register_single_select_tables_result select_table_sql, "singers"


### PR DESCRIPTION
Drops support for Rails 6.1 as it is no longer supported.

See https://rubyonrails.org/2024/10/15/new-maintenance-policy-and-eol-annouments