### PR TITLE
feat: transaction isolation level

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run acceptance tests on emulator
-      run: bundle exec rake acceptance
+      run: bundle exec rake acceptance TESTOPTS="-v"
       env:
         SPANNER_EMULATOR_HOST: localhost:9010
         SPANNER_TEST_PROJECT: test-project

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run tests
-      run: bundle exec rake test
+      run: bundle exec rake test TESTOPTS="-v"

--- a/acceptance/cases/tasks/database_tasks_test.rb
+++ b/acceptance/cases/tasks/database_tasks_test.rb
@@ -65,9 +65,9 @@ module ActiveRecord
       end
 
       def drop_database
+        spanner_instance.database(@database_id)&.drop
         ActiveRecord::Base.connection_pool.disconnect!
         ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-        spanner_instance.database(@database_id)&.drop
       end
 
       def test_structure_dump_and_load

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -274,6 +274,15 @@ module SpannerAdapter
   ActiveSupport::Notifications.subscribe("sql.active_record", SQLCounter.new)
 end
 
+module Kernel
+  # Monkey-patch Kernel.exit to call exit! instead.
+  # This prevents the tests from getting stuck after running (probably) due to
+  # gRPC connections that have not been closed yet.
+  def exit status = true
+    exit! status
+  end
+end
+
 Minitest.after_run do
   drop_test_database
   ActiveRecordSpannerAdapter::Connection.mutex.synchronize do

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -188,6 +188,7 @@ module SpannerAdapter
         unless @skip_test_table_create
           connection.drop_table :test_models, if_exists: true
         end
+        ActiveRecord::Base.connection_pool.disconnect!
 
         super
       end
@@ -275,6 +276,16 @@ end
 
 Minitest.after_run do
   drop_test_database
+  ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
+    ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
+    ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
+      if spanner.respond_to?(:service)
+        channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
+        channel.close
+        end
+    end
+    ActiveRecordSpannerAdapter::Connection.spanners_map.clear
+  end
 end
 
 create_test_database

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -285,16 +285,8 @@ end
 
 Minitest.after_run do
   drop_test_database
-  ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
-    ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-    ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
-      if spanner.respond_to?(:service)
-        channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
-        channel.close
-        end
-    end
-    ActiveRecordSpannerAdapter::Connection.spanners_map.clear
-  end
+  ActiveRecord::Base.connection_pool.disconnect!
+  ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
 end
 
 create_test_database

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -24,9 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.18"
-  # Pin gRPC to 1.64.3, as 1.65 and 1.66 cause test runs to hang randomly.
-  spec.add_dependency "grpc", "1.64.3"
+  spec.add_dependency "google-cloud-spanner", "~> 2.25"
+  spec.add_dependency "google-cloud-spanner-v1", "~> 1.7"
   spec.add_runtime_dependency "activerecord", [">= 7.0", "< 9"]
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/examples/snippets/isolation-level/README.md
+++ b/examples/snippets/isolation-level/README.md
@@ -1,0 +1,39 @@
+# Sample - Isolation Level
+
+This example shows how to use a specific isolation level for read/write transactions
+using the Spanner ActiveRecord adapter.
+
+You can specify the isolation level in two ways:
+
+1. Set a default in the database configuration:
+
+```yaml
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  isolation_level: :serializable,
+  pool: 5
+  timeout: 5000
+  schema_dump: false
+```
+
+2. Specify the isolation level for a specific transaction. This will override any
+   default that is set in the database configuration.
+
+```ruby
+ActiveRecord::Base.transaction isolation: :repeatable_read do
+  # Execute transaction code...
+end
+```
+
+The sample will automatically start a Spanner Emulator in a Docker container and execute the sample
+against that emulator. The emulator will automatically be stopped when the application finishes.
+
+Run the application with the command
+
+```bash
+bundle exec rake run
+```

--- a/examples/snippets/isolation-level/Rakefile
+++ b/examples/snippets/isolation-level/Rakefile
@@ -1,0 +1,13 @@
+# Copyright 2025 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../config/environment"
+require "sinatra/activerecord/rake"
+
+desc "Sample showing how to specify a transaction isolation level for Spanner with ActiveRecord."
+task :run do
+  Dir.chdir("..") { sh "bundle exec rake run[isolation-level]" }
+end

--- a/examples/snippets/isolation-level/application.rb
+++ b/examples/snippets/isolation-level/application.rb
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "io/console"
+require_relative "../config/environment"
+require_relative "models/singer"
+require_relative "models/album"
+
+class Application
+  def self.run # rubocop:disable Metrics/AbcSize
+    from_album = nil
+    to_album = nil
+    # Execute a read/write transaction using isolation level repeatable read.
+    puts "Executing a read/write transaction using isolation level repeatable read"
+    ActiveRecord::Base.transaction isolation: :repeatable_read do
+      # Transfer a marketing budget of 10,000 from one album to another.
+      from_album = Album.all.sample
+      to_album = Album.where.not(id: from_album.id).sample
+
+      puts ""
+      puts "Transferring 10,000 marketing budget from #{from_album.title} (#{from_album.marketing_budget}) " \
+           "to #{to_album.title} (#{to_album.marketing_budget})"
+      from_album.update marketing_budget: from_album.marketing_budget - 10000
+      to_album.update marketing_budget: to_album.marketing_budget + 10000
+    end
+    puts ""
+    puts "Budgets after update:"
+    puts "Marketing budget #{from_album.title}: #{from_album.reload.marketing_budget}"
+    puts "Marketing budget #{to_album.title}: #{to_album.reload.marketing_budget}"
+  end
+end
+
+Application.run

