### PR TITLE
feat: Ruby 3.2 minimum and Ruby 4.0 support

### DIFF
--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -18,28 +18,30 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0", "~> 8.1.0"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: "3.1"
-            ar: "~> 8.0.0"
-          - ruby: "3.1"
-            ar: "~> 8.1.0"
           - ruby: "3.4"
             ar: "~> 7.0.0"
           - ruby: "3.4"
             ar: "~> 7.1.0"
           - ruby: "3.4"
             ar: "~> 7.2.0"
+          - ruby: "4.0"
+            ar: "~> 7.0.0"
+          - ruby: "4.0"
+            ar: "~> 7.1.0"
+          - ruby: "4.0"
+            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.5.50
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.55
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/acceptance-tests-on-emulator.yaml
@@ -1,16 +1,20 @@
+name: acceptance tests on emulator
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:
       - main
   pull_request:
-name: acceptance tests on emulator
 jobs:
   test:
     runs-on: ubuntu-latest
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.50
         ports:
           - 9010:9010
           - 9020:9020
@@ -37,11 +41,13 @@ jobs:
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/acceptance-tests-on-production.yaml
+++ b/.github/workflows/acceptance-tests-on-production.yaml
@@ -1,9 +1,13 @@
+name: acceptance tests on production
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:
       - main
   pull_request:
-name: acceptance tests on production
 jobs:
   check-env:
     outputs:
@@ -26,20 +30,22 @@ jobs:
       matrix:
         ruby: [3.3]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
     - name: Authenticate Google Cloud
-      uses: google-github-actions/auth@v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
     - name: Setup GCloud
-      uses: google-github-actions/setup-gcloud@v3
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
     - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,28 +10,30 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0", "~> 8.1.0"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: "3.1"
-            ar: "~> 8.0.0"
-          - ruby: "3.1"
-            ar: "~> 8.1.0"
           - ruby: "3.4"
             ar: "~> 7.0.0"
           - ruby: "3.4"
             ar: "~> 7.1.0"
           - ruby: "3.4"
             ar: "~> 7.2.0"
+          - ruby: "4.0"
+            ar: "~> 7.0.0"
+          - ruby: "4.0"
+            ar: "~> 7.1.0"
+          - ruby: "4.0"
+            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,13 @@
+name: ci
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:
       - main
   pull_request:
-name: ci
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -29,11 +33,13 @@ jobs:
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.5.50
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.55
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -18,26 +18,28 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0", "~> 8.1.0"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: "3.1"
-            ar: "~> 8.0.0"
-          - ruby: "3.1"
-            ar: "~> 8.1.0"
           - ruby: "3.4"
             ar: "~> 7.0.0"
           - ruby: "3.4"
             ar: "~> 7.1.0"
           - ruby: "3.4"
             ar: "~> 7.2.0"
+          - ruby: "4.0"
+            ar: "~> 7.0.0"
+          - ruby: "4.0"
+            ar: "~> 7.1.0"
+          - ruby: "4.0"
+            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false

--- a/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-emulator.yaml
@@ -1,16 +1,20 @@
+name: nightly acceptance tests on emulator
+
+permissions:
+  contents: read
+
 on:
   schedule:
     # 06:00 UTC
     - cron:  '0 6 * * *'
   workflow_dispatch:
-name: nightly acceptance tests on emulator
 jobs:
   test:
     runs-on: ubuntu-latest
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:latest
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.50
         ports:
           - 9010:9010
           - 9020:9020
@@ -37,9 +41,11 @@ jobs:
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false

--- a/.github/workflows/nightly-acceptance-tests-on-production.yaml
+++ b/.github/workflows/nightly-acceptance-tests-on-production.yaml
@@ -1,8 +1,12 @@
+name: nightly acceptance tests on production
+
+permissions:
+  contents: read
+
 on:
   schedule:
     # 02:00 UTC
     - cron:  '0 2 * * *'
-name: nightly acceptance tests on production
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,20 +16,22 @@ jobs:
       matrix:
         ruby: [3.3]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby
     # (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
     - name: Authenticate Google Cloud
-      uses: google-github-actions/auth@v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
     - name: Setup GCloud
