### PR TITLE
feat: Add automatic PDML fallback for mutation limit errors

### DIFF
--- a/acceptance/cases/transactions/read_write_transactions_test.rb
+++ b/acceptance/cases/transactions/read_write_transactions_test.rb
@@ -273,6 +273,7 @@ module ActiveRecord
           TableWithSequence.connection.use_client_side_id_for_mutations = reset_value
         end
       end
+
       def test_single_dml_succeeds_with_fallback_to_pdml_enabled
         # This test verifies that a normal, successful DML statement works as
         # expected when the fallback isolation is enabled. Because no mutation

--- a/examples/snippets/partitioned-dml/application.rb
+++ b/examples/snippets/partitioned-dml/application.rb
@@ -10,7 +10,7 @@ require_relative "models/singer"
 require_relative "models/album"
 
 class Application
-  def self.run # rubocop:disable Metrics/AbcSize
+  def self.run
     singer_count = Singer.all.count
     album_count = Album.all.count
     puts ""
@@ -25,6 +25,7 @@ class Application
       count = Album.delete_all
       puts "Deleted #{count} albums"
     end
+
     puts ""
     puts "Deleting all singers in the database using normal Read-Write transaction with PDML fallback"
     #
@@ -39,15 +40,14 @@ class Application
     # 3. The Fallback: The adapter then retries the ENTIRE code block in a new,
     #    non-atomic Partitioned DML (PDML) transaction.
     #
-    # --- WARNING: CRITICAL USAGE REQUIREMENTS ---
+    # --- USAGE REQUIREMENTS ---
     # This implementation retries the whole transaction block without checking its contents.
     # The user of this feature is responsible for ensuring the following:
     #
-    # 1. SINGLE DML STATEMENT: The block SHOULD contain only ONE DML statement.
+    # 1. SINGLE DML STATEMENT: The block should contain only ONE DML statement.
     #    If it contains more, the PDML retry will fail with a low-level `seqno` error.
     #
-    # 2. IDEMPOTENCY: The block MUST be "idempotent" (safe to run multiple times),
-    #    as the code may be executed more than once.
+    # 2. IDEMPOTENCY: The DML statement must be idempotent. See https://cloud.google.com/spanner/docs/dml-partitioned#partitionable-idempotent for more information. # rubocop:disable Layout/LineLength
     #
     # 3. NON-ATOMIC: The retried PDML transaction is NOT atomic. Do not use this
     #    for multi-step operations that must all succeed or fail together.
@@ -55,28 +55,6 @@ class Application
     Singer.transaction isolation: :fallback_to_pdml do
       count = Singer.delete_all
       puts "Deleted #{count} singers"
-    end
-    Singer.transaction isolation: :fallback_to_pdml do
-      begin
-        singers_to_create = (1..10).map { |i| { first_name: "Test", last_name: "Singer #{i}" } }
-        Singer.create singers_to_create
-        puts "  #{Singer.count} singers now in database."
-
-        puts "\n  Running a large delete operation with 'isolation: :fallback_to_pdml'..."
-        puts "  NOTE: A real operation of this type on millions of rows could fail with a mutation limit error."
-        puts "  The adapter would catch this error and automatically retry with a PDML transaction."
-
-        Singer.transaction isolation: :fallback_to_pdml do
-          Singer.where("last_name LIKE 'Singer %'").delete_all
-        end
-
-        puts "\n  SUCCESS: The transaction completed successfully thanks to the PDML fallback."
-        puts "  Remaining singers: #{Singer.count}"
-      rescue StandardError => e
-        puts "\n  FAILED: The transaction unexpectedly failed with error: #{e.message}"
-      ensure
-        Singer.delete_all
-      end
     end
 
     puts ""

--- a/examples/snippets/partitioned-dml/application.rb
+++ b/examples/snippets/partitioned-dml/application.rb
@@ -19,8 +19,6 @@ class Application
 
     puts ""
     puts "Deleting all albums in the database using Partitioned DML"
