### PR TITLE
deps: unpin gRPC

### DIFF
--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.18"
-  # Pin gRPC to 1.64.3, as 1.65 and 1.66 cause test runs to hang randomly.
-  spec.add_dependency "grpc", "1.64.3"
   spec.add_runtime_dependency "activerecord", [">= 7.0", "< 9"]
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"


### PR DESCRIPTION
The latest [gapic-common](https://rubygems.org/gems/gapic-common) gem has a minimum requirement of grpc 1.66 which makes this gem incompatible with any other official google gem that makes use of gapic-common ([google-iam-credentials-v1](https://rubygems.org/gems/google-iam-credentials-v1) for example)

ruby-spanner-activerecord was originally pinned to grpc version 1.64.3 in #310. I'm hopeful that the test run hangs have been alleviated in one of the later releases of that gem (currently 1.71.0)