### PR TITLE
perf: fast O(1) type lookup map in SpannerActiveRecordConverter

### DIFF
--- a/lib/active_record/type/spanner/spanner_active_record_converter.rb
+++ b/lib/active_record/type/spanner/spanner_active_record_converter.rb
@@ -6,10 +6,34 @@
 
 # frozen_string_literal: true
 
+require "active_record/type/spanner/array"
+require "active_record/type/spanner/bytes"
+require "active_record/type/spanner/time"
+require "active_record/type/spanner/uuid"
+
 module ActiveRecord
   module Type
     module Spanner
       class SpannerActiveRecordConverter
+        TYPE_MAP = {
+          ActiveModel::Type::Integer => :INT64,
+          ActiveModel::Type::BigInteger => :INT64,
+          ActiveModel::Type::Boolean => :BOOL,
+          ActiveModel::Type::String => :STRING,
+          ActiveModel::Type::ImmutableString => :STRING,
+          ActiveModel::Type::Binary => :BYTES,
+          ActiveRecord::Type::Spanner::Bytes => :BYTES,
+          ActiveModel::Type::Float => :FLOAT64,
+          ActiveModel::Type::Decimal => :NUMERIC,
+          ActiveModel::Type::DateTime => :TIMESTAMP,
+          ActiveModel::Type::Time => :TIMESTAMP,
+          ActiveRecord::Type::Spanner::Time => :TIMESTAMP,
+          ActiveModel::Type::Date => :DATE,
+          ActiveRecord::Type::Json => :JSON,
+          ActiveRecord::Type::Spanner::Uuid => :UUID
+        }.freeze
+        private_constant :TYPE_MAP
+
         def self.serialize_with_transaction_isolation_level type, value, isolation_level
           if type.respond_to? :serialize_with_isolation_level
             type.serialize_with_isolation_level value, isolation_level
@@ -22,12 +46,19 @@ module ActiveRecord
 
         ##
         # Converts an ActiveModel::Type to a Spanner type code.
-        def self.convert_active_model_type_to_spanner type # rubocop:disable Metrics/CyclomaticComplexity
+        def self.convert_active_model_type_to_spanner type
+          return nil if type.nil?
+
           # Unwrap the underlying object if the type is a DelegateClass.
           type = type.__getobj__ if type.respond_to? :__getobj__
 
+          TYPE_MAP[type.class] || fallback_convert_active_model_type_to_spanner(type)
+        end
+
+        def self.fallback_convert_active_model_type_to_spanner type # rubocop:disable Metrics/CyclomaticComplexity
           case type
           when NilClass then nil
+          when ActiveRecord::Type::Spanner::Array then [convert_active_model_type_to_spanner(type.element_type)]
           when ActiveModel::Type::Integer, ActiveModel::Type::BigInteger then :INT64
           when ActiveModel::Type::Boolean then :BOOL
           when ActiveModel::Type::String, ActiveModel::Type::ImmutableString then :STRING
@@ -38,9 +69,9 @@ module ActiveRecord
           when ActiveModel::Type::Date then :DATE
           when ActiveRecord::Type::Json then :JSON
           when ActiveRecord::Type::Spanner::Uuid then :UUID
-          when ActiveRecord::Type::Spanner::Array then [convert_active_model_type_to_spanner(type.element_type)]
           end
         end
+        private_class_method :fallback_convert_active_model_type_to_spanner
       end
     end
   end

--- a/test/activerecord_spanner_adapter/spanner_active_record_converter_test.rb
+++ b/test/activerecord_spanner_adapter/spanner_active_record_converter_test.rb
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+require "test_helper"
+require "delegate"
+
+class SpannerActiveRecordConverterTest < Minitest::Test
+  Converter = ActiveRecord::Type::Spanner::SpannerActiveRecordConverter
+
+  class CustomInteger < ActiveModel::Type::Integer
+  end
+
+  class CustomString < ActiveModel::Type::String
+  end
+
+  class TypeDecorator < SimpleDelegator
+  end
+
+  def test_convert_active_model_type_to_spanner_standard_types
+    expected_mappings = {
+      ActiveModel::Type::Integer.new => :INT64,
+      ActiveModel::Type::BigInteger.new => :INT64,
+      ActiveModel::Type::Boolean.new => :BOOL,
+      ActiveModel::Type::String.new => :STRING,
+      ActiveModel::Type::ImmutableString.new => :STRING,
+      ActiveModel::Type::Binary.new => :BYTES,
+      ActiveRecord::Type::Spanner::Bytes.new => :BYTES,
+      ActiveModel::Type::Float.new => :FLOAT64,
+      ActiveModel::Type::Decimal.new => :NUMERIC,
+      ActiveModel::Type::DateTime.new => :TIMESTAMP,
+      ActiveModel::Type::Time.new => :TIMESTAMP,
+      ActiveRecord::Type::Spanner::Time.new => :TIMESTAMP,
+      ActiveModel::Type::Date.new => :DATE,
+      ActiveRecord::Type::Json.new => :JSON,
+      ActiveRecord::Type::Spanner::Uuid.new => :UUID
+    }
+
+    expected_mappings.each do |type, expected_code|
+      assert_equal expected_code, Converter.convert_active_model_type_to_spanner(type)
+    end
+  end
+
+  def test_convert_active_model_type_to_spanner_nil
+    assert_nil Converter.convert_active_model_type_to_spanner(nil)
+  end
+
+  def test_convert_active_model_type_to_spanner_unrecognized_type
+    assert_nil Converter.convert_active_model_type_to_spanner(Object.new)
+  end
+
+  def test_convert_active_model_type_to_spanner_array
+    int_array = ActiveRecord::Type::Spanner::Array.new ActiveModel::Type::Integer.new
+    assert_equal [:INT64], Converter.convert_active_model_type_to_spanner(int_array)
+
+    string_array = ActiveRecord::Type::Spanner::Array.new ActiveModel::Type::String.new
+    assert_equal [:STRING], Converter.convert_active_model_type_to_spanner(string_array)
+  end
+
+  def test_convert_active_model_type_to_spanner_delegator
+    decorated = TypeDecorator.new ActiveModel::Type::Integer.new
+    assert_equal :INT64, Converter.convert_active_model_type_to_spanner(decorated)
+  end
+
+  class CustomArray < ActiveRecord::Type::Spanner::Array
+  end
+
+  def test_convert_active_model_type_to_spanner_custom_subclasses
+    assert_equal :INT64, Converter.convert_active_model_type_to_spanner(CustomInteger.new)
+    assert_equal :STRING, Converter.convert_active_model_type_to_spanner(CustomString.new)
+    custom_array = CustomArray.new ActiveModel::Type::Integer.new
+    assert_equal [:INT64], Converter.convert_active_model_type_to_spanner(custom_array)
+  end
+
+  def test_serialize_with_transaction_isolation_level
+    int_type = ActiveModel::Type::Integer.new
+    assert_equal 42, Converter.serialize_with_transaction_isolation_level(int_type, "42", :dml)
+    assert_equal "hello", Converter.serialize_with_transaction_isolation_level(nil, "hello", :dml)
+  end
+end


### PR DESCRIPTION
Replace sequential case-when class checks with a constant hash lookup map for ActiveModel types.