-    # Note that a Partitioned DML transaction can contain ONLY ONE DML statement.
-    # If we want to delete all data in two different tables, we need to do so in two different PDML transactions.
     Album.transaction isolation: :pdml do
       count = Album.delete_all
       puts "Deleted #{count} albums"
@@ -39,6 +37,64 @@ class Application
     puts "Singers in the database: #{singer_count}"
     puts "Albums in the database: #{album_count}"
   end
+
+  def self.run_two_dmls_in_pdml_transaction_test
+    begin
+      Singer.transaction isolation: :pdml do
+        Album.delete_all
+        Singer.delete_all
+      end
+    rescue ActiveRecord::StatementInvalid
+      puts "  SUCCESS: As expected, the transaction failed because PDML only supports one DML statement."
+    ensure
+      Album.delete_all
+      Singer.delete_all
+    end
+  end
+
+  def self.demonstrate_successful_fallback
+    begin
+      singers_to_create = (1..10).map { |i| { first_name: "Test", last_name: "Singer #{i}" } }
+      Singer.create singers_to_create
+      puts "  #{Singer.count} singers now in database."
+
+      puts "\n  Running a large delete operation with 'isolation: :fallback_to_pdml'..."
+      puts "  NOTE: A real operation of this type on millions of rows could fail with a mutation limit error."
+      puts "  The adapter would catch this error and automatically retry with a PDML transaction."
+
+      Singer.transaction isolation: :fallback_to_pdml do
+        Singer.where("last_name LIKE 'Singer %'").delete_all
+      end
+
+      puts "\n  SUCCESS: The transaction completed successfully thanks to the PDML fallback."
+      puts "  Remaining singers: #{Singer.count}"
+    rescue StandardError => e
+      puts "\n  FAILED: The transaction unexpectedly failed with error: #{e.message}"
+    ensure
+      Singer.delete_all
+    end
+  end
+
+  def self.demonstrate_no_fallback_when_disabled
+    begin
+      puts "  Running a transaction that will fail, without enabling the fallback..."
+
+      Singer.transaction do
+        # To demonstrate this, we simulate what Active Record would do if Spanner
+        # returned a mutation limit error. It would raise a generic StatementInvalid error.
+        puts "  Simulating a DML operation that exceeds the mutation limit..."
+        raise ActiveRecordSpannerAdapter::TransactionMutationLimitExceededError,
+              "Simulated: The transaction contains too many mutations"
+      end
+    rescue ActiveRecord::StatementInvalid
+      puts "  SUCCESS: As expected, the transaction failed with a generic ActiveRecord::StatementInvalid."
+      puts "  No fallback was attempted."
+    end
+  end
 end
 
 Application.run
+Application.run_two_dmls_in_pdml_transaction_test
+
+Application.demonstrate_successful_fallback
+Application.demonstrate_no_fallback_when_disabled

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -72,11 +72,18 @@ module ActiveRecord
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
               if transaction_required
                 transaction do
-                  @connection.execute_query sql, statement_type: statement_type, params: params, types: types,
-request_options: request_options
+                  @connection.execute_query sql,
+                                            statement_type: statement_type,
+                                            params: params,
+                                            types: types,
+                                            request_options: request_options
                 end
               else
-                @connection.execute_query sql, statement_type: statement_type, params: params, types: types, single_use_selector: selector,
+                @connection.execute_query sql,
+                                          statement_type: statement_type,
+                                          params: params,
+                                          types: types,
+                                          single_use_selector: selector,
                                           request_options: request_options
               end
             end
@@ -230,7 +237,7 @@ request_options: request_options
 
         # Transaction
 
-        def transaction requires_new: nil, isolation: nil, joinable: true, **kwargs
+        def transaction requires_new: nil, isolation: nil, joinable: true, **kwargs # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           commit_options = kwargs.delete :commit_options
           exclude_from_streams = kwargs.delete :exclude_txn_from_change_streams
           fallback_to_pdml_enabled = kwargs.delete :fallback_to_pdml_enabled || false

