### PR TITLE
perf: serialize query types and params in a single pass

### DIFF
--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -15,6 +15,8 @@ module ActiveRecord
       module DatabaseStatements
         RequestOptions = Google::Cloud::Spanner::V1::RequestOptions
         TransactionMutationLimitExceededError = Google::Cloud::Spanner::Errors::TransactionMutationLimitExceededError
+        PARAM_KEYS = (1..100).map { |i| "p#{i}".freeze }.freeze
+        private_constant :PARAM_KEYS
 
         # DDL, DML and DQL Statements
 
@@ -338,47 +340,42 @@ module ActiveRecord
 
         # Translates binds to Spanner types and params.
         def to_types_and_params binds
-          types = to_types binds
-          params = to_params binds
+          return [{}, {}] if binds.empty?
+
+          types = {}
+          params = {}
+          binds.each_with_index do |bind, i|
+            key = PARAM_KEYS[i] || "p#{i + 1}"
+            bind_value = bind.respond_to?(:value) ? bind.value : bind
+
+            if bind.respond_to? :type
+              model_type = bind.type
+              types[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+                           .convert_active_model_type_to_spanner(model_type)
+              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+                            .serialize_with_transaction_isolation_level(model_type, bind_value, :dml)
+            elsif bind.instance_of? Symbol
+              types[key] = :STRING
+              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+                            .serialize_with_transaction_isolation_level(:STRING, bind_value, :dml)
+            elsif bind.instance_of?(TrueClass) || bind.instance_of?(FalseClass)
+              types[key] = :BOOL
+              params[key] = bind_value
+            else
+              types[key] = :INT64
+              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+                            .serialize_with_transaction_isolation_level(ActiveModel::Type::Integer, bind_value, :dml)
+            end
+          end
           [types, params]
         end
 
         def to_types binds
-          binds.enum_for(:each_with_index).to_h do |bind, i|
-            type = :INT64
-            if bind.respond_to? :type
-              type = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                     .convert_active_model_type_to_spanner(bind.type)
-            elsif bind.instance_of? Symbol
-              # This ensures that for example :environment is sent as the string 'environment' to Cloud Spanner.
-              type = :STRING
-            elsif bind.instance_of?(TrueClass) || bind.instance_of?(FalseClass)
-              type = :BOOL
-            end
-            [
-              # Generates binds for named parameters in the format `@p1, @p2, ...`
-              "p#{i + 1}", type
-            ]
-          end
+          to_types_and_params(binds)[0]
         end
 
         def to_params binds
-          binds.enum_for(:each_with_index).to_h do |bind, i|
-            type = if bind.respond_to? :type
-                     bind.type
-                   elsif bind.instance_of? Symbol
-                     # This ensures that for example :environment is sent as the string 'environment' to Cloud Spanner.
-                     :STRING
-                   else
-                     # The Cloud Spanner default type is INT64 if no other type is known.
-                     ActiveModel::Type::Integer
-                   end
-            bind_value = bind.respond_to?(:value) ? bind.value : bind
-            value = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                    .serialize_with_transaction_isolation_level(type, bind_value, :dml)
-
-            ["p#{i + 1}", value]
-          end
+          to_types_and_params(binds)[1]
         end
 
         # An insert/update/delete statement could use mutations in some specific circumstances.

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -342,33 +342,33 @@ module ActiveRecord
         private
 
         # Translates binds to Spanner types and params.
-        def to_types_and_params binds
+        def to_types_and_params binds # rubocop:disable Metrics/AbcSize
           return [{}, {}] if binds.empty?
 
+          converter = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+          integer_type = ActiveModel::Type::Integer
           types = {}
           params = {}
-          binds.each_with_index do |bind, i|
-            key = PARAM_KEYS[i] || "p#{i + 1}"
+          index = 0
+          binds.each do |bind|
+            key = PARAM_KEYS[index] || "p#{index + 1}"
             bind_value = bind.respond_to?(:value) ? bind.value : bind
 
             if bind.respond_to? :type
               model_type = bind.type
-              types[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                           .convert_active_model_type_to_spanner(model_type)
-              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                            .serialize_with_transaction_isolation_level(model_type, bind_value, :dml)
+              types[key] = converter.convert_active_model_type_to_spanner model_type
+              params[key] = converter.serialize_with_transaction_isolation_level model_type, bind_value, :dml
             elsif bind.instance_of? Symbol
               types[key] = :STRING
-              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                            .serialize_with_transaction_isolation_level(:STRING, bind_value, :dml)
+              params[key] = converter.serialize_with_transaction_isolation_level :STRING, bind_value, :dml
             elsif bind.instance_of?(TrueClass) || bind.instance_of?(FalseClass)
               types[key] = :BOOL
               params[key] = bind_value
             else
               types[key] = :INT64
-              params[key] = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
-                            .serialize_with_transaction_isolation_level(ActiveModel::Type::Integer, bind_value, :dml)
+              params[key] = converter.serialize_with_transaction_isolation_level integer_type, bind_value, :dml
             end
+            index += 1
           end
           [types, params]
         end

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       module DatabaseStatements
         RequestOptions = Google::Cloud::Spanner::V1::RequestOptions
         TransactionMutationLimitExceededError = Google::Cloud::Spanner::Errors::TransactionMutationLimitExceededError
-        PARAM_KEYS = (1..100).map { |i| "p#{i}".freeze }.freeze
+        PARAM_KEYS = (1..950).map { |i| "p#{i}".freeze }.freeze
         private_constant :PARAM_KEYS
 
         # DDL, DML and DQL Statements

--- a/test/activerecord_spanner_adapter/database_statements_test.rb
+++ b/test/activerecord_spanner_adapter/database_statements_test.rb
@@ -21,9 +21,9 @@ class DatabaseStatementsTest < TestHelper::MockActiveRecordTest
   end
 
   def test_to_types_and_params_with_attributes
-    int_attr = ActiveModel::Attribute.from_user("id", 42, ActiveModel::Type::Integer.new)
-    str_attr = ActiveModel::Attribute.from_user("name", "Alice", ActiveModel::Type::String.new)
-    bool_attr = ActiveModel::Attribute.from_user("active", true, ActiveModel::Type::Boolean.new)
+    int_attr = ActiveModel::Attribute.from_user "id", 42, ActiveModel::Type::Integer.new
+    str_attr = ActiveModel::Attribute.from_user "name", "Alice", ActiveModel::Type::String.new
+    bool_attr = ActiveModel::Attribute.from_user "active", true, ActiveModel::Type::Boolean.new
 
     binds = [int_attr, str_attr, bool_attr]
     types, params = @adapter.send :to_types_and_params, binds
@@ -40,20 +40,22 @@ class DatabaseStatementsTest < TestHelper::MockActiveRecordTest
     assert_equal({ "p1" => :production, "p2" => true, "p3" => false, "p4" => 123 }, params)
   end
 
-  def test_to_types_and_params_preserves_frozen_keys_up_to_100
-    binds = Array.new(105) { |i| ActiveModel::Attribute.from_user("col_#{i}", i, ActiveModel::Type::Integer.new) }
+  def test_to_types_and_params_preserves_frozen_keys_up_to_950
+    binds = Array.new(955) { |i| ActiveModel::Attribute.from_user "col_#{i}", i, ActiveModel::Type::Integer.new }
     types, params = @adapter.send :to_types_and_params, binds
 
-    assert_equal 105, types.size
-    assert_equal 105, params.size
+    assert_equal 955, types.size
+    assert_equal 955, params.size
     assert_equal "p1", types.keys.first
-    assert_equal "p105", types.keys.last
+    assert_equal "p950", types.keys[949]
+    assert_equal "p955", types.keys.last
     assert_equal 0, params["p1"]
-    assert_equal 104, params["p105"]
+    assert_equal 949, params["p950"]
+    assert_equal 954, params["p955"]
   end
 
   def test_to_types_and_to_params_compatibility_methods
-    int_attr = ActiveModel::Attribute.from_user("id", 1, ActiveModel::Type::Integer.new)
+    int_attr = ActiveModel::Attribute.from_user "id", 1, ActiveModel::Type::Integer.new
     types = @adapter.send :to_types, [int_attr]
     params = @adapter.send :to_params, [int_attr]
 

--- a/test/activerecord_spanner_adapter/database_statements_test.rb
+++ b/test/activerecord_spanner_adapter/database_statements_test.rb
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "test_helper"
+
+class DatabaseStatementsTest < TestHelper::MockActiveRecordTest
+  def setup
+    super
+    @adapter = ActiveRecord::ConnectionAdapters::SpannerAdapter.new(
+      connection, nil, nil, { project: project_id, instance: instance_id, database: database_id }
+    )
+  end
+
+  def test_to_types_and_params_empty_binds
+    types, params = @adapter.send :to_types_and_params, []
+    assert_equal({}, types)
+    assert_equal({}, params)
+  end
+
+  def test_to_types_and_params_with_attributes
+    int_attr = ActiveModel::Attribute.from_user("id", 42, ActiveModel::Type::Integer.new)
+    str_attr = ActiveModel::Attribute.from_user("name", "Alice", ActiveModel::Type::String.new)
+    bool_attr = ActiveModel::Attribute.from_user("active", true, ActiveModel::Type::Boolean.new)
+
+    binds = [int_attr, str_attr, bool_attr]
+    types, params = @adapter.send :to_types_and_params, binds
+
+    assert_equal({ "p1" => :INT64, "p2" => :STRING, "p3" => :BOOL }, types)
+    assert_equal({ "p1" => 42, "p2" => "Alice", "p3" => true }, params)
+  end
+
+  def test_to_types_and_params_with_symbols_and_booleans
+    binds = [:production, true, false, 123]
+    types, params = @adapter.send :to_types_and_params, binds
+
+    assert_equal({ "p1" => :STRING, "p2" => :BOOL, "p3" => :BOOL, "p4" => :INT64 }, types)
+    assert_equal({ "p1" => :production, "p2" => true, "p3" => false, "p4" => 123 }, params)
+  end
+
+  def test_to_types_and_params_preserves_frozen_keys_up_to_100
+    binds = Array.new(105) { |i| ActiveModel::Attribute.from_user("col_#{i}", i, ActiveModel::Type::Integer.new) }
+    types, params = @adapter.send :to_types_and_params, binds
+
+    assert_equal 105, types.size
+    assert_equal 105, params.size
+    assert_equal "p1", types.keys.first
+    assert_equal "p105", types.keys.last
+    assert_equal 0, params["p1"]
+    assert_equal 104, params["p105"]
+  end
+
+  def test_to_types_and_to_params_compatibility_methods
+    int_attr = ActiveModel::Attribute.from_user("id", 1, ActiveModel::Type::Integer.new)
+    types = @adapter.send :to_types, [int_attr]
+    params = @adapter.send :to_params, [int_attr]
+
+    assert_equal({ "p1" => :INT64 }, types)
+    assert_equal({ "p1" => 1 }, params)
+  end
+end


### PR DESCRIPTION
Combine to_types and to_params into a single loop, eliminate enum_for allocations, and pre-freeze parameter keys up to 950.