--- a/examples/snippets/isolation-level/config/database.yml
+++ b/examples/snippets/isolation-level/config/database.yml
@@ -1,0 +1,10 @@
+development:
+  adapter: spanner
+  emulator_host: localhost:9010
+  project: test-project
+  instance: test-instance
+  database: testdb
+  isolation_level: :serializable,
+  pool: 5
+  timeout: 5000
+  schema_dump: false

--- a/examples/snippets/isolation-level/db/migrate/01_create_tables.rb
+++ b/examples/snippets/isolation-level/db/migrate/01_create_tables.rb
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class CreateTables < ActiveRecord::Migration[6.0]
+  def change
+    connection.ddl_batch do
+      create_table :singers do |t|
+        t.string :first_name
+        t.string :last_name
+      end
+
+      create_table :albums do |t|
+        t.string :title
+        t.numeric :marketing_budget
+        t.references :singer, index: false, foreign_key: true
+      end
+    end
+  end
+end

--- a/examples/snippets/isolation-level/db/seeds.rb
+++ b/examples/snippets/isolation-level/db/seeds.rb
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require_relative "../../config/environment"
+require_relative "../models/singer"
+require_relative "../models/album"
+
+first_names = ["Pete", "Alice", "John", "Ethel", "Trudy", "Naomi", "Wendy", "Ruben", "Thomas", "Elly"]
+last_names = ["Wendelson", "Allison", "Peterson", "Johnson", "Henderson", "Ericsson", "Aronson", "Tennet", "Courtou"]
+
+adjectives = ["daily", "happy", "blue", "generous", "cooked", "bad", "open"]
+nouns = ["windows", "potatoes", "bank", "street", "tree", "glass", "bottle"]
+budgets = [15000, 25000, 10000, 20000, 30000, 12000, 13000]
+
+5.times do
+  Singer.create first_name: first_names.sample, last_name: last_names.sample
+end
+
+20.times do
+  singer_id = Singer.all.sample.id
+  Album.create title: "#{adjectives.sample} #{nouns.sample}", marketing_budget: budgets.sample, singer_id: singer_id
+end

--- a/examples/snippets/isolation-level/models/album.rb
+++ b/examples/snippets/isolation-level/models/album.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Album < ActiveRecord::Base
+  belongs_to :singer
+end

--- a/examples/snippets/isolation-level/models/singer.rb
+++ b/examples/snippets/isolation-level/models/singer.rb
@@ -1,0 +1,9 @@
+# Copyright 2021 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+class Singer < ActiveRecord::Base
+  has_many :albums
+end

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -292,7 +292,7 @@ module ActiveRecord
               if isolation.count != 1
           else
             raise "Unsupported isolation level: #{isolation}" unless
-              [:serializable, :read_only, :buffered_mutations, :pdml].include? isolation
+              [:serializable, :repeatable_read, :read_only, :buffered_mutations, :pdml].include? isolation
           end
 
           log "BEGIN #{isolation}" do

--- a/lib/active_record/connection_adapters/spanner_adapter.rb
+++ b/lib/active_record/connection_adapters/spanner_adapter.rb
@@ -150,7 +150,8 @@ module ActiveRecord
       end
 
       # Spanner Connection API
-      delegate :ddl_batch, :ddl_batch?, :start_batch_ddl, :abort_batch, :run_batch, to: :@connection
+      delegate :ddl_batch, :ddl_batch?, :start_batch_ddl, :abort_batch, :run_batch,
+               :isolation_level, :isolation_level=, to: :@connection
 
       def current_spanner_transaction
         @connection.current_transaction
@@ -168,6 +169,10 @@ module ActiveRecord
 
       def supports_explain?
         false
+      end
+
+      def supports_transaction_isolation?
+        true
       end
 
       def supports_foreign_keys?

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -40,14 +40,6 @@ module ActiveRecordSpannerAdapter
       end
     end
 
-    def self.mutex
-      @mutex
-    end
-
-    def self.spanners_map
-      @spanners
-    end
-
     # Clears the cached information about the underlying information schemas.
     # Call this method if you drop and recreate a database with the same name
     # to prevent the cached information to be used for the new database.

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -14,10 +14,12 @@ module ActiveRecordSpannerAdapter
     attr_reader :database_id
     attr_reader :spanner
     attr_accessor :current_transaction
+    attr_accessor :isolation_level
 
     def initialize config
       @instance_id = config[:instance]
       @database_id = config[:database]