--- a/lib/active_record/connection_adapters/spanner/errors/transaction_mutation_limit_exceeded_error.rb
+++ b/lib/active_record/connection_adapters/spanner/errors/transaction_mutation_limit_exceeded_error.rb
@@ -1,0 +1,20 @@
+module Google
+  module Cloud
+    module Spanner
+      module Errors
+        # Custom exception raised when a transaction exceeds the mutation limit in Google Cloud Spanner.
+        # This provides a specific error class for a common, recoverable scenario.
+        class TransactionMutationLimitExceededError < Google::Cloud::Error
+          ERROR_MESSAGE = "The transaction contains too many mutations".freeze
+
+          def self.is_mutation_limit_error? exception
+            return false if exception.message.nil?
+            cause = exception.cause
+            return false unless cause.is_a? GRPC::InvalidArgument
+            cause.details.include?(ERROR_MESSAGE) || exception.message.include?(ERROR_MESSAGE)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/spanner/errors/transaction_mutation_limit_exceeded_error.rb
+++ b/lib/active_record/connection_adapters/spanner/errors/transaction_mutation_limit_exceeded_error.rb
@@ -1,17 +1,22 @@
+# Copyright 2025 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
 module Google
   module Cloud
     module Spanner
       module Errors
         # Custom exception raised when a transaction exceeds the mutation limit in Google Cloud Spanner.
         # This provides a specific error class for a common, recoverable scenario.
-        class TransactionMutationLimitExceededError < Google::Cloud::Error
+        class TransactionMutationLimitExceededError < ActiveRecord::StatementInvalid
           ERROR_MESSAGE = "The transaction contains too many mutations".freeze
 
-          def self.is_mutation_limit_error? exception
-            return false if exception.message.nil?
-            cause = exception.cause
-            return false unless cause.is_a? GRPC::InvalidArgument
-            cause.details.include?(ERROR_MESSAGE) || exception.message.include?(ERROR_MESSAGE)
+          def self.is_mutation_limit_error? error
+            return false if error.nil?
+            error.is_a?(Google::Cloud::InvalidArgumentError) &&
+              error.message&.include?(ERROR_MESSAGE)
           end
         end
       end

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -255,15 +255,16 @@ module ActiveRecordSpannerAdapter
       end
       raise
     rescue Google::Cloud::Error => e
-      if TransactionMutationLimitExceededError.is_mutation_limit_error? e
-        raise
-      end
       # Check if it was the first statement in a transaction that included a BeginTransaction
       # option in the request. If so, execute an explicit BeginTransaction and then retry the
       # request without the BeginTransaction option.
       if current_transaction && selector&.begin&.read_write
         selector = create_transaction_after_failed_first_statement e
         retry
+      end
+
+      if TransactionMutationLimitExceededError.is_mutation_limit_error? e
+        raise
       end
       # It was not the first statement, so propagate the error.
       raise

--- a/lib/activerecord_spanner_adapter/connection.rb
+++ b/lib/activerecord_spanner_adapter/connection.rb
@@ -7,8 +7,11 @@
 require "google/cloud/spanner"
 require "spanner_client_ext"
 require "activerecord_spanner_adapter/information_schema"
+require_relative "../active_record/connection_adapters/spanner/errors/transaction_mutation_limit_exceeded_error"
 
 module ActiveRecordSpannerAdapter
+  TransactionMutationLimitExceededError = Google::Cloud::Spanner::Errors::TransactionMutationLimitExceededError
+
   class Connection
     attr_reader :instance_id
     attr_reader :database_id
@@ -209,7 +212,7 @@ module ActiveRecordSpannerAdapter
 
     # DQL, DML Statements
 
