### PR TITLE
Max commit delay

### DIFF
--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -103,12 +103,14 @@ module ActiveRecordSpannerAdapter
     def set_commit_options options = {}
       return if options.empty?
 
-      if options.key? :return_commit_stats
-        @return_commit_stats = options[:return_commit_stats]
+      options.each do |key, value|
+        case key
+        when :return_commit_stats
+          @return_commit_stats = value
+        when :max_commit_delay
+          @max_commit_delay = value
+        end
       end
-
-      return unless options.key? :max_commit_delay
-      @max_commit_delay = options[:max_commit_delay]
     end
 
     # Returns the commit options that should be used for the commit.

--- a/lib/spanner_client_ext.rb
+++ b/lib/spanner_client_ext.rb
@@ -23,13 +23,14 @@ module Google
       end
 
       class Session
-        def commit_transaction transaction, mutations = []
+        def commit_transaction transaction, mutations = [], commit_options: nil
           ensure_service!
 
           resp = service.commit(
             path,
             mutations,
-            transaction_id: transaction.transaction_id
+            transaction_id: transaction.transaction_id,
+            commit_options: commit_options
           )
           @last_updated_at = Time.now
           Convert.timestamp_to_time resp.commit_timestamp

--- a/test/activerecord_spanner_adapter/transaction_test.rb
+++ b/test/activerecord_spanner_adapter/transaction_test.rb
@@ -32,6 +32,16 @@ class TransactionTest < TestHelper::MockActiveRecordTest
     assert_equal :ROLLED_BACK, transaction.state
   end
 
+  def test_commit_options
+    transaction.begin
+    transaction.set_commit_options return_commit_stats: true, max_commit_delay: 1000
+    transaction.commit
+    assert_equal :COMMITTED, transaction.state
+    commit_options = transaction.get_commit_options
+    assert commit_options[:return_commit_stats]
+    assert_equal 1000, commit_options[:max_commit_delay]
+  end
+
   def test_no_nested_transactions
     transaction.begin
 

--- a/test/activerecord_spanner_adapter/transaction_test.rb
+++ b/test/activerecord_spanner_adapter/transaction_test.rb
@@ -37,7 +37,7 @@ class TransactionTest < TestHelper::MockActiveRecordTest
     transaction.set_commit_options return_commit_stats: true, max_commit_delay: 1000
     transaction.commit
     assert_equal :COMMITTED, transaction.state
-    commit_options = transaction.get_commit_options
+    commit_options = transaction.commit_options
     assert commit_options[:return_commit_stats]
     assert_equal 1000, commit_options[:max_commit_delay]
   end


### PR DESCRIPTION
feat: Add support for `max_commit_delay` option in `commit_options`

This change introduces the ability to configure the `max_commit_delay` option when calling the `service.commit` method. This allows users to fine-tune the commit behavior based on their application's needs, specifically enabling throughput-optimized writes by setting a delay.

**Key changes:**

*   Modified the `service.commit` method to accept a `commit_options` parameter.
*   Implemented logic to handle the `max_commit_delay` option within the `commit_options` parameter.
*   Added unit tests to validate the new functionality.