### PR TITLE
perf: freeze request tag prefixes and prevent duplicate option appends

### DIFF
--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -15,6 +15,12 @@ module ActiveRecord
       module DatabaseStatements
         RequestOptions = Google::Cloud::Spanner::V1::RequestOptions
         TransactionMutationLimitExceededError = Google::Cloud::Spanner::Errors::TransactionMutationLimitExceededError
+        REQUEST_TAG_PREFIXES = [
+          "/*request_tag:true,",
+          "/*_request_tag='true',",
+          "/*_request_tag:true,"
+        ].freeze
+        private_constant :REQUEST_TAG_PREFIXES
 
         # DDL, DML and DQL Statements
 
@@ -96,15 +102,10 @@ module ActiveRecord
         end
 
         def append_request_tag_from_query_logs sql, binds
-          possible_prefixes = [
-            "/*request_tag:true,",
-            "/*_request_tag='true',",
-            "/*_request_tag:true,",
-            "/*_request_tag='true',"
-          ]
-          possible_prefixes.each do |prefix|
+          REQUEST_TAG_PREFIXES.each do |prefix|
             if sql.start_with? prefix
               append_request_tag_from_query_logs_with_format sql, binds, prefix
+              break
             end
           end
         end
@@ -114,14 +115,16 @@ module ActiveRecord
           return unless end_of_comment
 
           request_tag = sql[prefix.length, end_of_comment - prefix.length]
-          options = binds.find { |bind| bind.is_a? RequestOptions } || RequestOptions.new
-          if options.request_tag == ""
-            options.request_tag = request_tag
+          options = binds.find { |bind| bind.is_a? RequestOptions }
+          if options
+            options.request_tag = if options.request_tag.empty?
+                                    request_tag
+                                  else
+                                    "#{options.request_tag},#{request_tag}"
+                                  end
           else
-            options.request_tag += ",#{request_tag}"
+            binds.append RequestOptions.new(request_tag: request_tag)
           end
-
-          binds.append options
         end
 
         def sql_for_insert sql, pk, binds, returning

--- a/test/activerecord_spanner_adapter/database_statements_test.rb
+++ b/test/activerecord_spanner_adapter/database_statements_test.rb
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "test_helper"
+
+class DatabaseStatementsTest < TestHelper::MockActiveRecordTest
+  RequestOptions = Google::Cloud::Spanner::V1::RequestOptions
+
+  def setup
+    super
+    @adapter = ActiveRecord::ConnectionAdapters::SpannerAdapter.new(
+      connection, nil, nil, { project: project_id, instance: instance_id, database: database_id }
+    )
+  end
+
+  def test_append_request_tag_from_query_logs_with_prefix
+    binds = []
+    sql = "/*request_tag:true,app_users*/ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_equal 1, binds.size
+    assert_instance_of RequestOptions, binds.first
+    assert_equal "app_users", binds.first.request_tag
+  end
+
+  def test_append_request_tag_from_query_logs_with_alternate_prefix
+    binds = []
+    sql = "/*_request_tag='true',custom_tag*/ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_equal 1, binds.size
+    assert_instance_of RequestOptions, binds.first
+    assert_equal "custom_tag", binds.first.request_tag
+  end
+
+  def test_append_request_tag_does_not_duplicate_existing_options_object
+    existing_options = RequestOptions.new request_tag: "initial_tag"
+    binds = [existing_options]
+    sql = "/*request_tag:true,second_tag*/ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_equal 1, binds.size
+    assert_same existing_options, binds.first
+    assert_equal "initial_tag,second_tag", binds.first.request_tag
+  end
+
+  def test_append_request_tag_from_query_logs_with_third_prefix
+    binds = []
+    sql = "/*_request_tag:true,third_tag*/ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_equal 1, binds.size
+    assert_instance_of RequestOptions, binds.first
+    assert_equal "third_tag", binds.first.request_tag
+  end
+
+  def test_append_request_tag_with_empty_initial_request_tag
+    existing_options = RequestOptions.new request_tag: ""
+    binds = [existing_options]
+    sql = "/*request_tag:true,new_tag*/ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_equal 1, binds.size
+    assert_same existing_options, binds.first
+    assert_equal "new_tag", binds.first.request_tag
+  end
+
+  def test_append_request_tag_with_unclosed_comment
+    binds = []
+    sql = "/*request_tag:true,unclosed_tag SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_empty binds
+  end
+
+  def test_append_request_tag_with_non_matching_comment
+    binds = []
+    sql = "/* some other comment */ SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_empty binds
+  end
+
+  def test_append_request_tag_ignores_unmatched_sql
+    binds = []
+    sql = "SELECT * FROM users"
+    @adapter.send :append_request_tag_from_query_logs, sql, binds
+
+    assert_empty binds
+  end
+end


### PR DESCRIPTION
Extract frozen REQUEST_TAG_PREFIXES constant and avoid duplicate RequestOptions appends in DatabaseStatements.