-    def execute_query sql, params: nil, types: nil, single_use_selector: nil, request_options: nil
+    def execute_query sql, statement_type: nil, params: nil, types: nil, single_use_selector: nil, request_options: nil
       if params
         converted_params, types =
           Google::Cloud::Spanner::Convert.to_input_params_and_types(
@@ -223,11 +226,12 @@ module ActiveRecordSpannerAdapter
       end
 
       selector = transaction_selector || single_use_selector
-      execute_sql_request sql, converted_params, types, selector, request_options
+      execute_sql_request sql, statement_type, converted_params, types, selector, request_options
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    def execute_sql_request sql, converted_params, types, selector, request_options = nil
+    def execute_sql_request sql, statement_type, converted_params, types, selector, request_options = nil
+      current_transaction&.increment_dml_counter if statement_type == :dml && current_transaction&.active?
       res = session.execute_query \
         sql,
         params: converted_params,
@@ -252,6 +256,29 @@ module ActiveRecordSpannerAdapter
       end
       raise
     rescue Google::Cloud::Error => e
+      # If the error is a TransactionMutationLimitExceededError, check if it is safe to fallback to a PDML transaction.
+      # If it is safe, create a PDML transaction and retry the request.
+      if TransactionMutationLimitExceededError.is_mutation_limit_error? e
+        is_safe_to_fallback =
+          current_transaction&.dml_statement_count == 1 && current_transaction&.mutations&.empty?
+
+        if current_transaction&.fallback_to_pdml_enabled && is_safe_to_fallback
+          pdml_transaction = ActiveRecordSpannerAdapter::Transaction.new self, :pdml
+          pdml_transaction.begin
+          pdml_selector = pdml_transaction.transaction_selector
+
+          result = session.execute_query(
+            sql,
+            params: converted_params,
+            types: types,
+            transaction: pdml_selector,
+            request_options: request_options
+          )
+          return result
+        end
+        # If it is not safe to fallback, raise a TransactionMutationLimitExceededError.
+        raise ::ActiveRecordSpannerAdapter::TransactionMutationLimitExceededError
+      end
       # Check if it was the first statement in a transaction that included a BeginTransaction
       # option in the request. If so, execute an explicit BeginTransaction and then retry the
       # request without the BeginTransaction option.

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -10,9 +10,6 @@ module ActiveRecordSpannerAdapter
     attr_reader :commit_options
     attr_reader :begin_transaction_selector
     attr_accessor :exclude_txn_from_change_streams
-    attr_accessor :fallback_to_pdml_enabled
-    attr_reader :dml_statement_count
-    attr_reader :mutations
 
 
 
@@ -25,8 +22,6 @@ module ActiveRecordSpannerAdapter
       @mutations = []
       @commit_options = commit_options
       @exclude_txn_from_change_streams = exclude_txn_from_change_streams
-      @fallback_to_pdml_enabled = false
-      @dml_statement_count = 0
     end
 
     def active?
@@ -40,10 +35,6 @@ module ActiveRecordSpannerAdapter
 
     def buffer mutation
       @mutations << mutation
-    end
-
-    def increment_dml_counter
-      @dml_statement_count += 1
     end
 
     # Begins the transaction.
@@ -165,6 +156,10 @@ module ActiveRecordSpannerAdapter
 
     def mark_aborted
       @state = :ABORTED
+    end
+
+    def is_pdml?
+      @isolation == :pdml
     end
 
     # Sets the underlying gRPC transaction to use for this Transaction.

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -158,10 +158,6 @@ module ActiveRecordSpannerAdapter
       @state = :ABORTED
     end
 
-    def is_pdml?
-      @isolation == :pdml
-    end
-
     # Sets the underlying gRPC transaction to use for this Transaction.
     # This is used for queries/DML statements that inlined the BeginTransaction option and returned
     # a transaction in the metadata.

--- a/lib/activerecord_spanner_adapter/transaction.rb
+++ b/lib/activerecord_spanner_adapter/transaction.rb
@@ -10,6 +10,9 @@ module ActiveRecordSpannerAdapter
     attr_reader :commit_options
     attr_reader :begin_transaction_selector
     attr_accessor :exclude_txn_from_change_streams
+    attr_accessor :fallback_to_pdml_enabled
+    attr_reader :dml_statement_count
+    attr_reader :mutations
 
 
 
@@ -22,6 +25,8 @@ module ActiveRecordSpannerAdapter
       @mutations = []
       @commit_options = commit_options
       @exclude_txn_from_change_streams = exclude_txn_from_change_streams
+      @fallback_to_pdml_enabled = false
+      @dml_statement_count = 0
     end
 
     def active?
@@ -35,6 +40,10 @@ module ActiveRecordSpannerAdapter
 
     def buffer mutation
       @mutations << mutation
+    end
+
+    def increment_dml_counter
+      @dml_statement_count += 1
     end
 
     # Begins the transaction.

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -195,30 +195,57 @@ module MockServerTests
 
     def test_update_all_on_table_with_sequence_falls_back_to_pdml
       update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
-
       mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
+
       @mock.push_error(update_sql, mutation_limit_error)
-      @mock.put_statement_result update_sql, StatementResult.new(1)
+      @mock.push_error(update_sql, mutation_limit_error)
+      @mock.put_statement_result(update_sql, StatementResult.new(1))
 
       TableWithSequence.transaction isolation: :fallback_to_pdml do
         TableWithSequence.where(id: 1).update_all(name: "New Foo Name")
       end
 
-      update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
-      assert_equal 2, update_requests.length, "Should have been two attempts for the UPDATE DML"
+      # A BeginTransactionRequest for a read-write transaction should have been sent
+      rw_begin_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && !req.options&.partitioned_dml }
+      assert_equal 1, rw_begin_requests.length, "Exactly one explicit read-write BeginTransactionRequest should have been sent"
 