+      @isolation_level = config[:isolation_level]
       @spanner = self.class.spanners config
     end
 
@@ -38,10 +40,21 @@ module ActiveRecordSpannerAdapter
       end
     end
 
+    def self.mutex
+      @mutex
+    end
+
+    def self.spanners_map
+      @spanners
+    end
+
     # Clears the cached information about the underlying information schemas.
     # Call this method if you drop and recreate a database with the same name
     # to prevent the cached information to be used for the new database.
     def self.reset_information_schemas!
+      @information_schemas.each do |_, info_schema|
+        info_schema.connection.disconnect!
+      end
       @information_schemas = {}
     end
 
@@ -271,7 +284,7 @@ module ActiveRecordSpannerAdapter
 
     def begin_transaction isolation = nil
       raise "Nested transactions are not allowed" if current_transaction&.active?
-      self.current_transaction = Transaction.new self, isolation
+      self.current_transaction = Transaction.new self, isolation || @isolation_level
       current_transaction.begin
       current_transaction
     end

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -52,7 +52,7 @@ module ActiveRecordSpannerAdapter
     # Call this method if you drop and recreate a database with the same name
     # to prevent the cached information to be used for the new database.
     def self.reset_information_schemas!
-      @information_schemas.each do |_, info_schema|
+      @information_schemas.each_value do |info_schema|
         info_schema.connection.disconnect!
       end
       @information_schemas = {}

--- a/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
@@ -54,6 +54,16 @@ module TestInterleavedTables
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
+      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
+        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
+        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
+          if spanner.respond_to?(:service)
+            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
+            channel.close
+            end
+        end
+        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
+      end
       @server.stop
       @server_thread.exit
       super

--- a/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table/interleaved_tables_test.rb
@@ -54,16 +54,7 @@ module TestInterleavedTables
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
-      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
-        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
-          if spanner.respond_to?(:service)
-            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
-            channel.close
-            end
-        end
-        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
-      end
+      ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
       @server.stop
       @server_thread.exit
       super

--- a/test/activerecord_spanner_interleaved_table_version_7_1_and_higher/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table_version_7_1_and_higher/interleaved_tables_test.rb
@@ -58,6 +58,16 @@ module TestInterleavedTables_7_1_AndHigher
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
+      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
+        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
+        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
+          if spanner.respond_to?(:service)
+            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
+            channel.close
+          end
+        end
+        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
+      end
       @server.stop
       @server_thread.exit
       super

--- a/test/activerecord_spanner_interleaved_table_version_7_1_and_higher/interleaved_tables_test.rb
+++ b/test/activerecord_spanner_interleaved_table_version_7_1_and_higher/interleaved_tables_test.rb
@@ -58,16 +58,7 @@ module TestInterleavedTables_7_1_AndHigher
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
-      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
-        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
-          if spanner.respond_to?(:service)
-            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
-            channel.close
-          end
-        end
-        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
-      end
+      ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
       @server.stop
       @server_thread.exit
       super

--- a/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
@@ -86,6 +86,16 @@ module MockServerTests
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
+      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
+        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
+        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
+          if spanner.respond_to?(:service)
+            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
+            channel.close
+          end
+        end
+        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
+      end
       @server.stop
       @server_thread.exit
       super

--- a/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/base_spanner_mock_server_test.rb
@@ -86,16 +86,7 @@ module MockServerTests
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
-      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
-        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
-          if spanner.respond_to?(:service)
-            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
-            channel.close
-          end
-        end
-        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
-      end
+      ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
       @server.stop
       @server_thread.exit
       super

--- a/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
+++ b/test/migrations_with_mock_server/migrations_with_mock_server_test.rb
@@ -70,16 +70,7 @@ module TestMigrationsWithMockServer
 
     def teardown
       ActiveRecord::Base.connection_pool.disconnect!
-      ActiveRecordSpannerAdapter::Connection.mutex.synchronize do
-        ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
-        ActiveRecordSpannerAdapter::Connection.spanners_map.each do |_, spanner|
-          if spanner.respond_to?(:service)
-            channel = spanner.service.service.spanner_stub.grpc_stub.instance_variable_get(:@ch)
-            channel.close
-          end
-        end
-        ActiveRecordSpannerAdapter::Connection.spanners_map.clear
-      end
+      ActiveRecordSpannerAdapter::Connection.reset_information_schemas!
       @server.stop
       @server_thread.exit
       super

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -300,3 +300,12 @@ module MockGoogleSpanner
     end
   end
 end
+
+module Kernel
+  # Monkey-patch Kernel.exit to call exit! instead.
+  # This prevents the tests from getting stuck after running (probably) due to
+  # gRPC connections that have not been closed yet.
+  def exit status = true
+    exit! status
+  end
+end


### PR DESCRIPTION
Add support for :repeatable_read transaction isolation level. This can be used in the following ways:
- By passing in a value for the :isolation argument when starting a transaction.
- By setting the :isolation_level property of a connection.
- By setting the :isolation_level property in the database config.