-      uses: google-github-actions/setup-gcloud@v3
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
     - name: Install dependencies

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -11,26 +11,28 @@ jobs:
       max-parallel: 4
       matrix:
         # Run acceptance tests all supported combinations of Ruby and ActiveRecord.
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0", "~> 8.1.0"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: "3.1"
-            ar: "~> 8.0.0"
-          - ruby: "3.1"
-            ar: "~> 8.1.0"
           - ruby: "3.4"
             ar: "~> 7.0.0"
           - ruby: "3.4"
             ar: "~> 7.1.0"
           - ruby: "3.4"
             ar: "~> 7.2.0"
+          - ruby: "4.0"
+            ar: "~> 7.0.0"
+          - ruby: "4.0"
+            ar: "~> 7.1.0"
+          - ruby: "4.0"
+            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false

--- a/.github/workflows/nightly-unit-tests.yaml
+++ b/.github/workflows/nightly-unit-tests.yaml
@@ -1,9 +1,13 @@
+name: nightly-unit-tests
+
+permissions:
+  contents: read
+
 on:
   schedule:
     # 05:30 UTC
     - cron:  '30 5 * * *'
   workflow_dispatch:
-name: nightly-unit-tests
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -30,9 +34,11 @@ jobs:
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         # Disable caching as we are overriding the ActiveRecord below.
         bundler-cache: false

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -12,11 +12,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
-        ruby-version: '3.4.8'
+        ruby-version: '4.0'
     - name: cache gems
       uses: actions/cache@v5
       with:

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -1,5 +1,8 @@
 name: rubocop
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize]
@@ -12,13 +15,15 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: setup ruby
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         ruby-version: '4.0'
     - name: cache gems
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -1,6 +1,10 @@
+name: samples
+
+permissions:
+  contents: read
+
 on:
   pull_request:
-name: samples
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,9 +31,11 @@ jobs:
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -8,24 +8,28 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         ar: ["~> 7.0.0", "~> 7.1.0", "~> 7.2.0", "~> 8.0.0"]
         # Exclude combinations that are not supported.
         exclude:
-          - ruby: "3.1"
-            ar: "~> 8.0.0"
           - ruby: "3.4"
             ar: "~> 7.0.0"
           - ruby: "3.4"
             ar: "~> 7.1.0"
           - ruby: "3.4"
             ar: "~> 7.2.0"
+          - ruby: "4.0"
+            ar: "~> 7.0.0"
+          - ruby: "4.0"
+            ar: "~> 7.1.0"
+          - ruby: "4.0"
+            ar: "~> 7.2.0"
     env:
       AR_VERSION: ${{ matrix.ar }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         bundler-cache: false
         ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ gem "minitest", "~> 5.27.0"
 gem "minitest-rg", "~> 5.4.0"
 gem "pry", "~> 0.14.2"
 gem "pry-byebug", "~> 3.11.0"
+gem "readline"
 gem "mutex_m"
+gem "irb"
 # Add sqlite3 for testing for compatibility with other adapters.
 gem 'sqlite3'
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ for Spanner PostgreSQL-dialect databases.__
 
 This project provides a Spanner adapter for ActiveRecord. It supports the following versions:
 
-- ActiveRecord 7.0.x with Ruby 3.1 and higher.
-- ActiveRecord 7.1.x with Ruby 3.1 and higher.
-- ActiveRecord 7.2.x with Ruby 3.1 and higher.
+- ActiveRecord 7.0.x with Ruby 3.2 and higher.
+- ActiveRecord 7.1.x with Ruby 3.2 and higher.
+- ActiveRecord 7.2.x with Ruby 3.2 and higher.
 - ActiveRecord 8.0.x with Ruby 3.2 and higher.
 - ActiveRecord 8.1.x with Ruby 3.2 and higher.
 

--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename f }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.25"
   spec.add_dependency "google-cloud-spanner-v1", "~> 1.7"
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"
   spec.add_development_dependency "bundler", [">= 2.0", "< 5.0"]
-  spec.add_development_dependency "google-style", "~> 1.31.0"
+  spec.add_development_dependency "google-style", "~> 1.32.0"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.1"


### PR DESCRIPTION
chore(ci): pin action versions and resolve zizmor security warnings

Used go/github-zizmor-help?polyglot=github-com#local-scans-run-zizmor-on-your-cloudtop