-      pdml_begin_request = @mock.requests.find { |req| req.is_a?(BeginTransactionRequest) && req.options&.partitioned_dml }
+      # A RollbackRequest should have been sent for the failed read-write transaction.
+      rollback_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::RollbackRequest) }
+      refute_nil rollback_request, "A RollbackRequest should have been sent after the second attempt failed"
+
+      # We assert for 3 total attempts for the UPDATE DML. This complex sequence
+      # is a result of the error triggering two different retry/fallback mechanisms
+      # at different layers of the adapter. The flow is as follows:
+      #
+      # 1. Attempt #1 (Initial "Piggybacked" DML): The first `update_all` call is
+      #    sent without a pre-existing transaction. This attempt is mocked to fail
+      #    before a transaction ID is assigned.
+      #
+      # 2. Attempt #2 (Low-Level Retry): The `execute_sql_request` method catches
+      #    this initial failure. It explicitly begins a new transaction by sending a
+      #    `BeginTransactionRequest`, which generates a real transaction ID. This
+      #    is the transaction that can, and will, be rolled back later. The method
+      #    then `retry`s the `UPDATE` statement. We also mock this second attempt to
+      #    fail so the error can propagate to the high-level fallback logic.
+      #
+      # 3. Attempt #3 (High-Level PDML Fallback): The main `transaction` method's
+      #    `rescue` block finally sees the error. Because a transaction ID now exists
+      #    from step #2, it is first rolled back Then, the successful fallback
+      #    to a PDML transaction is initiated, running the `UPDATE` one last time.
+      #
+      update_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
+      assert_equal 3, update_requests.length, "Should have been three attempts for the UPDATE DML before the PDML fallback"
+      
+      # A PDML transaction should have been started for the final, successful attempt.
+      pdml_begin_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && req.options&.partitioned_dml }
       refute_nil pdml_begin_request, "A BeginTransactionRequest for PDML should have been sent"
-
-      fallback_request = update_requests[1]
-      assert fallback_request.transaction&.id, "Fallback DML should run within a transaction and have an ID"
-      assert_nil fallback_request.transaction&.begin, "Fallback DML should use the existing PDML transaction, not begin a new one"
     end
 
     def test_no_fallback_to_pdml_on_table_with_sequence_when_disabled
       update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
 
       mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
+      @mock.push_error(update_sql, mutation_limit_error)
       @mock.push_error(update_sql, mutation_limit_error)
 
       err = assert_raises ActiveRecord::StatementInvalid do
@@ -229,8 +256,9 @@ module MockServerTests
 
       assert_kind_of Google::Cloud::InvalidArgumentError, err.cause
 
+    
       update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
-      assert_equal 1, update_requests.length, "Should only have been one attempt for the UPDATE DML"
+      assert_equal 2, update_requests.length, "Should only have been two attempts for the UPDATE DML"
 
       pdml_begin_request = @mock.requests.find { |req| req.is_a?(BeginTransactionRequest) && req.options&.partitioned_dml }
       assert_nil pdml_begin_request, "No PDML transaction should have been started"

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -195,9 +195,9 @@ module MockServerTests
 
     def test_update_all_on_table_with_sequence_falls_back_to_pdml
       update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
+
       mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
 
-      @mock.push_error(update_sql, mutation_limit_error)
       @mock.push_error(update_sql, mutation_limit_error)
       @mock.put_statement_result(update_sql, StatementResult.new(1))
 
@@ -205,47 +205,25 @@ module MockServerTests
         TableWithSequence.where(id: 1).update_all(name: "New Foo Name")
       end
 
-      # A BeginTransactionRequest for a read-write transaction should have been sent
-      rw_begin_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && !req.options&.partitioned_dml }
-      assert_equal 1, rw_begin_requests.length, "Exactly one explicit read-write BeginTransactionRequest should have been sent"
-
-      # A RollbackRequest should have been sent for the failed read-write transaction.
-      rollback_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::RollbackRequest) }
-      refute_nil rollback_request, "A RollbackRequest should have been sent after the second attempt failed"
-
-      # We assert for 3 total attempts for the UPDATE DML. This complex sequence
-      # is a result of the error triggering two different retry/fallback mechanisms
-      # at different layers of the adapter. The flow is as follows:
-      #
-      # 1. Attempt #1 (Initial "Piggybacked" DML): The first `update_all` call is
-      #    sent without a pre-existing transaction. This attempt is mocked to fail
-      #    before a transaction ID is assigned.
-      #
-      # 2. Attempt #2 (Low-Level Retry): The `execute_sql_request` method catches
-      #    this initial failure. It explicitly begins a new transaction by sending a
-      #    `BeginTransactionRequest`, which generates a real transaction ID. This
-      #    is the transaction that can, and will, be rolled back later. The method
-      #    then `retry`s the `UPDATE` statement. We also mock this second attempt to
-      #    fail so the error can propagate to the high-level fallback logic.
-      #
-      # 3. Attempt #3 (High-Level PDML Fallback): The main `transaction` method's
-      #    `rescue` block finally sees the error. Because a transaction ID now exists
-      #    from step #2, it is first rolled back Then, the successful fallback
-      #    to a PDML transaction is initiated, running the `UPDATE` one last time.
-      #
-      update_requests = @mock.requests.select { |req| req.is_a?(Google::Cloud::Spanner::V1::ExecuteSqlRequest) && req.sql == update_sql }
-      assert_equal 3, update_requests.length, "Should have been three attempts for the UPDATE DML before the PDML fallback"
+      # The first attempt should have failed with a TransactionMutationLimitExceededError.
+      #  The second attempt should have succeeded with a PDML transaction.
+      #  So we should have two requests for the same DML statement.
+      update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
+      assert_equal 2, update_requests.length, "Should have been two attempts for the UPDATE DML"
       
       # A PDML transaction should have been started for the final, successful attempt.
       pdml_begin_request = @mock.requests.find { |req| req.is_a?(Google::Cloud::Spanner::V1::BeginTransactionRequest) && req.options&.partitioned_dml }
       refute_nil pdml_begin_request, "A BeginTransactionRequest for PDML should have been sent"
+
+      fallback_request = update_requests[1]
+      assert fallback_request.transaction&.id, "Fallback DML should run within a transaction that has an ID (created by the PDML transaction)"
+      assert_nil fallback_request.transaction&.begin, "Fallback DML should use the existing PDML transaction, not begin a new one"
     end
 
     def test_no_fallback_to_pdml_on_table_with_sequence_when_disabled
       update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
 
       mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
-      @mock.push_error(update_sql, mutation_limit_error)
       @mock.push_error(update_sql, mutation_limit_error)
 
       err = assert_raises ActiveRecord::StatementInvalid do
@@ -258,7 +236,7 @@ module MockServerTests
 
     
       update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
-      assert_equal 2, update_requests.length, "Should only have been two attempts for the UPDATE DML"
+      assert_equal 1, update_requests.length, "Should only have been two attempts for the UPDATE DML"
 
       pdml_begin_request = @mock.requests.find { |req| req.is_a?(BeginTransactionRequest) && req.options&.partitioned_dml }
       assert_nil pdml_begin_request, "No PDML transaction should have been started"

--- a/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
+++ b/test/activerecord_spanner_mock_server/spanner_active_record_with_mock_server_test.rb
@@ -13,6 +13,7 @@ require_relative "models/other_adapter"
 module MockServerTests
   CommitRequest = Google::Cloud::Spanner::V1::CommitRequest
   ExecuteSqlRequest = Google::Cloud::Spanner::V1::ExecuteSqlRequest
+  BeginTransactionRequest = Google::Cloud::Spanner::V1::BeginTransactionRequest
 
   class SpannerActiveRecordMockServerTest < BaseSpannerMockServerTest
     VERSION_7_1_0 = Gem::Version.create('7.1.0')
@@ -190,6 +191,49 @@ module MockServerTests
         assert_equal :INT64, request.param_types["p2"].code
         assert_equal :INT64, request.param_types["p1"].code
       end
+    end
+
+    def test_update_all_on_table_with_sequence_falls_back_to_pdml
+      update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
+
+      mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
+      @mock.push_error(update_sql, mutation_limit_error)
+      @mock.put_statement_result update_sql, StatementResult.new(1)
+
+      TableWithSequence.transaction(fallback_to_pdml_enabled: true) do
+        TableWithSequence.where(id: 1).update_all(name: "New Foo Name")
+      end
+
+      update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
+      assert_equal 2, update_requests.length, "Should have been two attempts for the UPDATE DML"
+
+      pdml_begin_request = @mock.requests.find { |req| req.is_a?(BeginTransactionRequest) && req.options&.partitioned_dml }
+      refute_nil pdml_begin_request, "A BeginTransactionRequest for PDML should have been sent"
+
+      fallback_request = update_requests[1]
+      assert fallback_request.transaction&.id, "Fallback DML should run within a transaction and have an ID"
+      assert_nil fallback_request.transaction&.begin, "Fallback DML should use the existing PDML transaction, not begin a new one"
+    end
+
+    def test_no_fallback_to_pdml_on_table_with_sequence_when_disabled
+      update_sql = "UPDATE `table_with_sequence` SET `name` = @p1 WHERE `table_with_sequence`.`id` = @p2"
+
+      mutation_limit_error = GRPC::InvalidArgument.new("The transaction contains too many mutations")
+      @mock.push_error(update_sql, mutation_limit_error)
+
+      err = assert_raises ActiveRecord::StatementInvalid do
+        TableWithSequence.transaction do
+          TableWithSequence.where(id: 1).update_all(name: "This name will not be updated")
+        end
+      end
+
+      assert_kind_of Google::Cloud::Spanner::Errors::TransactionMutationLimitExceededError, err.cause
+
+      update_requests = @mock.requests.select { |req| req.is_a?(ExecuteSqlRequest) && req.sql == update_sql }
+      assert_equal 1, update_requests.length, "Should only have been one attempt for the UPDATE DML"
+
+      pdml_begin_request = @mock.requests.find { |req| req.is_a?(BeginTransactionRequest) && req.options&.partitioned_dml }
+      assert_nil pdml_begin_request, "No PDML transaction should have been started"
     end
 
     def test_selects_singers_with_condition


### PR DESCRIPTION
**Description:**
This change introduces an opt-in, automatic retry mechanism for DML statement that fails due to Spanner's transaction mutation limit.

When a DML statement fails with a TransactionMutationLimitExceededError, this logic will automatically retry the statement within a new Partitioned DML (PDML) transaction.

**Key Features:**

* The fallback is transparent and enabled by passing a fallback_to_pdml isolation option to a standard transaction block.
* If the fallback is disabled or unsafe, a specific TransactionMutationLimitExceededError is raised.

**Usage:**
```
Singer.transaction(isolation: fallback_to_pdml) do
  # If this fails with a mutation limit error, it will be retried with PDML.
  Singer.where("last_name LIKE ?", "A%").update_all(status: "Archived")
end
```